### PR TITLE
test(sdk): builder utility coverage (199 tests) + fix jest config gap

### DIFF
--- a/packages/bitbadgesjs-sdk/jest.config.cjs
+++ b/packages/bitbadgesjs-sdk/jest.config.cjs
@@ -3,6 +3,9 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   setupFiles: ['./jest.setup.js'],
+  // Only run .spec.ts files under src/ — skip compiled output under dist/.
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/*.spec.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
 

--- a/packages/bitbadgesjs-sdk/package.json
+++ b/packages/bitbadgesjs-sdk/package.json
@@ -80,7 +80,7 @@
     "routes-check": "ts-node ./scripts/check_routes_consistency.ts ../../../bitbadges-indexer/src/indexer.ts  ./openapitypes-helpers/routes.yaml",
     "clean": "tsc --build tsconfig.build.json --clean  && shx rm -rf coverage *.log junit.xml dist && jest --clearCache",
     "fixup": "./scripts/fixup.sh",
-    "test": "jest ./src/**/*.spec.ts --setupFiles ./jest.setup.js",
+    "test": "jest --setupFiles ./jest.setup.js",
     "test:unit": "jest test/unit",
     "test:integration": "jest test/unit",
     "test:watch": "jest --watch",

--- a/packages/bitbadgesjs-sdk/src/builder/sdk/addressGenerator.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/sdk/addressGenerator.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for builder/sdk/addressGenerator.ts
+ *
+ * Generates deterministic module-derived bb1 addresses for Smart Token
+ * backing scenarios. The hash derivation is:
+ *
+ *   addr = sha256( sha256("module") || moduleNameBytes || 0x00 || derivKey[0] )
+ *   then iteratively:  addr = sha256( sha256(addrBytes) || derivKey[i] )
+ *
+ * For IBC-backed denoms, the derivation key is:
+ *   [ 0x12, utf8(ibcDenom) ]
+ *
+ * For Cosmos-coin-wrapper denoms, the derivation key is:
+ *   [ 0x0c, utf8(denom) ]
+ *
+ * The tests here focus on DETERMINISM and DISTINCTNESS (different inputs →
+ * different outputs). We don't hardcode golden values because the on-chain
+ * module would produce different hashes — but on this commit the outputs
+ * must be reproducible within the JS side so that Smart Token callers get
+ * consistent backing addresses between builder sessions.
+ */
+
+import {
+  generateAlias,
+  generateAliasAddressForIBCBackedDenom,
+  generateAliasAddressForDenom,
+  getAliasDerivationKeysForIBCBackedDenom,
+  getAliasDerivationKeysForDenom
+} from './addressGenerator.js';
+
+describe('addressGenerator', () => {
+  describe('generateAlias — core derivation', () => {
+    it('throws when derivationKeys is empty', () => {
+      expect(() => generateAlias('tokenization', [])).toThrow(/derivationKeys/);
+    });
+
+    it('produces a bb1-prefixed bech32 address', () => {
+      const addr = generateAlias('tokenization', [Buffer.from([0x00, 0x01, 0x02])]);
+      expect(addr).toMatch(/^bb1/);
+    });
+
+    it('is deterministic for the same module + keys', () => {
+      const k = [Buffer.from('fixed-input', 'utf8')];
+      const a = generateAlias('tokenization', k);
+      const b = generateAlias('tokenization', k);
+      expect(a).toBe(b);
+    });
+
+    it('different module names produce different addresses', () => {
+      const k = [Buffer.from('same-input', 'utf8')];
+      const a = generateAlias('tokenization', k);
+      const b = generateAlias('other-module', k);
+      expect(a).not.toBe(b);
+    });
+
+    it('different derivation keys produce different addresses', () => {
+      const a = generateAlias('tokenization', [Buffer.from('a')]);
+      const b = generateAlias('tokenization', [Buffer.from('b')]);
+      expect(a).not.toBe(b);
+    });
+
+    it('adding a second derivation key changes the output (Derive is applied iteratively)', () => {
+      const base = generateAlias('tokenization', [Buffer.from('x')]);
+      const derived = generateAlias('tokenization', [Buffer.from('x'), Buffer.from('y')]);
+      expect(base).not.toBe(derived);
+    });
+  });
+
+  describe('getAliasDerivationKeysForIBCBackedDenom', () => {
+    it('returns [0x12 prefix, utf8(denom)] as two Buffers', () => {
+      const denom = 'ibc/ABC';
+      const keys = getAliasDerivationKeysForIBCBackedDenom(denom);
+      expect(keys).toHaveLength(2);
+      expect(keys[0].length).toBe(1);
+      expect(keys[0][0]).toBe(0x12);
+      expect(keys[1].toString('utf8')).toBe(denom);
+    });
+  });
+
+  describe('getAliasDerivationKeysForDenom', () => {
+    it('returns [0x0c prefix, utf8(denom)] for cosmos coin wrappers', () => {
+      const denom = 'uatom';
+      const keys = getAliasDerivationKeysForDenom(denom);
+      expect(keys).toHaveLength(2);
+      expect(keys[0][0]).toBe(0x0c);
+      expect(keys[1].toString('utf8')).toBe(denom);
+    });
+
+    it('uses a different prefix byte than the IBC variant (0x0c vs 0x12)', () => {
+      const ibc = getAliasDerivationKeysForIBCBackedDenom('ibc/X');
+      const coin = getAliasDerivationKeysForDenom('X');
+      expect(ibc[0][0]).not.toBe(coin[0][0]);
+    });
+  });
+
+  describe('generateAliasAddressForIBCBackedDenom', () => {
+    it('is deterministic for the same IBC denom', () => {
+      const denom = 'ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349';
+      expect(generateAliasAddressForIBCBackedDenom(denom))
+        .toBe(generateAliasAddressForIBCBackedDenom(denom));
+    });
+
+    it('different IBC denoms produce different backing addresses', () => {
+      const a = generateAliasAddressForIBCBackedDenom('ibc/AAA');
+      const b = generateAliasAddressForIBCBackedDenom('ibc/BBB');
+      expect(a).not.toBe(b);
+    });
+
+    it('returns a bb1-prefixed bech32 address', () => {
+      const addr = generateAliasAddressForIBCBackedDenom('ibc/TEST');
+      expect(addr).toMatch(/^bb1/);
+    });
+  });
+
+  describe('generateAliasAddressForDenom (Cosmos coin wrappers)', () => {
+    it('is deterministic for the same coin denom', () => {
+      expect(generateAliasAddressForDenom('uatom'))
+        .toBe(generateAliasAddressForDenom('uatom'));
+    });
+
+    it('different coin denoms produce different backing addresses', () => {
+      expect(generateAliasAddressForDenom('uatom'))
+        .not.toBe(generateAliasAddressForDenom('uosmo'));
+    });
+
+    it('returns a bb1-prefixed bech32 address', () => {
+      expect(generateAliasAddressForDenom('uatom')).toMatch(/^bb1/);
+    });
+  });
+
+  describe('cross-variant distinctness', () => {
+    it('IBC-backed alias for "ibc/foo" differs from coin-wrapper alias for "ibc/foo"', () => {
+      // Even though the input string is identical, the derivation prefix byte
+      // is different (0x12 vs 0x0c), so the addresses must not collide.
+      const viaIbc = generateAliasAddressForIBCBackedDenom('ibc/foo');
+      const viaCoin = generateAliasAddressForDenom('ibc/foo');
+      expect(viaIbc).not.toBe(viaCoin);
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/sdk/addressUtils.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/sdk/addressUtils.spec.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for builder/sdk/addressUtils.ts
+ *
+ * Lower-level (non-MCP-tool-wrapper) address conversion helpers used by
+ * many builder tools. Each exported function is exercised against its
+ * full branch coverage:
+ *
+ *   - isHex / ethToCosmos / cosmosToEth: hex and bech32 round-trip invariants
+ *   - validateAddress: eth vs. cosmos vs. unknown classification, and the
+ *     20-byte / 32-byte isModuleDerived split
+ *   - toBitBadgesAddress / toEthAddress: idempotent identity + cross-conversion
+ *   - ensureBb1: the long list of special-value pass-throughs
+ *   - ensureBb1ListId: compound list id handling ("!Mint:0x...:bb1..." etc.)
+ */
+
+import {
+  ethToCosmos,
+  cosmosToEth,
+  validateAddress,
+  toBitBadgesAddress,
+  toEthAddress,
+  ensureBb1,
+  ensureBb1ListId
+} from './addressUtils.js';
+
+const ETH_ZERO = '0x' + '0'.repeat(40);
+const BB1_ZERO = 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv';
+const ETH_NZ = '0x742d35cc6634c0532925a3b844bc9e7595f0beb1';
+
+describe('addressUtils — ethToCosmos', () => {
+  it('converts 20-byte hex to a bb1 bech32 string', () => {
+    expect(ethToCosmos(ETH_ZERO)).toBe(BB1_ZERO);
+  });
+
+  it('round-trips with cosmosToEth for a non-zero fixture', () => {
+    expect(cosmosToEth(ethToCosmos(ETH_NZ))).toBe(ETH_NZ);
+  });
+
+  it('normalizes mixed-case hex (toLowerCase) before encoding', () => {
+    const upper = ETH_NZ.toUpperCase().replace('0X', '0x');
+    expect(ethToCosmos(upper)).toBe(ethToCosmos(ETH_NZ));
+  });
+
+  it('throws when input does not start with 0x', () => {
+    expect(() => ethToCosmos('742d35cc6634c0532925a3b844bc9e7595f0beb1')).toThrow(/must start with 0x/);
+  });
+
+  it('throws when hex length is wrong (too short)', () => {
+    expect(() => ethToCosmos('0x' + '0'.repeat(39))).toThrow(/40 hex/);
+  });
+
+  it('throws when hex length is wrong (too long)', () => {
+    expect(() => ethToCosmos('0x' + '0'.repeat(41))).toThrow(/40 hex/);
+  });
+
+  it('throws on non-hex characters even with correct length', () => {
+    expect(() => ethToCosmos('0x' + 'z'.repeat(40))).toThrow(/40 hex/);
+  });
+});
+
+describe('addressUtils — cosmosToEth', () => {
+  it('converts a valid bb1 address to 0x', () => {
+    expect(cosmosToEth(BB1_ZERO)).toBe(ETH_ZERO);
+  });
+
+  it('throws when the address does not start with bb1', () => {
+    expect(() => cosmosToEth('cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a'))
+      .toThrow(/must start with bb1/);
+  });
+
+  it('throws when bech32 decoding fails (corrupt checksum)', () => {
+    const broken = BB1_ZERO.slice(0, -1) + 'x';
+    expect(() => cosmosToEth(broken)).toThrow();
+  });
+
+  it('throws when the decoded address is not 20 bytes (module-derived 32-byte)', () => {
+    // A bb1 address encoding 32 zero bytes would be module-derived
+    const { bech32 } = require('bech32');
+    const module32 = bech32.encode('bb', bech32.toWords(Buffer.alloc(32, 0)));
+    expect(() => cosmosToEth(module32)).toThrow(/module-derived/);
+  });
+});
+
+describe('addressUtils — validateAddress', () => {
+  it('recognizes a valid ETH address', () => {
+    const r = validateAddress(ETH_NZ);
+    expect(r.valid).toBe(true);
+    expect(r.chain).toBe('eth');
+    expect(r.isModuleDerived).toBe(false);
+    expect(r.normalized).toBe(ETH_NZ.toLowerCase());
+  });
+
+  it('rejects a malformed ETH address and returns an explanatory error', () => {
+    const r = validateAddress('0xZZZZ');
+    expect(r.valid).toBe(false);
+    expect(r.chain).toBe('unknown');
+    expect(r.error).toMatch(/40 hex/);
+  });
+
+  it('recognizes a valid bb1 20-byte address and marks isModuleDerived=false', () => {
+    const r = validateAddress(BB1_ZERO);
+    expect(r.valid).toBe(true);
+    expect(r.chain).toBe('cosmos');
+    expect(r.isModuleDerived).toBe(false);
+  });
+
+  it('flags 32-byte bb1 addresses as isModuleDerived=true', () => {
+    const { bech32 } = require('bech32');
+    const module32 = bech32.encode('bb', bech32.toWords(Buffer.alloc(32, 0)));
+    const r = validateAddress(module32);
+    expect(r.valid).toBe(true);
+    expect(r.isModuleDerived).toBe(true);
+  });
+
+  it('rejects a bb1 address with invalid checksum', () => {
+    const broken = BB1_ZERO.slice(0, -1) + 'x';
+    const r = validateAddress(broken);
+    expect(r.valid).toBe(false);
+    expect(r.chain).toBe('unknown');
+    expect(r.error).toMatch(/decode bech32/i);
+  });
+
+  it('returns chain=unknown with helpful error for unrecognized input', () => {
+    const r = validateAddress('cosmos1qqqqq');
+    expect(r.valid).toBe(false);
+    expect(r.chain).toBe('unknown');
+  });
+});
+
+describe('addressUtils — toBitBadgesAddress', () => {
+  it('passes through a bb1 address unchanged', () => {
+    expect(toBitBadgesAddress(BB1_ZERO)).toBe(BB1_ZERO);
+  });
+
+  it('converts a 0x address to bb1', () => {
+    expect(toBitBadgesAddress(ETH_ZERO)).toBe(BB1_ZERO);
+  });
+
+  it('throws on unknown format', () => {
+    expect(() => toBitBadgesAddress('garbage')).toThrow(/Unknown/);
+  });
+});
+
+describe('addressUtils — toEthAddress', () => {
+  it('passes through a 0x address unchanged', () => {
+    expect(toEthAddress(ETH_ZERO)).toBe(ETH_ZERO);
+  });
+
+  it('converts a bb1 address to 0x', () => {
+    expect(toEthAddress(BB1_ZERO)).toBe(ETH_ZERO);
+  });
+
+  it('throws on unknown format', () => {
+    expect(() => toEthAddress('foo')).toThrow(/Unknown/);
+  });
+
+  it('throws when bb1 address is module-derived (32-byte)', () => {
+    const { bech32 } = require('bech32');
+    const module32 = bech32.encode('bb', bech32.toWords(Buffer.alloc(32, 0)));
+    expect(() => toEthAddress(module32)).toThrow(/module-derived/);
+  });
+});
+
+describe('addressUtils — ensureBb1', () => {
+  it('returns falsy input unchanged (empty string, undefined-ish)', () => {
+    expect(ensureBb1('')).toBe('');
+  });
+
+  it('passes special reserved values through unchanged', () => {
+    for (const special of ['Mint', 'All', 'None', 'Total', 'AllWithMint']) {
+      expect(ensureBb1(special)).toBe(special);
+    }
+  });
+
+  it('passes through negated list ids (starting with "!")', () => {
+    expect(ensureBb1('!Mint')).toBe('!Mint');
+    expect(ensureBb1('!SomeList')).toBe('!SomeList');
+  });
+
+  it('passes through AllWithout* variants', () => {
+    expect(ensureBb1('AllWithoutMint')).toBe('AllWithoutMint');
+    expect(ensureBb1('AllWithoutSomething')).toBe('AllWithoutSomething');
+  });
+
+  it('passes through values that already start with bb1', () => {
+    expect(ensureBb1(BB1_ZERO)).toBe(BB1_ZERO);
+  });
+
+  it('converts a 0x 42-char address to bb1', () => {
+    expect(ensureBb1(ETH_ZERO)).toBe(BB1_ZERO);
+  });
+
+  it('returns malformed 0x addresses as-is (does NOT throw)', () => {
+    // Downstream validation is supposed to catch these — ensureBb1 is a
+    // best-effort coercer, not a validator.
+    expect(ensureBb1('0xshort')).toBe('0xshort');
+  });
+
+  it('returns arbitrary unknown strings as-is', () => {
+    expect(ensureBb1('random-list-id')).toBe('random-list-id');
+  });
+});
+
+describe('addressUtils — ensureBb1ListId', () => {
+  it('returns empty input unchanged', () => {
+    expect(ensureBb1ListId('')).toBe('');
+  });
+
+  it('converts a bare 0x address', () => {
+    expect(ensureBb1ListId(ETH_ZERO)).toBe(BB1_ZERO);
+  });
+
+  it('preserves a bare bb1 address', () => {
+    expect(ensureBb1ListId(BB1_ZERO)).toBe(BB1_ZERO);
+  });
+
+  it('handles the "!" negation prefix and still converts the inner address', () => {
+    expect(ensureBb1ListId('!' + ETH_ZERO)).toBe('!' + BB1_ZERO);
+  });
+
+  it('handles parentheses', () => {
+    expect(ensureBb1ListId('(' + ETH_ZERO + ')')).toBe('(' + BB1_ZERO + ')');
+  });
+
+  it('handles the combined "!(...)", converting addresses inside', () => {
+    expect(ensureBb1ListId('!(' + ETH_ZERO + ')')).toBe('!(' + BB1_ZERO + ')');
+  });
+
+  it('converts each colon-separated part that looks like a 0x address', () => {
+    const input = ETH_ZERO + ':' + ETH_NZ + ':' + BB1_ZERO;
+    const expected = BB1_ZERO + ':' + ethToCosmos(ETH_NZ) + ':' + BB1_ZERO;
+    expect(ensureBb1ListId(input)).toBe(expected);
+  });
+
+  it('preserves non-address parts verbatim in compound ids', () => {
+    const input = 'Mint:' + ETH_ZERO + ':AllWithoutSomething';
+    const expected = 'Mint:' + BB1_ZERO + ':AllWithoutSomething';
+    expect(ensureBb1ListId(input)).toBe(expected);
+  });
+
+  it('handles complex "!(AllWithout:0x...:bb1...)" form', () => {
+    const input = '!(AllWithout:' + ETH_ZERO + ':' + BB1_ZERO + ')';
+    const expected = '!(AllWithout:' + BB1_ZERO + ':' + BB1_ZERO + ')';
+    expect(ensureBb1ListId(input)).toBe(expected);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/sdk/coinRegistry.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/sdk/coinRegistry.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for builder/sdk/coinRegistry.ts
+ *
+ * The registry maps known symbols (USDC/ATOM/OSMO) to IBC denoms +
+ * pre-generated Smart Token backing addresses. The builder uses this
+ * extensively when generating mint/backing approvals, so every lookup
+ * permutation and denom resolution path must be covered.
+ */
+
+import {
+  MAINNET_COINS_REGISTRY,
+  buildSymbolToTokenInfoMap,
+  lookupTokenInfo,
+  getAllTokens,
+  getCoinDetails,
+  resolveIbcDenom,
+  getDecimals
+} from './coinRegistry.js';
+
+describe('coinRegistry', () => {
+  describe('MAINNET_COINS_REGISTRY fixtures', () => {
+    it('includes the core denoms we care about', () => {
+      expect(MAINNET_COINS_REGISTRY).toHaveProperty('ubadge');
+      // USDC, ATOM, OSMO keys are IBC denoms; check via symbol.
+      const symbols = Object.values(MAINNET_COINS_REGISTRY).map(c => c.symbol);
+      expect(symbols).toContain('USDC');
+      expect(symbols).toContain('ATOM');
+      expect(symbols).toContain('OSMO');
+      expect(symbols).toContain('BADGE');
+    });
+  });
+
+  describe('buildSymbolToTokenInfoMap', () => {
+    it('only includes IBC-denom entries (not native ubadge/badges:*)', () => {
+      const map = buildSymbolToTokenInfoMap();
+      for (const token of map.values()) {
+        expect(token.ibcDenom.startsWith('ibc/')).toBe(true);
+      }
+    });
+
+    it('is cached — returns the same Map instance on repeated calls', () => {
+      const a = buildSymbolToTokenInfoMap();
+      const b = buildSymbolToTokenInfoMap();
+      expect(a).toBe(b);
+    });
+
+    it('each entry has a well-formed bb1 backing address', () => {
+      const map = buildSymbolToTokenInfoMap();
+      for (const token of map.values()) {
+        expect(token.backingAddress).toMatch(/^bb1/);
+        expect(token.backingAddress.length).toBeGreaterThan(10);
+      }
+    });
+  });
+
+  describe('lookupTokenInfo', () => {
+    it('finds a token by symbol (case-insensitive)', () => {
+      const usdc = lookupTokenInfo('USDC');
+      const usdcLower = lookupTokenInfo('usdc');
+      expect(usdc).not.toBeNull();
+      expect(usdcLower).not.toBeNull();
+      expect(usdc!.backingAddress).toBe(usdcLower!.backingAddress);
+    });
+
+    it('finds a token by exact IBC denom', () => {
+      const denom = 'ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349';
+      const result = lookupTokenInfo(denom);
+      expect(result).not.toBeNull();
+      expect(result!.symbol).toBe('USDC');
+    });
+
+    it('IBC-denom lookup is case-insensitive on the hex portion', () => {
+      const lower = lookupTokenInfo('ibc/f082b65c88e4b6d5ef1db243cda1d331d002759e938a0f5cd3ffdc5d53b3e349');
+      expect(lower).not.toBeNull();
+      expect(lower!.symbol).toBe('USDC');
+    });
+
+    it('returns a synthetic TokenInfo for unknown IBC denoms (symbol=UNKNOWN)', () => {
+      const result = lookupTokenInfo('ibc/NEWDENOM999999999999999999999999999999999');
+      expect(result).not.toBeNull();
+      expect(result!.symbol).toBe('UNKNOWN');
+      expect(result!.decimals).toBe('6');
+      expect(result!.backingAddress).toMatch(/^bb1/);
+    });
+
+    it('returns null for an unknown non-IBC symbol', () => {
+      expect(lookupTokenInfo('DOES_NOT_EXIST')).toBeNull();
+    });
+
+    it('returns null for an empty query (no symbol, no ibc/ prefix)', () => {
+      expect(lookupTokenInfo('')).toBeNull();
+    });
+  });
+
+  describe('getAllTokens', () => {
+    it('returns all IBC-backed tokens as an array', () => {
+      const all = getAllTokens();
+      expect(Array.isArray(all)).toBe(true);
+      expect(all.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('every returned token has a unique symbol', () => {
+      const all = getAllTokens();
+      const symbols = all.map(t => t.symbol);
+      expect(new Set(symbols).size).toBe(symbols.length);
+    });
+  });
+
+  describe('getCoinDetails', () => {
+    it('returns details for ubadge (native)', () => {
+      const d = getCoinDetails('ubadge');
+      expect(d).not.toBeNull();
+      expect(d!.symbol).toBe('BADGE');
+      expect(d!.decimals).toBe('9');
+    });
+
+    it('returns details for a known IBC denom', () => {
+      const d = getCoinDetails('ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349');
+      expect(d).not.toBeNull();
+      expect(d!.symbol).toBe('USDC');
+    });
+
+    it('returns null for unknown denom', () => {
+      expect(getCoinDetails('ibc/UNKNOWN_DENOM_XXX')).toBeNull();
+    });
+  });
+
+  describe('resolveIbcDenom', () => {
+    it('returns ibc/... input unchanged', () => {
+      const denom = 'ibc/ANYDENOM';
+      expect(resolveIbcDenom(denom)).toBe(denom);
+    });
+
+    it('resolves a known symbol to its IBC denom', () => {
+      const resolved = resolveIbcDenom('USDC');
+      expect(resolved).toMatch(/^ibc\//);
+      const expected = lookupTokenInfo('USDC')!.ibcDenom;
+      expect(resolved).toBe(expected);
+    });
+
+    it('returns null for unknown symbol', () => {
+      expect(resolveIbcDenom('UNKNOWN_SYMBOL')).toBeNull();
+    });
+  });
+
+  describe('getDecimals', () => {
+    it('returns 9 for native ubadge (BADGE)', () => {
+      expect(getDecimals('ubadge')).toBe(9);
+    });
+
+    it('returns 6 for known IBC denoms (USDC/ATOM/OSMO)', () => {
+      const usdcDenom = lookupTokenInfo('USDC')!.ibcDenom;
+      expect(getDecimals(usdcDenom)).toBe(6);
+    });
+
+    it('returns 6 as default for unknown IBC denoms', () => {
+      expect(getDecimals('ibc/COMPLETELY_NEW_DENOM')).toBe(6);
+    });
+
+    it('returns 6 when looking up a known SYMBOL (symbol hits lookupTokenInfo path)', () => {
+      // Note: getDecimals first tries the registry (which is keyed by base denom),
+      // then falls back to lookupTokenInfo for symbols. USDC isn't in the
+      // registry as a key but lookupTokenInfo finds it.
+      expect(getDecimals('USDC')).toBe(6);
+    });
+
+    it('returns 9 as default for unknown non-IBC strings (native-token fallback)', () => {
+      expect(getDecimals('totally-unknown')).toBe(9);
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/convertAddress.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/convertAddress.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for `convert_address` builder tool.
+ *
+ * convertAddress wraps bech32 encoding/decoding to move between the two
+ * canonical BitBadges address formats:
+ *   - 0x... (Ethereum-style, 20-byte hex)
+ *   - bb1... (Cosmos bech32 with "bb" prefix)
+ *
+ * This is called by the LLM builder both for user convenience (paste either
+ * format) and to normalize addresses before stuffing them into txs. The
+ * round-trip property is critical — eth → bb1 → eth must give back the same
+ * lowercased address, and bb1 → eth → bb1 must give back the same lowercased
+ * bech32 form.
+ *
+ * Every code path in `handleConvertAddress` is exercised:
+ *   - source detection (eth / cosmos / unknown)
+ *   - auto-target selection when `targetFormat` is omitted
+ *   - identity short-circuit (eth→eth, bb1→bb1)
+ *   - actual conversion (both directions)
+ *   - error handling for bad inputs
+ */
+
+import { handleConvertAddress } from './convertAddress.js';
+
+describe('handleConvertAddress', () => {
+  // Canonical fixture pair: the 20 zero bytes in both formats.
+  const ETH_ZERO = '0x' + '0'.repeat(40);
+  const BB1_ZERO = 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv';
+
+  // A non-zero fixture to make sure we're not just passing `00...00` through
+  const ETH_NONZERO = '0x742d35cc6634c0532925a3b844bc9e7595f0beb1';
+
+  describe('auto-detected target format', () => {
+    it('converts 0x → bb1 when target is omitted', () => {
+      const res = handleConvertAddress({ address: ETH_ZERO });
+      expect(res.success).toBe(true);
+      expect(res.originalFormat).toBe('eth');
+      expect(res.targetFormat).toBe('bitbadges');
+      expect(res.convertedAddress).toBe(BB1_ZERO);
+      expect(res.originalAddress).toBe(ETH_ZERO);
+    });
+
+    it('converts bb1 → 0x when target is omitted', () => {
+      const res = handleConvertAddress({ address: BB1_ZERO });
+      expect(res.success).toBe(true);
+      expect(res.originalFormat).toBe('bitbadges');
+      expect(res.targetFormat).toBe('eth');
+      expect(res.convertedAddress).toBe(ETH_ZERO);
+    });
+
+    it('round-trips a non-zero ETH address: 0x → bb1 → 0x', () => {
+      const toBb1 = handleConvertAddress({ address: ETH_NONZERO });
+      expect(toBb1.success).toBe(true);
+      expect(toBb1.convertedAddress).toMatch(/^bb1/);
+
+      const backToEth = handleConvertAddress({ address: toBb1.convertedAddress! });
+      expect(backToEth.success).toBe(true);
+      expect(backToEth.convertedAddress).toBe(ETH_NONZERO);
+    });
+
+    it('normalizes mixed-case ETH input to lowercase during conversion', () => {
+      const mixed = '0x742D35CC6634C0532925A3B844BC9E7595F0BEB1';
+      const res = handleConvertAddress({ address: mixed });
+      expect(res.success).toBe(true);
+      // The converted bb1 must be the same as the one derived from the
+      // lowercased form — confirming eth→cosmos normalizes case.
+      const expected = handleConvertAddress({ address: mixed.toLowerCase() });
+      expect(res.convertedAddress).toBe(expected.convertedAddress);
+    });
+  });
+
+  describe('explicit targetFormat', () => {
+    it('identity: 0x → eth returns original unchanged', () => {
+      const res = handleConvertAddress({ address: ETH_ZERO, targetFormat: 'eth' });
+      expect(res.success).toBe(true);
+      expect(res.originalAddress).toBe(ETH_ZERO);
+      expect(res.convertedAddress).toBe(ETH_ZERO);
+      expect(res.originalFormat).toBe('eth');
+      expect(res.targetFormat).toBe('eth');
+    });
+
+    it('identity: bb1 → bitbadges returns original unchanged', () => {
+      const res = handleConvertAddress({ address: BB1_ZERO, targetFormat: 'bitbadges' });
+      expect(res.success).toBe(true);
+      expect(res.convertedAddress).toBe(BB1_ZERO);
+      expect(res.originalFormat).toBe('bitbadges');
+      expect(res.targetFormat).toBe('bitbadges');
+    });
+
+    it('explicit 0x → bitbadges produces the same result as auto-detect', () => {
+      const auto = handleConvertAddress({ address: ETH_NONZERO });
+      const explicit = handleConvertAddress({ address: ETH_NONZERO, targetFormat: 'bitbadges' });
+      expect(explicit.convertedAddress).toBe(auto.convertedAddress);
+    });
+
+    it('explicit bb1 → eth produces the same result as auto-detect', () => {
+      const toBb1 = handleConvertAddress({ address: ETH_NONZERO });
+      const explicit = handleConvertAddress({ address: toBb1.convertedAddress!, targetFormat: 'eth' });
+      expect(explicit.success).toBe(true);
+      expect(explicit.convertedAddress).toBe(ETH_NONZERO);
+    });
+  });
+
+  describe('rejects unknown formats', () => {
+    it('returns success=false for an empty string', () => {
+      const res = handleConvertAddress({ address: '' });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/unknown/i);
+    });
+
+    it('returns success=false for a bare "0x"', () => {
+      const res = handleConvertAddress({ address: '0x' });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/unknown/i);
+    });
+
+    it('returns success=false for a 41-char 0x string (wrong length)', () => {
+      const res = handleConvertAddress({ address: '0x' + '0'.repeat(39) });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/unknown/i);
+    });
+
+    it('returns success=false for a non-prefixed random string', () => {
+      const res = handleConvertAddress({ address: 'not-an-address' });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/unknown/i);
+    });
+
+    it('surfaces bech32 decode failure as an error when bb1 checksum is corrupt', () => {
+      const broken = BB1_ZERO.slice(0, -1) + 'x';
+      const res = handleConvertAddress({ address: broken });
+      // The detectFormat() function only checks the prefix, so this is
+      // routed through cosmosToEth() and bech32.decode() throws.
+      // handleConvertAddress wraps that in its catch block → success: false.
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/failed to convert/i);
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/diagnoseError.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/diagnoseError.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for `diagnose_error`.
+ *
+ * Scores each error pattern against the user-supplied error message + context,
+ * returns the top match as `diagnosis` and the next ≤3 as `suggestions`.
+ * Scoring rules:
+ *   - +10 per trigger keyword present in (error + context)
+ *   - +5 extra if the trigger is in the error itself (not just context)
+ *   - +3 if the category name appears in (error + context)
+ *
+ * These tests exercise:
+ *   - happy-path match for several distinct known categories
+ *   - the trigger-in-error bonus (error > context)
+ *   - the no-match path (suggestions empty, `tip` points to next steps)
+ *   - case-insensitivity
+ *   - multiple-pattern resolution (top pick is the highest score)
+ */
+
+import { handleDiagnoseError } from './diagnoseError.js';
+import { ERROR_PATTERNS } from '../../resources/errorPatterns.js';
+
+describe('handleDiagnoseError', () => {
+  describe('matches known error categories', () => {
+    it('diagnoses "cannot unmarshal number" → Numbers-not-strings pattern', () => {
+      const res = handleDiagnoseError({ error: 'json: cannot unmarshal number into Go struct' });
+      expect(res.success).toBe(true);
+      expect(res.diagnosis).not.toBeNull();
+      expect(res.diagnosis!.category).toBe('serialization');
+      expect(res.diagnosis!.matchedPattern).toMatch(/Numbers not strings/i);
+    });
+
+    it('diagnoses "account sequence mismatch" → signing category', () => {
+      const res = handleDiagnoseError({ error: 'account sequence mismatch, expected 5, got 4' });
+      expect(res.diagnosis).not.toBeNull();
+      expect(res.diagnosis!.category).toBe('signing');
+      expect(res.diagnosis!.matchedPattern).toMatch(/sequence/i);
+    });
+
+    it('diagnoses "out of gas" → insufficient gas pattern', () => {
+      const res = handleDiagnoseError({ error: 'out of gas in location' });
+      expect(res.diagnosis).not.toBeNull();
+      expect(res.diagnosis!.matchedPattern).toMatch(/gas/i);
+    });
+
+    it('diagnoses "insufficient funds" → signing category', () => {
+      const res = handleDiagnoseError({ error: 'insufficient funds: need 100ubadge' });
+      expect(res.diagnosis).not.toBeNull();
+      expect(res.diagnosis!.category).toBe('signing');
+    });
+
+    it('diagnoses "decoding bech32" → invalid address format', () => {
+      const res = handleDiagnoseError({ error: 'failed decoding bech32: checksum error' });
+      expect(res.diagnosis).not.toBeNull();
+      expect(res.diagnosis!.category).toBe('address');
+    });
+
+    it('diagnoses "auto-scan failed" → transfer category', () => {
+      const res = handleDiagnoseError({ error: 'auto-scan failed — must explicitly prioritize approvals' });
+      expect(res.diagnosis).not.toBeNull();
+      expect(res.diagnosis!.category).toBe('transfer');
+    });
+  });
+
+  describe('scoring edge cases', () => {
+    it('returns success=false when no pattern matches', () => {
+      const res = handleDiagnoseError({ error: 'xyzzy totally unrelated gibberish 12345' });
+      expect(res.success).toBe(false);
+      expect(res.diagnosis).toBeNull();
+      expect(res.suggestions).toHaveLength(0);
+      expect(res.tip).toMatch(/No matching error pattern/i);
+      expect(res.tip).toMatch(/validate_transaction/);
+    });
+
+    it('match is case-insensitive (SHOUTING error message still matches)', () => {
+      const res = handleDiagnoseError({ error: 'ACCOUNT SEQUENCE MISMATCH' });
+      expect(res.diagnosis).not.toBeNull();
+      expect(res.diagnosis!.category).toBe('signing');
+    });
+
+    it('context alone (not error) can match, though with a weaker score', () => {
+      const res = handleDiagnoseError({ error: 'something went wrong', context: 'out of gas' });
+      // The trigger is in context but not error → should still match
+      expect(res.diagnosis).not.toBeNull();
+      expect(res.diagnosis!.matchedPattern).toMatch(/gas/i);
+    });
+
+    it('prefers a pattern matched in the error over one matched only in the context', () => {
+      // Two keywords, one in error (+15), one in context-only (+10)
+      const res = handleDiagnoseError({
+        error: 'account sequence mismatch',
+        context: 'out of gas' // different pattern, context-only
+      });
+      expect(res.diagnosis).not.toBeNull();
+      // The error-side keyword gets the +5 bonus, so it should win.
+      expect(res.diagnosis!.matchedPattern).toMatch(/sequence/i);
+    });
+
+    it('returns up to 3 suggestions (after the top match) when multiple patterns score > 0', () => {
+      // Craft a query that hits many patterns simultaneously
+      const res = handleDiagnoseError({
+        error: 'invalid address sequence gas unmarshal number insufficient funds auto-scan'
+      });
+      expect(res.diagnosis).not.toBeNull();
+      expect(res.suggestions.length).toBeGreaterThan(0);
+      expect(res.suggestions.length).toBeLessThanOrEqual(3);
+    });
+
+    it('suggestions are sorted by descending relevance', () => {
+      const res = handleDiagnoseError({
+        error: 'invalid address sequence gas unmarshal insufficient funds auto-scan'
+      });
+      for (let i = 0; i + 1 < res.suggestions.length; i++) {
+        expect(res.suggestions[i].relevance).toBeGreaterThanOrEqual(res.suggestions[i + 1].relevance);
+      }
+    });
+  });
+
+  describe('output shape', () => {
+    it('tip always references simulate_transaction as a next step when a diagnosis exists', () => {
+      const res = handleDiagnoseError({ error: 'out of gas' });
+      expect(res.tip).toMatch(/simulate_transaction/);
+    });
+
+    it('diagnosis object exposes explanation + fix, and optionally an example', () => {
+      const res = handleDiagnoseError({ error: 'cannot unmarshal number' });
+      expect(res.diagnosis).not.toBeNull();
+      expect(typeof res.diagnosis!.explanation).toBe('string');
+      expect(res.diagnosis!.explanation.length).toBeGreaterThan(10);
+      expect(typeof res.diagnosis!.fix).toBe('string');
+      expect(res.diagnosis!.fix.length).toBeGreaterThan(10);
+      // "Numbers not strings" has an example
+      expect(res.diagnosis!.example).toBeDefined();
+    });
+
+    it('suggestions include pattern, category, and relevance fields', () => {
+      const res = handleDiagnoseError({
+        error: 'invalid address sequence gas unmarshal insufficient funds auto-scan'
+      });
+      for (const s of res.suggestions) {
+        expect(typeof s.pattern).toBe('string');
+        expect(typeof s.category).toBe('string');
+        expect(typeof s.relevance).toBe('number');
+        expect(s.relevance).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('invariants across all ERROR_PATTERNS', () => {
+    it('every pattern has at least one trigger that would match itself', () => {
+      // Sanity check on the resource: if a pattern has no triggers, it can never match.
+      for (const pattern of ERROR_PATTERNS) {
+        expect(pattern.triggers.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('every pattern can be matched by feeding back its first trigger', () => {
+      for (const pattern of ERROR_PATTERNS) {
+        const res = handleDiagnoseError({ error: pattern.triggers[0] });
+        expect(res.diagnosis).not.toBeNull();
+        // The top match isn't guaranteed to be *this* pattern (overlap between
+        // pattern triggers is possible), but SOMETHING must match.
+      }
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/generateUniqueId.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/generateUniqueId.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for `generate_unique_id`.
+ *
+ * The LLM builder calls this whenever it creates a new approval or tracker —
+ * the suffix is a cryptographically-random 4-byte hex so that two parallel
+ * builder sessions don't collide on approvalId (which would cause on-chain
+ * conflicts).
+ *
+ * Because the output is random, tests focus on:
+ *   - shape of each generated id (`{prefix}_{8 hex chars}`)
+ *   - bounds clamping (count clamped to [1, 20])
+ *   - default count behavior when omitted
+ *   - uniqueness across a large batch (collision probability vanishingly low)
+ *
+ * NOTE: 4-byte hex has a 2^32 collision space, so within a single batch of
+ * 20 ids a collision is astronomically unlikely but theoretically possible.
+ * The uniqueness assertion uses a Set size check and is expected to hold in
+ * normal runs — flaky failures here would indicate a bug in randomBytes().
+ */
+
+import { handleGenerateUniqueId as _handle } from './generateUniqueId.js';
+
+// Thin wrapper so tests can omit `count` (Zod's `.default(1)` makes the
+// inferred input type require it, but the runtime accepts undefined).
+const handleGenerateUniqueId = (input: { prefix: string; count?: number }) =>
+  _handle(input as any);
+
+describe('handleGenerateUniqueId', () => {
+  describe('shape of output', () => {
+    it('returns success=true and an array of ids', () => {
+      const res = handleGenerateUniqueId({ prefix: 'public-mint' });
+      expect(res.success).toBe(true);
+      expect(Array.isArray(res.ids)).toBe(true);
+      expect(res.ids.length).toBeGreaterThan(0);
+    });
+
+    it('returns exactly 1 id when count is omitted (default)', () => {
+      const res = handleGenerateUniqueId({ prefix: 'public-mint' });
+      expect(res.ids).toHaveLength(1);
+    });
+
+    it('each id matches `{prefix}_{8 lowercase hex chars}`', () => {
+      const res = handleGenerateUniqueId({ prefix: 'subscription-mint' });
+      for (const id of res.ids) {
+        expect(id).toMatch(/^subscription-mint_[0-9a-f]{8}$/);
+      }
+    });
+
+    it('preserves the prefix verbatim including hyphens and casing', () => {
+      const res = handleGenerateUniqueId({ prefix: 'MyCustomPrefix-With-Hyphens' });
+      expect(res.ids[0].startsWith('MyCustomPrefix-With-Hyphens_')).toBe(true);
+    });
+
+    it('returns an instructive `note` string so the agent knows how to use the ids', () => {
+      const res = handleGenerateUniqueId({ prefix: 'x' });
+      expect(res.note).toMatch(/approval/i);
+    });
+  });
+
+  describe('count parameter', () => {
+    it('returns exactly `count` ids when count is in range', () => {
+      const res = handleGenerateUniqueId({ prefix: 'x', count: 5 });
+      expect(res.ids).toHaveLength(5);
+    });
+
+    it('clamps count=0 up to 1 (minimum)', () => {
+      const res = handleGenerateUniqueId({ prefix: 'x', count: 0 });
+      expect(res.ids).toHaveLength(1);
+    });
+
+    it('clamps a negative count up to 1', () => {
+      const res = handleGenerateUniqueId({ prefix: 'x', count: -100 });
+      expect(res.ids).toHaveLength(1);
+    });
+
+    it('clamps count=21 down to 20 (maximum)', () => {
+      const res = handleGenerateUniqueId({ prefix: 'x', count: 21 });
+      expect(res.ids).toHaveLength(20);
+    });
+
+    it('clamps very large count down to 20', () => {
+      const res = handleGenerateUniqueId({ prefix: 'x', count: 10_000 });
+      expect(res.ids).toHaveLength(20);
+    });
+
+    it('accepts count=1 and count=20 exactly at the bounds', () => {
+      expect(handleGenerateUniqueId({ prefix: 'x', count: 1 }).ids).toHaveLength(1);
+      expect(handleGenerateUniqueId({ prefix: 'x', count: 20 }).ids).toHaveLength(20);
+    });
+  });
+
+  describe('uniqueness', () => {
+    it('a single batch of 20 has all unique suffixes (collisions would indicate an RNG bug)', () => {
+      const res = handleGenerateUniqueId({ prefix: 'x', count: 20 });
+      const suffixes = res.ids.map(id => id.split('_')[1]);
+      expect(new Set(suffixes).size).toBe(20);
+    });
+
+    it('successive calls return different suffixes', () => {
+      const a = handleGenerateUniqueId({ prefix: 'x' }).ids[0];
+      const b = handleGenerateUniqueId({ prefix: 'x' }).ids[0];
+      expect(a).not.toBe(b);
+    });
+
+    it('cross-batch uniqueness holds across 10 calls of 20 ids each (~200 samples)', () => {
+      const all: string[] = [];
+      for (let i = 0; i < 10; i++) {
+        all.push(...handleGenerateUniqueId({ prefix: 'x', count: 20 }).ids);
+      }
+      expect(new Set(all).size).toBe(all.length);
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/getCurrentTimestamp.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/getCurrentTimestamp.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for `get_current_timestamp`.
+ *
+ * Returns the current time in ms (as a string for BitBadges' string-encoded
+ * numeric convention), plus a handful of pre-computed helper values the LLM
+ * uses when setting up time-bounded approvals (claim windows, transfer
+ * times, etc.). Uses `jest.useFakeTimers` to pin time and assert exact values.
+ *
+ * Each path and every helper field is checked at least once.
+ */
+
+import { handleGetCurrentTimestamp } from './getCurrentTimestamp.js';
+
+const FIXED_MS = 1700000000000; // 2023-11-14T22:13:20.000Z
+
+const FIVE_MIN = 5 * 60 * 1000;
+const ONE_HOUR = 60 * 60 * 1000;
+const ONE_DAY = 24 * ONE_HOUR;
+const ONE_WEEK = 7 * ONE_DAY;
+const ONE_MONTH = 30 * ONE_DAY;
+const ONE_YEAR = 365 * ONE_DAY;
+
+describe('handleGetCurrentTimestamp', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(FIXED_MS));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('no offsets', () => {
+    it('returns current timestamp as both string and number', () => {
+      const res = handleGetCurrentTimestamp({});
+      expect(res.timestampMs).toBe(FIXED_MS);
+      expect(res.timestamp).toBe(String(FIXED_MS));
+    });
+
+    it('returns isoDate matching the timestamp', () => {
+      const res = handleGetCurrentTimestamp({});
+      expect(res.isoDate).toBe(new Date(FIXED_MS).toISOString());
+    });
+
+    it('returns MAX_UINT64 as foreverEnd (for "never expires" semantics)', () => {
+      const res = handleGetCurrentTimestamp({});
+      expect(res.foreverEnd).toBe('18446744073709551615');
+    });
+
+    it('helpers are computed relative to now', () => {
+      const res = handleGetCurrentTimestamp({});
+      expect(res.helpers.fiveMinutesFromNow).toBe(String(FIXED_MS + FIVE_MIN));
+      expect(res.helpers.oneHourFromNow).toBe(String(FIXED_MS + ONE_HOUR));
+      expect(res.helpers.oneDayFromNow).toBe(String(FIXED_MS + ONE_DAY));
+      expect(res.helpers.oneWeekFromNow).toBe(String(FIXED_MS + ONE_WEEK));
+      expect(res.helpers.oneMonthFromNow).toBe(String(FIXED_MS + ONE_MONTH));
+      expect(res.helpers.oneYearFromNow).toBe(String(FIXED_MS + ONE_YEAR));
+    });
+
+    it('durations are constant (not relative to now)', () => {
+      const res = handleGetCurrentTimestamp({});
+      expect(res.durations.fiveMinutes).toBe(String(FIVE_MIN));
+      expect(res.durations.oneHour).toBe(String(ONE_HOUR));
+      expect(res.durations.oneDay).toBe(String(ONE_DAY));
+      expect(res.durations.oneWeek).toBe(String(ONE_WEEK));
+      expect(res.durations.oneMonth).toBe(String(ONE_MONTH));
+      expect(res.durations.oneYear).toBe(String(ONE_YEAR));
+    });
+  });
+
+  describe('offsets', () => {
+    it('offsetMs adds to now', () => {
+      const res = handleGetCurrentTimestamp({ offsetMs: 12345 });
+      expect(res.timestampMs).toBe(FIXED_MS + 12345);
+    });
+
+    it('offsetHours adds `hours * 3600_000` to now', () => {
+      const res = handleGetCurrentTimestamp({ offsetHours: 3 });
+      expect(res.timestampMs).toBe(FIXED_MS + 3 * ONE_HOUR);
+    });
+
+    it('offsetDays adds `days * 86_400_000` to now', () => {
+      const res = handleGetCurrentTimestamp({ offsetDays: 7 });
+      expect(res.timestampMs).toBe(FIXED_MS + 7 * ONE_DAY);
+    });
+
+    it('all offsets combine additively (ms + hours + days)', () => {
+      const res = handleGetCurrentTimestamp({ offsetMs: 100, offsetHours: 2, offsetDays: 1 });
+      expect(res.timestampMs).toBe(FIXED_MS + 100 + 2 * ONE_HOUR + ONE_DAY);
+    });
+
+    it('negative offsets move backward in time', () => {
+      const res = handleGetCurrentTimestamp({ offsetHours: -1 });
+      expect(res.timestampMs).toBe(FIXED_MS - ONE_HOUR);
+    });
+
+    it('helpers are computed relative to the offset-adjusted "now", not wall clock', () => {
+      const res = handleGetCurrentTimestamp({ offsetDays: 30 });
+      expect(res.helpers.oneDayFromNow).toBe(String(FIXED_MS + 30 * ONE_DAY + ONE_DAY));
+    });
+
+    it('offsetMs=0 and offsetHours=0 behave as if omitted (falsy, skipped by `if (input.x)`)', () => {
+      const res = handleGetCurrentTimestamp({ offsetMs: 0, offsetHours: 0, offsetDays: 0 });
+      expect(res.timestampMs).toBe(FIXED_MS);
+    });
+  });
+
+  describe('output shape invariants', () => {
+    it('timestamp is always the String() of timestampMs', () => {
+      const res = handleGetCurrentTimestamp({ offsetDays: 5 });
+      expect(res.timestamp).toBe(String(res.timestampMs));
+    });
+
+    it('every helper key exists and is a string', () => {
+      const res = handleGetCurrentTimestamp({});
+      const keys = ['fiveMinutesFromNow', 'oneHourFromNow', 'oneDayFromNow', 'oneWeekFromNow', 'oneMonthFromNow', 'oneYearFromNow'] as const;
+      for (const k of keys) {
+        expect(typeof res.helpers[k]).toBe('string');
+      }
+    });
+
+    it('every duration key exists and is a string', () => {
+      const res = handleGetCurrentTimestamp({});
+      const keys = ['fiveMinutes', 'oneHour', 'oneDay', 'oneWeek', 'oneMonth', 'oneYear'] as const;
+      for (const k of keys) {
+        expect(typeof res.durations[k]).toBe('string');
+      }
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/lookupTokenInfo.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/lookupTokenInfo.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for `lookup_token_info`.
+ *
+ * Wraps the coinRegistry to resolve a symbol (USDC/ATOM/OSMO) or an IBC denom
+ * (ibc/...) to a TokenInfo object that includes the deterministic backing
+ * address for Smart Token denom wrapping.
+ *
+ * Behaviors covered:
+ *   - exact-symbol match (case-insensitive)
+ *   - exact-IBC-denom match (case-insensitive)
+ *   - unknown IBC denom → generates a synthetic TokenInfo with backingAddress
+ *   - unknown symbol → error with the list of known symbols
+ *   - `query` = "" or "all" → returns every known token
+ *   - backingAddress is a valid bb1 bech32 address
+ */
+
+import { handleLookupTokenInfo } from './lookupTokenInfo.js';
+
+describe('handleLookupTokenInfo', () => {
+  describe('exact symbol lookup', () => {
+    it('finds USDC by uppercase symbol', () => {
+      const res = handleLookupTokenInfo({ query: 'USDC' });
+      expect(res.success).toBe(true);
+      expect(res.tokenInfo).toBeDefined();
+      expect(res.tokenInfo!.symbol).toBe('USDC');
+      expect(res.tokenInfo!.ibcDenom.startsWith('ibc/')).toBe(true);
+    });
+
+    it('is case-insensitive for symbol (lowercase "usdc" still matches)', () => {
+      const res = handleLookupTokenInfo({ query: 'usdc' });
+      expect(res.success).toBe(true);
+      expect(res.tokenInfo!.symbol).toBe('USDC');
+    });
+
+    it('is case-insensitive for symbol (mixed case "UsDc")', () => {
+      const res = handleLookupTokenInfo({ query: 'UsDc' });
+      expect(res.success).toBe(true);
+      expect(res.tokenInfo!.symbol).toBe('USDC');
+    });
+
+    it('finds ATOM by symbol and returns decimals=6', () => {
+      const res = handleLookupTokenInfo({ query: 'ATOM' });
+      expect(res.success).toBe(true);
+      expect(res.tokenInfo!.decimals).toBe('6');
+    });
+
+    it('finds OSMO by symbol', () => {
+      const res = handleLookupTokenInfo({ query: 'OSMO' });
+      expect(res.success).toBe(true);
+      expect(res.tokenInfo!.symbol).toBe('OSMO');
+    });
+  });
+
+  describe('exact IBC denom lookup', () => {
+    it('finds USDC by its full IBC denom', () => {
+      const denom = 'ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349';
+      const res = handleLookupTokenInfo({ query: denom });
+      expect(res.success).toBe(true);
+      expect(res.tokenInfo!.symbol).toBe('USDC');
+      expect(res.tokenInfo!.ibcDenom).toBe(denom);
+    });
+
+    it('IBC denom lookup is case-insensitive (lowercased hex)', () => {
+      // Known USDC denom in lowercase
+      const denom = 'ibc/f082b65c88e4b6d5ef1db243cda1d331d002759e938a0f5cd3ffdc5d53b3e349';
+      const res = handleLookupTokenInfo({ query: denom });
+      expect(res.success).toBe(true);
+      expect(res.tokenInfo!.symbol).toBe('USDC');
+    });
+  });
+
+  describe('unknown IBC denom fallback', () => {
+    it('generates a synthetic TokenInfo for an unknown but valid-looking IBC denom', () => {
+      const denom = 'ibc/' + 'A'.repeat(64);
+      const res = handleLookupTokenInfo({ query: denom });
+      expect(res.success).toBe(true);
+      expect(res.tokenInfo).toBeDefined();
+      expect(res.tokenInfo!.symbol).toBe('UNKNOWN');
+      expect(res.tokenInfo!.decimals).toBe('6');
+      expect(res.tokenInfo!.backingAddress).toMatch(/^bb1/);
+    });
+
+    it('synthetic TokenInfo still has a valid bb1 backing address', () => {
+      const denom = 'ibc/0123456789ABCDEF';
+      const res = handleLookupTokenInfo({ query: denom });
+      expect(res.success).toBe(true);
+      expect(res.tokenInfo!.backingAddress.length).toBeGreaterThan(4);
+    });
+  });
+
+  describe('unknown symbol', () => {
+    it('returns success=false with an error listing known symbols', () => {
+      const res = handleLookupTokenInfo({ query: 'ZZZ' });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/Token not found/i);
+      // Should list at least one known symbol
+      expect(res.error).toMatch(/USDC/);
+    });
+  });
+
+  describe('"all" or empty query returns every token', () => {
+    it('query="all" returns the full list', () => {
+      const res = handleLookupTokenInfo({ query: 'all' });
+      expect(res.success).toBe(true);
+      expect(res.allTokens).toBeDefined();
+      expect(res.allTokens!.length).toBeGreaterThanOrEqual(3); // USDC, ATOM, OSMO
+      const symbols = res.allTokens!.map(t => t.symbol);
+      expect(symbols).toContain('USDC');
+      expect(symbols).toContain('ATOM');
+      expect(symbols).toContain('OSMO');
+    });
+
+    it('query="ALL" (case variants) also returns the full list', () => {
+      const res = handleLookupTokenInfo({ query: 'ALL' });
+      expect(res.success).toBe(true);
+      expect(res.allTokens).toBeDefined();
+      expect(res.allTokens!.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('empty query returns the full list (not an error)', () => {
+      const res = handleLookupTokenInfo({ query: '' });
+      expect(res.success).toBe(true);
+      expect(res.allTokens).toBeDefined();
+    });
+  });
+
+  describe('backingAddress determinism', () => {
+    it('the same symbol always returns the same backing address', () => {
+      const a = handleLookupTokenInfo({ query: 'USDC' }).tokenInfo!;
+      const b = handleLookupTokenInfo({ query: 'USDC' }).tokenInfo!;
+      expect(a.backingAddress).toBe(b.backingAddress);
+    });
+
+    it('different IBC denoms get different backing addresses', () => {
+      const usdc = handleLookupTokenInfo({ query: 'USDC' }).tokenInfo!;
+      const atom = handleLookupTokenInfo({ query: 'ATOM' }).tokenInfo!;
+      expect(usdc.backingAddress).not.toBe(atom.backingAddress);
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/searchKnowledgeBase.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/searchKnowledgeBase.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for `search_knowledge_base`.
+ *
+ * Builds an in-memory index from the embedded docs/recipes/learnings/etc.,
+ * scores each section against the query, and returns the top 10. We don't
+ * assert exact scores (the resource text changes over time) — we assert
+ * behavioral invariants that must hold regardless of what content lands in
+ * the resources at any given commit.
+ */
+
+import { handleSearchKnowledgeBase } from './searchKnowledgeBase.js';
+
+describe('handleSearchKnowledgeBase', () => {
+  describe('empty / trivial queries', () => {
+    it('returns success=false with no results when every query term is ≤1 char', () => {
+      const res = handleSearchKnowledgeBase({ query: 'a' });
+      // Single char gets filtered out by `t.length > 1`, so the effective
+      // query term list is empty → success=false path.
+      expect(res.success).toBe(false);
+      expect(res.results).toEqual([]);
+      expect(res.totalMatches).toBe(0);
+    });
+
+    it('returns success=false for an empty string query', () => {
+      const res = handleSearchKnowledgeBase({ query: '' });
+      expect(res.success).toBe(false);
+      expect(res.results).toEqual([]);
+    });
+
+    it('returns success=false for whitespace-only query', () => {
+      const res = handleSearchKnowledgeBase({ query: '   ' });
+      expect(res.success).toBe(false);
+    });
+  });
+
+  describe('matching + ranking', () => {
+    it('finds at least one result for a known domain term ("approval")', () => {
+      const res = handleSearchKnowledgeBase({ query: 'approval' });
+      expect(res.success).toBe(true);
+      expect(res.results.length).toBeGreaterThan(0);
+      expect(res.totalMatches).toBeGreaterThan(0);
+    });
+
+    it('results are sorted by descending relevance', () => {
+      const res = handleSearchKnowledgeBase({ query: 'approval transfer' });
+      expect(res.results.length).toBeGreaterThan(1);
+      for (let i = 0; i + 1 < res.results.length; i++) {
+        expect(res.results[i].relevance).toBeGreaterThanOrEqual(res.results[i + 1].relevance);
+      }
+    });
+
+    it('returns at most 10 results (even when totalMatches is higher)', () => {
+      const res = handleSearchKnowledgeBase({ query: 'the' });
+      expect(res.results.length).toBeLessThanOrEqual(10);
+      if (res.totalMatches > 10) {
+        expect(res.results.length).toBe(10);
+      }
+    });
+
+    it('each result includes source, section, content, and relevance', () => {
+      const res = handleSearchKnowledgeBase({ query: 'approval' });
+      for (const r of res.results) {
+        expect(typeof r.source).toBe('string');
+        expect(typeof r.section).toBe('string');
+        expect(typeof r.content).toBe('string');
+        expect(typeof r.relevance).toBe('number');
+        expect(r.relevance).toBeGreaterThan(0);
+      }
+    });
+
+    it('truncates content that exceeds 1500 chars and appends [truncated]', () => {
+      // Use a very common query so we get back big chunks of docs
+      const res = handleSearchKnowledgeBase({ query: 'approval' });
+      const truncated = res.results.filter(r => r.content.includes('...[truncated]'));
+      if (truncated.length > 0) {
+        for (const r of truncated) {
+          // 1500 + length of "\n...[truncated]" suffix
+          expect(r.content.length).toBeLessThanOrEqual(1500 + 20);
+        }
+      }
+      // We don't assert that truncation happened — depends on resource content.
+    });
+  });
+
+  describe('category filter', () => {
+    it('category="errors" returns only error-category sources', () => {
+      const res = handleSearchKnowledgeBase({ query: 'gas', category: 'errors' });
+      if (res.success) {
+        for (const r of res.results) {
+          expect(r.source).toMatch(/^errors/);
+        }
+      }
+    });
+
+    it('category="rules" returns only rule sources', () => {
+      const res = handleSearchKnowledgeBase({ query: 'approval', category: 'rules' });
+      if (res.success) {
+        for (const r of res.results) {
+          expect(r.source).toMatch(/^rules/);
+        }
+      }
+    });
+
+    it('category="recipes" returns only recipe sources', () => {
+      const res = handleSearchKnowledgeBase({ query: 'mint', category: 'recipes' });
+      if (res.success) {
+        for (const r of res.results) {
+          expect(r.source).toMatch(/^recipes/);
+        }
+      }
+    });
+
+    it('category="docs" returns only docs-category sources (docs/* or workflows)', () => {
+      // The index maps `getWorkflowsContent()` to source="workflows" but
+      // category="docs", so docs-filtered results can include workflows too.
+      const res = handleSearchKnowledgeBase({ query: 'approval', category: 'docs' });
+      if (res.success) {
+        for (const r of res.results) {
+          expect(r.source === 'workflows' || r.source.startsWith('docs')).toBe(true);
+        }
+      }
+    });
+
+    it('category="all" is equivalent to omitting the filter', () => {
+      const withAll = handleSearchKnowledgeBase({ query: 'approval', category: 'all' });
+      const without = handleSearchKnowledgeBase({ query: 'approval' });
+      expect(withAll.totalMatches).toBe(without.totalMatches);
+    });
+
+    it('category filter reduces totalMatches relative to "all"', () => {
+      const all = handleSearchKnowledgeBase({ query: 'approval', category: 'all' });
+      const errors = handleSearchKnowledgeBase({ query: 'approval', category: 'errors' });
+      // errors is a strict subset → totalMatches must be ≤ all
+      expect(errors.totalMatches).toBeLessThanOrEqual(all.totalMatches);
+    });
+  });
+
+  describe('query semantics', () => {
+    it('splits multi-word queries on whitespace and only counts terms of length > 1', () => {
+      const longOnly = handleSearchKnowledgeBase({ query: 'approval' });
+      const withOneCharNoise = handleSearchKnowledgeBase({ query: 'approval a x z' });
+      // Single-char terms are filtered out, so totalMatches should match.
+      expect(withOneCharNoise.totalMatches).toBe(longOnly.totalMatches);
+    });
+
+    it('scoring is case-insensitive', () => {
+      const lower = handleSearchKnowledgeBase({ query: 'approval' });
+      const upper = handleSearchKnowledgeBase({ query: 'APPROVAL' });
+      // Same results, same total. (Individual scores should match too but we
+      // only assert totalMatches to avoid coupling to scorer internals.)
+      expect(upper.totalMatches).toBe(lower.totalMatches);
+    });
+
+    it('regex-special characters in query do not throw (they are escaped)', () => {
+      // scoreRelevance does `termLower.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`
+      // so these inputs must not blow up.
+      const malicious = ['.', '*', '(', '[', '\\', '$', '{', '}', '|', '?', '^'];
+      for (const m of malicious) {
+        // Pair with a real word so queryTerms isn't empty
+        const res = handleSearchKnowledgeBase({ query: `approval ${m}${m}` });
+        expect(typeof res.success).toBe('boolean');
+      }
+    });
+  });
+
+  describe('no-match query', () => {
+    // NOTE — this test documents a known BUG (see backlog/0223):
+    // `scoreRelevance` applies a +2/+2 "short section" bonus unconditionally,
+    // even when the query terms don't match the section at all. As a result,
+    // any query returns every short section in the knowledge base with a
+    // non-zero relevance. This test pins the current (wrong) behavior so
+    // we'll know when it changes. When the bug is fixed, flip this to
+    // `expect(res.success).toBe(false)`.
+    it('BUG: short sections always match (pins current behavior — see backlog/0223)', () => {
+      const res = handleSearchKnowledgeBase({
+        query: 'zxqvwmplqr xqzvmrjkwh qrstvwxyzz'
+      });
+      // Current behavior: short sections score +2 or +4 even with zero keyword hits.
+      expect(res.totalMatches).toBeGreaterThan(0);
+      for (const r of res.results) {
+        // Every "match" here should be short — that's the only reason it scored.
+        expect(r.content.length).toBeLessThan(500);
+        // Max possible from the short-section bonus: 4 (2 for <500, 2 for <200)
+        expect(r.relevance).toBeLessThanOrEqual(4);
+      }
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateAddress.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateAddress.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for `validate_address` builder tool.
+ *
+ * validateAddress is called by the LLM builder to confirm user-supplied addresses
+ * before putting them into on-chain transactions. Misclassifying a valid address
+ * or accepting an invalid one would cause downstream tx failures, so the
+ * function must be airtight across every input shape we actually encounter:
+ *
+ *   - empty / whitespace strings
+ *   - 0x prefix with invalid length / invalid hex
+ *   - valid 20-byte ETH addresses (mixed case)
+ *   - bb1 / cosmos1 bech32 addresses with valid + invalid checksums
+ *   - generic bech32 addresses from other chains (osmo1, ibc channel ids, etc.)
+ *   - strings that look like addresses but aren't
+ *
+ * Each branch in `handleValidateAddress` is exercised at least once.
+ */
+
+import { handleValidateAddress } from './validateAddress.js';
+
+describe('handleValidateAddress', () => {
+  describe('empty + malformed input', () => {
+    it('returns valid=false with explicit empty-address error for ""', () => {
+      const res = handleValidateAddress({ address: '' });
+      expect(res.success).toBe(true);
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('unknown');
+      expect(res.error).toMatch(/empty/i);
+    });
+
+    it('returns valid=false for whitespace-only input', () => {
+      const res = handleValidateAddress({ address: '   ' });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('unknown');
+      expect(res.error).toMatch(/empty/i);
+    });
+
+    it('returns valid=false for a random unrelated string', () => {
+      const res = handleValidateAddress({ address: 'definitely-not-an-address' });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('unknown');
+      expect(res.details?.format).toBe('unknown');
+      expect(res.error).toMatch(/not recognized/i);
+    });
+  });
+
+  describe('ETH (0x) addresses', () => {
+    it('accepts a well-formed 0x address (lowercase hex)', () => {
+      const addr = '0x' + 'a'.repeat(40);
+      const res = handleValidateAddress({ address: addr });
+      expect(res.valid).toBe(true);
+      expect(res.chain).toBe('eth');
+      expect(res.normalized).toBe(addr.toLowerCase());
+      expect(res.details?.format).toBe('ethereum');
+      expect(res.details?.length).toBe(42);
+    });
+
+    it('accepts a well-formed 0x address with mixed case and normalizes to lowercase', () => {
+      const addr = '0xAbCdEf0123456789aBcDeF0123456789AbCdEf01';
+      const res = handleValidateAddress({ address: addr });
+      expect(res.valid).toBe(true);
+      expect(res.normalized).toBe(addr.toLowerCase());
+    });
+
+    it('rejects a 0x address that is too short (41 chars)', () => {
+      const addr = '0x' + 'a'.repeat(39);
+      const res = handleValidateAddress({ address: addr });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('eth');
+      expect(res.normalized).toBeUndefined();
+    });
+
+    it('rejects a 0x address that is too long (43 chars)', () => {
+      const addr = '0x' + 'a'.repeat(41);
+      const res = handleValidateAddress({ address: addr });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('eth');
+    });
+
+    it('rejects a 0x address that contains non-hex characters', () => {
+      const addr = '0x' + 'z'.repeat(40);
+      const res = handleValidateAddress({ address: addr });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('eth');
+    });
+
+    it('rejects bare "0x" (prefix only)', () => {
+      const res = handleValidateAddress({ address: '0x' });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('eth');
+    });
+  });
+
+  describe('BitBadges (bb1) addresses', () => {
+    // Real-ish bech32 address generated from 20 zero bytes with bb prefix:
+    //   bech32.encode('bb', bech32.toWords(Buffer.alloc(20, 0)))
+    const validBb1 = 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv';
+
+    it('accepts a valid bb1 address and reports the correct prefix', () => {
+      const res = handleValidateAddress({ address: validBb1 });
+      expect(res.valid).toBe(true);
+      expect(res.chain).toBe('cosmos');
+      expect(res.details?.prefix).toBe('bb');
+      expect(res.details?.format).toBe('bech32');
+      expect(res.normalized).toBe(validBb1.toLowerCase());
+    });
+
+    it('rejects a bb1 address with a corrupted checksum', () => {
+      // Flip the last character — breaks the bech32 checksum
+      const broken = validBb1.slice(0, -1) + 'x';
+      const res = handleValidateAddress({ address: broken });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('cosmos');
+      expect(res.normalized).toBeUndefined();
+    });
+  });
+
+  describe('Cosmos-prefixed (cosmos1) addresses', () => {
+    // Valid cosmos1 encoding of 20 zero bytes
+    const validCosmos1 = 'cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a';
+
+    it('accepts a valid cosmos1 address', () => {
+      const res = handleValidateAddress({ address: validCosmos1 });
+      expect(res.valid).toBe(true);
+      expect(res.chain).toBe('cosmos');
+      expect(res.details?.prefix).toBe('cosmos');
+    });
+
+    it('rejects a cosmos1 address with invalid checksum', () => {
+      const broken = validCosmos1.slice(0, -1) + 'z';
+      const res = handleValidateAddress({ address: broken });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('cosmos');
+    });
+  });
+
+  describe('generic bech32 (other-chain prefixes)', () => {
+    // osmo1 of 20 zero bytes
+    const validOsmo = 'osmo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqmcn030';
+
+    it('accepts a valid osmo1 bech32 address via generic fallback', () => {
+      const res = handleValidateAddress({ address: validOsmo });
+      expect(res.valid).toBe(true);
+      expect(res.chain).toBe('cosmos');
+      expect(res.details?.prefix).toBe('osmo');
+    });
+
+    it('rejects an arbitrary non-bech32 string that has no 0x/bb1/cosmos1 prefix', () => {
+      const res = handleValidateAddress({ address: 'foo1bar' });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('unknown');
+    });
+  });
+
+  describe('output shape is consistent', () => {
+    it('always returns success=true for non-throw paths (even when address is invalid)', () => {
+      // This is important for MCP tool contracts — `success` means "the tool ran",
+      // not "the address is valid". Downstream agents check `valid` separately.
+      const cases = ['', '0x', '0xdead', 'bb1broken', 'random', '   '];
+      for (const addr of cases) {
+        const res = handleValidateAddress({ address: addr });
+        expect(res.success).toBe(true);
+      }
+    });
+
+    it('returns details.length matching the input length for malformed inputs', () => {
+      const res = handleValidateAddress({ address: '0xdeadbeef' });
+      expect(res.details?.length).toBe(10);
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateTransaction.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateTransaction.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for `validate_transaction`.
+ *
+ * Thin wrapper around core/validate.ts — its job is to:
+ *   1. Accept either a JSON string OR a pre-parsed object (via `transaction`)
+ *   2. Normalize to JSON, parse it, and type-check (must be an object)
+ *   3. Pass the parsed object to the full SDK validator
+ *   4. Wrap parse/type errors in the standard issues[] format
+ *
+ * Tests below hit every branch in the normalization layer. Business-logic
+ * coverage lives in `src/core/validate.spec.ts` (separate suite).
+ */
+
+import { handleValidateTransaction } from './validateTransaction.js';
+
+describe('handleValidateTransaction — input normalization', () => {
+  const validTx = {
+    '@type': '/badges.MsgUniversalUpdateCollection',
+    creator: 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv',
+    collectionId: '0'
+    // Other fields may produce validator warnings, but the wrapper itself
+    // doesn't care — it just needs to reach the inner `validateTransaction`.
+  };
+
+  describe('transactionJson input', () => {
+    it('accepts a valid JSON string and delegates to the core validator', () => {
+      const res = handleValidateTransaction({ transactionJson: JSON.stringify(validTx) });
+      // The wrapper returns whatever validateTransaction returns; we just
+      // assert it has the correct shape.
+      expect(res).toHaveProperty('valid');
+      expect(res).toHaveProperty('issues');
+      expect(Array.isArray(res.issues)).toBe(true);
+    });
+
+    it('returns a single "Invalid JSON" issue when the string is unparseable', () => {
+      const res = handleValidateTransaction({ transactionJson: '{not json' });
+      expect(res.valid).toBe(false);
+      expect(res.issues).toHaveLength(1);
+      expect(res.issues[0].severity).toBe('error');
+      expect(res.issues[0].message).toMatch(/Invalid JSON/);
+    });
+
+    it('treats an empty-string transactionJson as unparseable JSON', () => {
+      const res = handleValidateTransaction({ transactionJson: '' });
+      expect(res.valid).toBe(false);
+      expect(res.issues[0].message).toMatch(/Invalid JSON/);
+    });
+
+    it('rejects top-level JSON values that are not objects (arrays)', () => {
+      const res = handleValidateTransaction({ transactionJson: '[]' });
+      expect(res.valid).toBe(false);
+      // [] is typeof 'object' → so it actually passes the type guard. Instead,
+      // the real validator will flag it via missing @type. Don't over-assert here.
+      expect(res.issues.length).toBeGreaterThan(0);
+    });
+
+    it('rejects top-level JSON values that are strings', () => {
+      const res = handleValidateTransaction({ transactionJson: '"hello"' });
+      expect(res.valid).toBe(false);
+      expect(res.issues[0].message).toMatch(/must be a JSON object/);
+    });
+
+    it('rejects top-level JSON values that are numbers', () => {
+      const res = handleValidateTransaction({ transactionJson: '42' });
+      expect(res.valid).toBe(false);
+      expect(res.issues[0].message).toMatch(/must be a JSON object/);
+    });
+
+    it('rejects top-level null', () => {
+      const res = handleValidateTransaction({ transactionJson: 'null' });
+      expect(res.valid).toBe(false);
+      expect(res.issues[0].message).toMatch(/must be a JSON object/);
+    });
+  });
+
+  describe('transaction (object) input', () => {
+    it('accepts a pre-parsed object and delegates to the core validator', () => {
+      const res = handleValidateTransaction({ transaction: validTx });
+      expect(res).toHaveProperty('valid');
+      expect(Array.isArray(res.issues)).toBe(true);
+    });
+
+    it('prefers `transaction` over `transactionJson` when both are provided', () => {
+      // `transaction` takes precedence in the normalization step. To prove
+      // this, send an invalid JSON string alongside a valid object — the
+      // object should win (no "Invalid JSON" error).
+      const res = handleValidateTransaction({
+        transaction: validTx,
+        transactionJson: '{not json'
+      });
+      for (const issue of res.issues) {
+        expect(issue.message).not.toMatch(/Invalid JSON/);
+      }
+    });
+  });
+
+  describe('missing-input edge cases', () => {
+    it('without transaction or transactionJson, returns an Invalid JSON issue (empty string path)', () => {
+      // The wrapper's `??` fallback turns missing input into '' → JSON.parse fails.
+      // (The Zod `.refine` schema would catch this *before* the wrapper runs in
+      // real MCP usage, but handleValidateTransaction itself is defensively
+      // callable with missing fields.)
+      const res = handleValidateTransaction({} as any);
+      expect(res.valid).toBe(false);
+      expect(res.issues[0].message).toMatch(/Invalid JSON/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **199 tests across 11 new spec files** covering the pure utility layer under `packages/bitbadgesjs-sdk/src/builder/` — validateAddress, convertAddress, generateUniqueId, getCurrentTimestamp, diagnoseError, lookupTokenInfo, searchKnowledgeBase, validateTransaction, addressGenerator, addressUtils, coinRegistry. Every meaningful code path (empty/malformed inputs, boundaries, error paths, round-trip invariants, case-insensitivity, special-value pass-throughs) is exercised.
- **Fixes a silent jest config gap** that had been hiding ~216 tests from CI. `package.json` had `"test": "jest ./src/**/*.spec.ts …"`; `**` only expands recursively when bash `globstar` is enabled, so any spec ≥2 directories under `src/` was skipped — including the pre-existing `builder/resources/errorPatterns.spec.ts`, `builder/tools/registry.spec.ts`, `api-indexer/metadata/tokenMetadata.spec.ts`, and `core/builders/builders.spec.ts`. Fixed by dropping the explicit path and adding `roots`/`testMatch` to `jest.config.cjs` (scoped to `src/`, skipping `dist/`).

### Impact on test totals

| | Suites | Tests |
|---|--:|--:|
| Before this PR | 27 | 1101 |
| After config fix (same code, surfaces dead suites) | 33 | ~1317 |
| After this PR (config fix + 11 new specs) | **44** | **1516** |

All green.

### Bug found while testing (filed separately, NOT fixed here)

`search_knowledge_base` returns false matches for any query, even nonsense ones — the "shorter sections" bonus in `scoreRelevance` is applied unconditionally, so every short section gets a non-zero relevance regardless of whether the query matches anything. The spec in this PR includes a test that **pins the current (wrong) behavior** so we know when it changes. Tracked at `backlog/0223-bug-search-knowledge-base-short-section-false-matches.md` in the autopilot repo — left for human review because the fix changes user-visible tool behavior.

Implements autopilot backlog #0222.

## Test plan

- [x] `npm test` passes (44 suites / 1516 tests) on this branch
- [x] All 11 new spec files tested in isolation — zero flakiness observed across multiple runs
- [x] Previously-dead specs (`errorPatterns.spec.ts`, `registry.spec.ts`, `api-indexer/metadata/tokenMetadata.spec.ts`, `core/builders/builders.spec.ts`) now run and pass
- [x] Unchanged specs under `src/core/` and `src/signing/` still pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>