### PR TITLE
test(sdk): core protocol validator coverage (+235 tests, #0243)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/core/auctions.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/auctions.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for auctions.ts — Auction standard protocol validator.
+ *
+ * Covers validateAuctionCollection + doesCollectionFollowAuctionProtocol.
+ * A valid Auction has 0-2 approvals (a mint-to-winner + optional burn).
+ * Post-settlement state (no mint approval left) is valid — the mint
+ * approval auto-deletes afterOneUse. Unbounded transferTimes are rejected.
+ */
+
+import { validateAuctionCollection, doesCollectionFollowAuctionProtocol } from './auctions.js';
+import { GO_MAX_UINT_64 } from '../common/math.js';
+
+const makeMintApproval = () => ({
+  approvalId: 'mint-to-winner',
+  fromListId: 'Mint',
+  toListId: 'bb1winner',
+  initiatedByListId: 'bb1seller',
+  transferTimes: [{ start: 1n, end: 1000n }],
+  tokenIds: [{ start: 1n, end: 1n }],
+  approvalCriteria: {
+    maxNumTransfers: { overallMaxNumTransfers: 1n },
+    overridesFromOutgoingApprovals: true
+  }
+});
+
+const makeBurnApproval = () => ({
+  approvalId: 'burn',
+  fromListId: '!Mint',
+  toListId: 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv',
+  initiatedByListId: 'All',
+  transferTimes: [{ start: 1n, end: 1000n }],
+  tokenIds: [{ start: 1n, end: 1n }],
+  approvalCriteria: {
+    maxNumTransfers: { overallMaxNumTransfers: 1n }
+  }
+});
+
+const makeValidCollection = (): any => ({
+  standards: ['Auction'],
+  validTokenIds: [{ start: 1n, end: 1n }],
+  collectionApprovals: [makeMintApproval()]
+});
+
+// ---- happy path ----------------------------------------------------------
+
+describe('validateAuctionCollection — happy path', () => {
+  it('accepts a minimal valid auction with just a mint approval', () => {
+    const r = validateAuctionCollection(makeValidCollection());
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it('accepts an auction with both mint + burn (2 approvals)', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = [makeMintApproval(), makeBurnApproval()];
+    const r = validateAuctionCollection(c);
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it('accepts post-settlement state (no mint approval remaining)', () => {
+    // After auto-deletion of the mint-to-winner approval, the collection
+    // may be left with just the burn approval, or zero approvals.
+    const c = makeValidCollection();
+    c.collectionApprovals = [makeBurnApproval()];
+    const r = validateAuctionCollection(c);
+    expect(r.valid).toBe(true);
+
+    c.collectionApprovals = [];
+    const r2 = validateAuctionCollection(c);
+    expect(r2.valid).toBe(true);
+  });
+
+  it('doesCollectionFollowAuctionProtocol returns true for a valid collection', () => {
+    expect(doesCollectionFollowAuctionProtocol(makeValidCollection())).toBe(true);
+  });
+});
+
+// ---- standard check ------------------------------------------------------
+
+describe('validateAuctionCollection — standards check', () => {
+  it('rejects when "Auction" is missing', () => {
+    const c = makeValidCollection();
+    c.standards = ['Other'];
+    const r = validateAuctionCollection(c);
+    expect(r.errors).toContain('Missing "Auction" standard');
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects when standards is undefined', () => {
+    const c = makeValidCollection();
+    c.standards = undefined;
+    expect(validateAuctionCollection(c).errors).toContain('Missing "Auction" standard');
+  });
+
+  it('accepts multi-standard including Auction', () => {
+    const c = makeValidCollection();
+    c.standards = ['Bounty', 'Auction', 'Other'];
+    expect(validateAuctionCollection(c).valid).toBe(true);
+  });
+});
+
+// ---- validTokenIds -------------------------------------------------------
+
+describe('validateAuctionCollection — validTokenIds', () => {
+  it('rejects multiple ranges', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [
+      { start: 1n, end: 1n },
+      { start: 2n, end: 2n }
+    ];
+    expect(validateAuctionCollection(c).errors).toContain('validTokenIds must be exactly [{start: 1, end: 1}]');
+  });
+
+  it('rejects range [1,2]', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [{ start: 1n, end: 2n }];
+    expect(validateAuctionCollection(c).errors).toContain('validTokenIds must be exactly [{start: 1, end: 1}]');
+  });
+
+  it('rejects empty validTokenIds', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [];
+    expect(validateAuctionCollection(c).errors).toContain('validTokenIds must be exactly [{start: 1, end: 1}]');
+  });
+});
+
+// ---- approval count ------------------------------------------------------
+
+describe('validateAuctionCollection — approval count cap', () => {
+  it('rejects >2 approvals', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = [makeMintApproval(), makeBurnApproval(), makeBurnApproval()];
+    const r = validateAuctionCollection(c);
+    expect(r.errors.some((e: string) => e.includes('Expected 0-2 approvals'))).toBe(true);
+  });
+});
+
+// ---- mint approval rules -------------------------------------------------
+
+describe('validateAuctionCollection — mint approval rules', () => {
+  it('rejects when overallMaxNumTransfers is not 1', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.maxNumTransfers.overallMaxNumTransfers = 2n;
+    expect(validateAuctionCollection(c).errors).toContain('Mint-to-winner overallMaxNumTransfers must be 1');
+  });
+
+  it('rejects when maxNumTransfers is missing', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.maxNumTransfers = undefined;
+    expect(validateAuctionCollection(c).errors).toContain('Mint-to-winner overallMaxNumTransfers must be 1');
+  });
+
+  it('rejects when overridesFromOutgoingApprovals is false', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.overridesFromOutgoingApprovals = false;
+    expect(validateAuctionCollection(c).errors).toContain(
+      'Mint-to-winner must have overridesFromOutgoingApprovals=true'
+    );
+  });
+
+  it('rejects when initiatedByListId is "All" (seller must be restricted)', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].initiatedByListId = 'All';
+    expect(validateAuctionCollection(c).errors).toContain(
+      'Mint-to-winner initiatedByListId must restrict to seller (not "All")'
+    );
+  });
+
+  it('rejects unbounded transferTimes (max uint64)', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].transferTimes = [{ start: 1n, end: GO_MAX_UINT_64 }];
+    expect(validateAuctionCollection(c).errors).toContain(
+      'Mint-to-winner transferTimes must have a bounded end date (not max uint64)'
+    );
+  });
+
+  it('rejects transferTimes end strictly greater than max uint64 (>=)', () => {
+    // >= GO_MAX_UINT_64 is rejected per the ">=" comparison.
+    const c = makeValidCollection();
+    c.collectionApprovals[0].transferTimes = [{ start: 1n, end: GO_MAX_UINT_64 + 1n }];
+    expect(validateAuctionCollection(c).errors).toContain(
+      'Mint-to-winner transferTimes must have a bounded end date (not max uint64)'
+    );
+  });
+
+  it('accepts transferTimes end just below max uint64', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].transferTimes = [{ start: 1n, end: GO_MAX_UINT_64 - 1n }];
+    expect(validateAuctionCollection(c).valid).toBe(true);
+  });
+
+  it('does not complain when transferTimes is absent', () => {
+    // tt is optional in the check — empty/undefined is not flagged
+    const c = makeValidCollection();
+    c.collectionApprovals[0].transferTimes = [];
+    expect(
+      validateAuctionCollection(c).errors.some((e: string) => e.includes('transferTimes'))
+    ).toBe(false);
+  });
+});
+
+// ---- doesCollectionFollowAuctionProtocol ---------------------------------
+
+describe('doesCollectionFollowAuctionProtocol', () => {
+  it('returns false for an invalid auction', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].initiatedByListId = 'All';
+    expect(doesCollectionFollowAuctionProtocol(c)).toBe(false);
+  });
+
+  it('returns true when all rules are met', () => {
+    expect(doesCollectionFollowAuctionProtocol(makeValidCollection())).toBe(true);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/core/blankCriteria.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/blankCriteria.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for blankCriteria.ts — factory for a default/empty
+ * iApprovalCriteriaWithDetails<bigint>.
+ *
+ * The function is small but it's widely used to seed new approvals in
+ * builders. It must:
+ *   - Produce fresh objects every call (no shared references)
+ *   - Thread the passed id into both amountTrackerId fields
+ *   - Keep the structural shape required by downstream validators
+ *     (i.e. `Required<iApprovalCriteriaWithDetails<bigint>>`).
+ */
+
+import { blankCriteria } from './blankCriteria.js';
+
+describe('blankCriteria', () => {
+  it('threads the id into amountTrackerId fields', () => {
+    const c = blankCriteria('my-tracker');
+    expect(c.maxNumTransfers.amountTrackerId).toBe('my-tracker');
+    expect(c.approvalAmounts.amountTrackerId).toBe('my-tracker');
+  });
+
+  it('threads an empty id string (defensive)', () => {
+    const c = blankCriteria('');
+    expect(c.maxNumTransfers.amountTrackerId).toBe('');
+    expect(c.approvalAmounts.amountTrackerId).toBe('');
+  });
+
+  it('returns fresh objects per call (no shared state)', () => {
+    const a = blankCriteria('x');
+    const b = blankCriteria('y');
+    expect(a).not.toBe(b);
+    expect(a.maxNumTransfers).not.toBe(b.maxNumTransfers);
+    expect(a.senderChecks).not.toBe(b.senderChecks);
+    expect(a.predeterminedBalances).not.toBe(b.predeterminedBalances);
+    expect(a.predeterminedBalances.incrementedBalances).not.toBe(b.predeterminedBalances.incrementedBalances);
+  });
+
+  it('mutations on one instance do not leak to another', () => {
+    const a = blankCriteria('a');
+    const b = blankCriteria('b');
+    a.mustOwnTokens.push({} as any);
+    a.predeterminedBalances.manualBalances.push({} as any);
+    a.merkleChallenges.push({} as any);
+    expect(b.mustOwnTokens).toEqual([]);
+    expect(b.predeterminedBalances.manualBalances).toEqual([]);
+    expect(b.merkleChallenges).toEqual([]);
+  });
+
+  it('has all four *Checks blocks with all flags false', () => {
+    const c = blankCriteria('t');
+    for (const block of ['senderChecks', 'recipientChecks', 'initiatorChecks'] as const) {
+      const b = c[block];
+      expect(b.mustBeEvmContract).toBe(false);
+      expect(b.mustNotBeEvmContract).toBe(false);
+      expect(b.mustBeLiquidityPool).toBe(false);
+      expect(b.mustNotBeLiquidityPool).toBe(false);
+    }
+  });
+
+  it('autoDeletionOptions are all false by default', () => {
+    const c = blankCriteria('t');
+    expect(c.autoDeletionOptions).toEqual({
+      afterOneUse: false,
+      afterOverallMaxNumTransfers: false,
+      allowCounterpartyPurge: false,
+      allowPurgeIfExpired: false
+    });
+  });
+
+  it('predetermined balances: empty manualBalances and zeroed counters', () => {
+    const c = blankCriteria('t');
+    expect(c.predeterminedBalances.manualBalances).toEqual([]);
+    expect(c.predeterminedBalances.orderCalculationMethod).toEqual({
+      useOverallNumTransfers: false,
+      usePerToAddressNumTransfers: false,
+      usePerFromAddressNumTransfers: false,
+      usePerInitiatedByAddressNumTransfers: false,
+      useMerkleChallengeLeafIndex: false,
+      challengeTrackerId: ''
+    });
+
+    const ib = c.predeterminedBalances.incrementedBalances;
+    expect(ib.startBalances).toEqual([]);
+    expect(ib.incrementTokenIdsBy).toBe(0n);
+    expect(ib.incrementOwnershipTimesBy).toBe(0n);
+    expect(ib.durationFromTimestamp).toBe(0n);
+    expect(ib.allowOverrideTimestamp).toBe(false);
+    expect(ib.allowOverrideWithAnyValidToken).toBe(false);
+    expect(ib.allowAmountScaling).toBe(false);
+    expect(ib.maxScalingMultiplier).toBe(0n);
+    expect(ib.recurringOwnershipTimes).toEqual({
+      startTime: 0n,
+      intervalLength: 0n,
+      chargePeriodLength: 0n
+    });
+  });
+
+  it('maxNumTransfers and approvalAmounts have zeroed counters', () => {
+    const c = blankCriteria('zz');
+    expect(c.maxNumTransfers.overallMaxNumTransfers).toBe(0n);
+    expect(c.maxNumTransfers.perToAddressMaxNumTransfers).toBe(0n);
+    expect(c.maxNumTransfers.perFromAddressMaxNumTransfers).toBe(0n);
+    expect(c.maxNumTransfers.perInitiatedByAddressMaxNumTransfers).toBe(0n);
+    expect(c.maxNumTransfers.resetTimeIntervals).toEqual({ startTime: 0n, intervalLength: 0n });
+
+    expect(c.approvalAmounts.overallApprovalAmount).toBe(0n);
+    expect(c.approvalAmounts.perFromAddressApprovalAmount).toBe(0n);
+    expect(c.approvalAmounts.perToAddressApprovalAmount).toBe(0n);
+    expect(c.approvalAmounts.perInitiatedByAddressApprovalAmount).toBe(0n);
+    expect(c.approvalAmounts.resetTimeIntervals).toEqual({ startTime: 0n, intervalLength: 0n });
+  });
+
+  it('challenge / token arrays are empty', () => {
+    const c = blankCriteria('x');
+    expect(c.merkleChallenges).toEqual([]);
+    expect(c.mustOwnTokens).toEqual([]);
+    expect(c.dynamicStoreChallenges).toEqual([]);
+    expect(c.ethSignatureChallenges).toEqual([]);
+    expect(c.votingChallenges).toEqual([]);
+    expect(c.evmQueryChallenges).toEqual([]);
+    expect(c.coinTransfers).toEqual([]);
+  });
+
+  it('boolean require/override/allow flags are all false', () => {
+    const c = blankCriteria('x');
+    expect(c.requireToDoesNotEqualInitiatedBy).toBe(false);
+    expect(c.requireFromDoesNotEqualInitiatedBy).toBe(false);
+    expect(c.requireToEqualsInitiatedBy).toBe(false);
+    expect(c.requireFromEqualsInitiatedBy).toBe(false);
+    expect(c.overridesFromOutgoingApprovals).toBe(false);
+    expect(c.overridesToIncomingApprovals).toBe(false);
+    expect(c.mustPrioritize).toBe(false);
+    expect(c.allowBackedMinting).toBe(false);
+    expect(c.allowSpecialWrapping).toBe(false);
+  });
+
+  it('userApprovalSettings has zero royalty and empty denoms', () => {
+    const c = blankCriteria('t');
+    expect(c.userApprovalSettings.allowedDenoms).toEqual([]);
+    expect(c.userApprovalSettings.disableUserCoinTransfers).toBe(false);
+    expect(c.userApprovalSettings.userRoyalties).toEqual({ percentage: 0n, payoutAddress: '' });
+  });
+
+  it('altTimeChecks has empty offline arrays', () => {
+    const c = blankCriteria('t');
+    expect(c.altTimeChecks).toEqual({ offlineHours: [], offlineDays: [] });
+  });
+
+  it('handles unicode and special-char id', () => {
+    const c = blankCriteria('тест-💥');
+    expect(c.maxNumTransfers.amountTrackerId).toBe('тест-💥');
+    expect(c.approvalAmounts.amountTrackerId).toBe('тест-💥');
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/core/bounties.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/bounties.spec.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for bounties.ts — Bounty standard protocol validator.
+ *
+ * Covers validateBountyCollection + doesCollectionFollowBountyProtocol.
+ * A valid Bounty has 3 approvals (accept, deny, expire) where accept+deny
+ * share a verifier voting challenge and the expire path has no voting and
+ * starts after the accept/deny expiration.
+ */
+
+import { validateBountyCollection, doesCollectionFollowBountyProtocol } from './bounties.js';
+
+const BURN = 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv';
+const VERIFIER = 'bb1verifier';
+
+// ---- fixture helpers ------------------------------------------------------
+
+const makeAcceptApproval = () => ({
+  approvalId: 'accept',
+  fromListId: 'Mint',
+  toListId: BURN,
+  initiatedByListId: 'All',
+  transferTimes: [{ start: 1n, end: 1000n }],
+  tokenIds: [{ start: 1n, end: 1n }],
+  approvalCriteria: {
+    overridesFromOutgoingApprovals: true,
+    overridesToIncomingApprovals: true,
+    maxNumTransfers: { overallMaxNumTransfers: 1n },
+    coinTransfers: [
+      {
+        to: 'bb1recipient',
+        overrideFromWithApproverAddress: true,
+        coins: [{ denom: 'ubadge', amount: 100n }]
+      }
+    ],
+    votingChallenges: [{ voters: [{ address: VERIFIER }] }]
+  }
+});
+
+const makeDenyApproval = () => ({
+  approvalId: 'deny',
+  fromListId: 'Mint',
+  toListId: BURN,
+  initiatedByListId: 'All',
+  transferTimes: [{ start: 1n, end: 1000n }],
+  tokenIds: [{ start: 1n, end: 1n }],
+  approvalCriteria: {
+    overridesFromOutgoingApprovals: true,
+    overridesToIncomingApprovals: true,
+    maxNumTransfers: { overallMaxNumTransfers: 1n },
+    coinTransfers: [
+      {
+        to: 'bb1submitter',
+        overrideFromWithApproverAddress: true,
+        coins: [{ denom: 'ubadge', amount: 100n }]
+      }
+    ],
+    votingChallenges: [{ voters: [{ address: VERIFIER }] }]
+  }
+});
+
+const makeExpireApproval = () => ({
+  approvalId: 'expire',
+  fromListId: 'Mint',
+  toListId: BURN,
+  initiatedByListId: 'All',
+  transferTimes: [{ start: 1001n, end: 2000n }],
+  tokenIds: [{ start: 1n, end: 1n }],
+  approvalCriteria: {
+    overridesFromOutgoingApprovals: true,
+    overridesToIncomingApprovals: true,
+    maxNumTransfers: { overallMaxNumTransfers: 1n },
+    coinTransfers: [
+      {
+        to: 'bb1submitter',
+        overrideFromWithApproverAddress: true,
+        coins: [{ denom: 'ubadge', amount: 100n }]
+      }
+    ]
+    // no votingChallenges
+  }
+});
+
+const makeValidCollection = (): any => ({
+  standards: ['Bounty'],
+  validTokenIds: [{ start: 1n, end: 1n }],
+  collectionApprovals: [makeAcceptApproval(), makeDenyApproval(), makeExpireApproval()],
+  collectionPermissions: {}
+});
+
+const clone = (obj: any) =>
+  JSON.parse(JSON.stringify(obj, (_k, v) => (typeof v === 'bigint' ? v.toString() + 'n' : v)), (_k, v) => {
+    if (typeof v === 'string' && /^\d+n$/.test(v)) return BigInt(v.slice(0, -1));
+    return v;
+  });
+
+// ---- tests ---------------------------------------------------------------
+
+describe('validateBountyCollection — happy path', () => {
+  it('accepts a minimal valid bounty collection', () => {
+    const result = validateBountyCollection(makeValidCollection());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('doesCollectionFollowBountyProtocol returns true for a valid collection', () => {
+    expect(doesCollectionFollowBountyProtocol(makeValidCollection())).toBe(true);
+  });
+});
+
+describe('validateBountyCollection — standards check', () => {
+  it('rejects when "Bounty" standard is missing', () => {
+    const c = clone(makeValidCollection());
+    c.standards = ['Other'];
+    const r = validateBountyCollection(c);
+    expect(r.valid).toBe(false);
+    expect(r.errors).toContain('Missing "Bounty" standard');
+  });
+
+  it('rejects when standards is undefined', () => {
+    const c = clone(makeValidCollection());
+    c.standards = undefined;
+    const r = validateBountyCollection(c);
+    expect(r.valid).toBe(false);
+    expect(r.errors).toContain('Missing "Bounty" standard');
+  });
+
+  it('accepts multi-standard collection that includes "Bounty"', () => {
+    const c = makeValidCollection();
+    c.standards = ['Other', 'Bounty', 'Extra'];
+    const r = validateBountyCollection(c);
+    expect(r.errors).toEqual([]);
+    expect(r.valid).toBe(true);
+  });
+});
+
+describe('validateBountyCollection — validTokenIds', () => {
+  it('rejects validTokenIds != [{1,1}] (wrong range)', () => {
+    const c = clone(makeValidCollection());
+    c.validTokenIds = [{ start: 1n, end: 2n }];
+    const r = validateBountyCollection(c);
+    expect(r.errors).toContain('validTokenIds must be exactly [{start: 1, end: 1}]');
+  });
+
+  it('rejects empty validTokenIds', () => {
+    const c = clone(makeValidCollection());
+    c.validTokenIds = [];
+    expect(validateBountyCollection(c).errors).toContain('validTokenIds must be exactly [{start: 1, end: 1}]');
+  });
+
+  it('rejects multiple validTokenIds ranges', () => {
+    const c = clone(makeValidCollection());
+    c.validTokenIds = [
+      { start: 1n, end: 1n },
+      { start: 2n, end: 2n }
+    ];
+    expect(validateBountyCollection(c).errors).toContain('validTokenIds must be exactly [{start: 1, end: 1}]');
+  });
+
+  it('rejects start != 1', () => {
+    const c = clone(makeValidCollection());
+    c.validTokenIds = [{ start: 2n, end: 2n }];
+    expect(validateBountyCollection(c).errors).toContain('validTokenIds must be exactly [{start: 1, end: 1}]');
+  });
+});
+
+describe('validateBountyCollection — approval count', () => {
+  it('rejects when fewer than 3 approvals', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals = [makeAcceptApproval(), makeDenyApproval()];
+    const r = validateBountyCollection(c);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e: string) => e.includes('Expected exactly 3 approvals'))).toBe(true);
+  });
+
+  it('rejects when more than 3 approvals', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals = [
+      makeAcceptApproval(),
+      makeDenyApproval(),
+      makeExpireApproval(),
+      makeExpireApproval()
+    ];
+    expect(validateBountyCollection(c).errors.some((e: string) => e.includes('found 4'))).toBe(true);
+  });
+
+  it('short-circuits on wrong count — no per-approval errors run', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals = [];
+    const r = validateBountyCollection(c);
+    // Only the count error is expected (plus possibly standards if applicable)
+    expect(r.errors.filter((e: string) => e.includes('Approval'))).toEqual([]);
+  });
+});
+
+describe('validateBountyCollection — fromListId / toListId', () => {
+  it('rejects approval with fromListId != "Mint"', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[0].fromListId = '!Mint';
+    const r = validateBountyCollection(c);
+    expect(r.errors.some((e: string) => e.includes('fromListId must be "Mint"'))).toBe(true);
+  });
+
+  it('rejects approval whose toListId is not the burn address', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[0].toListId = 'bb1someaddr';
+    const r = validateBountyCollection(c);
+    expect(r.errors.some((e: string) => e.includes('toListId must be burn address'))).toBe(true);
+  });
+});
+
+describe('validateBountyCollection — maxNumTransfers', () => {
+  it('rejects when overallMaxNumTransfers is not 1', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[0].approvalCriteria.maxNumTransfers.overallMaxNumTransfers = 2n;
+    const r = validateBountyCollection(c);
+    expect(r.errors.some((e: string) => e.includes('overallMaxNumTransfers must be 1'))).toBe(true);
+  });
+
+  it('rejects when maxNumTransfers is missing entirely', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[0].approvalCriteria.maxNumTransfers = undefined;
+    expect(validateBountyCollection(c).errors.some((e: string) => e.includes('overallMaxNumTransfers must be 1'))).toBe(true);
+  });
+});
+
+describe('validateBountyCollection — override flags', () => {
+  it('rejects when overridesFromOutgoingApprovals is false', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[0].approvalCriteria.overridesFromOutgoingApprovals = false;
+    expect(
+      validateBountyCollection(c).errors.some((e: string) => e.includes('overridesFromOutgoingApprovals must be true'))
+    ).toBe(true);
+  });
+
+  it('rejects when overridesToIncomingApprovals is false', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[0].approvalCriteria.overridesToIncomingApprovals = false;
+    expect(
+      validateBountyCollection(c).errors.some((e: string) => e.includes('overridesToIncomingApprovals must be true'))
+    ).toBe(true);
+  });
+});
+
+describe('validateBountyCollection — coinTransfers', () => {
+  it('rejects when coinTransfers length != 1', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[0].approvalCriteria.coinTransfers = [];
+    const r = validateBountyCollection(c);
+    expect(r.errors.some((e: string) => e.includes('must have exactly 1 coinTransfer'))).toBe(true);
+  });
+
+  it('rejects when coinTransfer.overrideFromWithApproverAddress is false', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[0].approvalCriteria.coinTransfers[0].overrideFromWithApproverAddress = false;
+    expect(
+      validateBountyCollection(c).errors.some((e: string) =>
+        e.includes('coinTransfer must have overrideFromWithApproverAddress=true')
+      )
+    ).toBe(true);
+  });
+
+  it('rejects when denoms do not match across approvals', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[0].approvalCriteria.coinTransfers[0].coins[0].denom = 'uusdc';
+    expect(validateBountyCollection(c).errors).toContain('All approvals must use the same coin denom');
+  });
+
+  it('rejects when amounts do not match across approvals', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[0].approvalCriteria.coinTransfers[0].coins[0].amount = 999n;
+    expect(validateBountyCollection(c).errors).toContain('All approvals must transfer the same amount');
+  });
+});
+
+describe('validateBountyCollection — voting structure', () => {
+  it('rejects when 3 approvals have voting (expected 2)', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[2].approvalCriteria.votingChallenges = [
+      { voters: [{ address: VERIFIER }] }
+    ];
+    expect(validateBountyCollection(c).errors.some((e: string) => e.includes('Expected 2 approvals with votingChallenges'))).toBe(true);
+  });
+
+  it('rejects when only 1 approval has voting', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[1].approvalCriteria.votingChallenges = [];
+    const r = validateBountyCollection(c);
+    expect(r.errors.some((e: string) => e.includes('Expected 2 approvals with votingChallenges'))).toBe(true);
+    expect(r.errors.some((e: string) => e.includes('Expected 1 approval without votingChallenges'))).toBe(true);
+  });
+
+  it('rejects when accept and deny have different verifier addresses', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[1].approvalCriteria.votingChallenges[0].voters[0].address = 'bb1differentverifier';
+    expect(validateBountyCollection(c).errors).toContain('Accept and deny must have the same verifier address');
+  });
+
+  it('rejects when accept and deny pay to the same address', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[1].approvalCriteria.coinTransfers[0].to = 'bb1recipient'; // match accept payout
+    expect(
+      validateBountyCollection(c).errors
+    ).toContain('Accept and deny must pay out to different addresses (recipient vs submitter)');
+  });
+
+  it('rejects when accept and deny expirations differ', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[1].transferTimes = [{ start: 1n, end: 999n }];
+    expect(validateBountyCollection(c).errors).toContain('Accept and deny must have the same expiration time');
+  });
+});
+
+describe('validateBountyCollection — expire path timing', () => {
+  it('rejects when expire starts before or at voting end', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[2].transferTimes = [{ start: 1000n, end: 2000n }]; // equal to voting end
+    expect(validateBountyCollection(c).errors).toContain('Expire approval must start after accept/deny expiration');
+  });
+
+  it('rejects when expire starts strictly before voting end', () => {
+    const c = clone(makeValidCollection());
+    c.collectionApprovals[2].transferTimes = [{ start: 500n, end: 1500n }];
+    expect(validateBountyCollection(c).errors).toContain('Expire approval must start after accept/deny expiration');
+  });
+});
+
+describe('doesCollectionFollowBountyProtocol', () => {
+  it('returns false for an invalid collection', () => {
+    const c = clone(makeValidCollection());
+    c.standards = [];
+    expect(doesCollectionFollowBountyProtocol(c)).toBe(false);
+  });
+
+  it('returns true for a valid collection', () => {
+    expect(doesCollectionFollowBountyProtocol(makeValidCollection())).toBe(true);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/core/crowdfunds.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/crowdfunds.spec.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests for crowdfunds.ts — Crowdfund protocol validator.
+ *
+ * A valid Crowdfund needs:
+ *   - standards includes "Crowdfund"
+ *   - validTokenIds = [{1,2}] (refund + progress tokens)
+ *   - 4+ approvals: deposit-refund (Mint->All, token 1),
+ *                   deposit-progress (Mint->crowdfunder, token 2),
+ *                   success (Mint->burn, mustOwnTokens),
+ *                   refund (!Mint->burn, token 1, mustOwnTokens)
+ *   - Deposit paths use allowAmountScaling + overridesFromOutgoing
+ *   - Success/refund use overrideFromWithApproverAddress
+ *   - Same denom across all coinTransfers
+ */
+
+import { validateCrowdfundCollection, doesCollectionFollowCrowdfundProtocol } from './crowdfunds.js';
+
+const BURN = 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv';
+const CROWDFUNDER = 'bb1crowdfunder';
+
+const makeDepositRefund = () => ({
+  approvalId: 'deposit-refund',
+  fromListId: 'Mint',
+  toListId: 'All',
+  initiatedByListId: 'All',
+  transferTimes: [{ start: 1n, end: 1000n }],
+  tokenIds: [{ start: 1n, end: 1n }],
+  approvalCriteria: {
+    overridesFromOutgoingApprovals: true,
+    requireToEqualsInitiatedBy: true,
+    coinTransfers: [{ coins: [{ denom: 'ubadge', amount: 100n }] }],
+    predeterminedBalances: {
+      incrementedBalances: {
+        allowAmountScaling: true
+      }
+    }
+  }
+});
+
+const makeDepositProgress = () => ({
+  approvalId: 'deposit-progress',
+  fromListId: 'Mint',
+  toListId: CROWDFUNDER,
+  initiatedByListId: 'All',
+  transferTimes: [{ start: 1n, end: 1000n }],
+  tokenIds: [{ start: 2n, end: 2n }],
+  approvalCriteria: {
+    overridesFromOutgoingApprovals: true,
+    coinTransfers: [{ coins: [{ denom: 'ubadge', amount: 100n }] }],
+    predeterminedBalances: {
+      incrementedBalances: {
+        allowAmountScaling: true
+      }
+    }
+  }
+});
+
+const makeSuccess = () => ({
+  approvalId: 'success',
+  fromListId: 'Mint',
+  toListId: BURN,
+  initiatedByListId: CROWDFUNDER,
+  transferTimes: [{ start: 1001n, end: 2000n }],
+  tokenIds: [{ start: 2n, end: 2n }],
+  approvalCriteria: {
+    coinTransfers: [
+      {
+        overrideFromWithApproverAddress: true,
+        coins: [{ denom: 'ubadge', amount: 1000n }]
+      }
+    ],
+    mustOwnTokens: [
+      {
+        tokenIds: [{ start: 2n, end: 2n }],
+        amountRange: { start: 100n, end: 100n }
+      }
+    ]
+  }
+});
+
+const makeRefund = () => ({
+  approvalId: 'refund',
+  fromListId: '!Mint',
+  toListId: BURN,
+  initiatedByListId: 'All',
+  transferTimes: [{ start: 2001n, end: 3000n }],
+  tokenIds: [{ start: 1n, end: 1n }],
+  approvalCriteria: {
+    coinTransfers: [
+      {
+        overrideFromWithApproverAddress: true,
+        overrideToWithInitiator: true,
+        coins: [{ denom: 'ubadge', amount: 1n }]
+      }
+    ],
+    mustOwnTokens: [
+      {
+        tokenIds: [{ start: 2n, end: 2n }],
+        amountRange: { start: 1n, end: 100n }
+      }
+    ]
+  }
+});
+
+const makeValidCollection = (): any => ({
+  standards: ['Crowdfund'],
+  validTokenIds: [{ start: 1n, end: 2n }],
+  collectionApprovals: [makeDepositRefund(), makeDepositProgress(), makeSuccess(), makeRefund()],
+  collectionPermissions: {
+    canDeleteCollection: [{}],
+    canUpdateCollectionApprovals: [{}],
+    canUpdateValidTokenIds: [{}],
+    canUpdateStandards: [{}]
+  }
+});
+
+describe('validateCrowdfundCollection — happy path', () => {
+  it('accepts a fully-formed crowdfund', () => {
+    const r = validateCrowdfundCollection(makeValidCollection());
+    expect(r.errors).toEqual([]);
+    expect(r.valid).toBe(true);
+    expect(r.details?.crowdfunderAddress).toBe(CROWDFUNDER);
+    expect(r.details?.depositDenom).toBe('ubadge');
+    expect(r.details?.deadlineTime).toBe(1000n);
+    expect(r.details?.goalAmount).toBe(100n);
+  });
+
+  it('doesCollectionFollowCrowdfundProtocol returns true', () => {
+    expect(doesCollectionFollowCrowdfundProtocol(makeValidCollection())).toBe(true);
+  });
+});
+
+describe('validateCrowdfundCollection — standards', () => {
+  it('rejects missing Crowdfund standard', () => {
+    const c = makeValidCollection();
+    c.standards = [];
+    expect(validateCrowdfundCollection(c).errors).toContain('Missing "Crowdfund" standard');
+  });
+});
+
+describe('validateCrowdfundCollection — validTokenIds', () => {
+  it('rejects [{1,1}] (missing progress token 2)', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [{ start: 1n, end: 1n }];
+    expect(validateCrowdfundCollection(c).errors).toContain(
+      'validTokenIds must be [{start: 1, end: 2}] (refund + progress tokens)'
+    );
+  });
+
+  it('rejects wrong start', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [{ start: 0n, end: 2n }];
+    expect(validateCrowdfundCollection(c).errors).toContain(
+      'validTokenIds must be [{start: 1, end: 2}] (refund + progress tokens)'
+    );
+  });
+
+  it('rejects empty validTokenIds', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [];
+    expect(validateCrowdfundCollection(c).errors).toContain(
+      'validTokenIds must be [{start: 1, end: 2}] (refund + progress tokens)'
+    );
+  });
+});
+
+describe('validateCrowdfundCollection — permissions warnings', () => {
+  it('warns when canDeleteCollection is empty (not frozen)', () => {
+    const c = makeValidCollection();
+    c.collectionPermissions.canDeleteCollection = [];
+    const r = validateCrowdfundCollection(c);
+    expect(r.warnings.some((w) => w.includes('canDeleteCollection'))).toBe(true);
+  });
+
+  it('warns for all 4 permission fields when missing', () => {
+    const c = makeValidCollection();
+    c.collectionPermissions = {};
+    const r = validateCrowdfundCollection(c);
+    expect(r.warnings.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe('validateCrowdfundCollection — approval count', () => {
+  it('rejects when fewer than 4 approvals', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = [makeDepositRefund()];
+    const r = validateCrowdfundCollection(c);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes('Expected at least 4 approvals'))).toBe(true);
+  });
+});
+
+describe('validateCrowdfundCollection — missing approval types', () => {
+  it('rejects when deposit-refund missing', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = [makeDepositProgress(), makeSuccess(), makeRefund(), makeRefund()];
+    const r = validateCrowdfundCollection(c);
+    expect(r.errors.some((e) => e.includes('Missing deposit-refund approval'))).toBe(true);
+  });
+
+  it('rejects when deposit-progress missing', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = [makeDepositRefund(), makeSuccess(), makeRefund(), makeRefund()];
+    const r = validateCrowdfundCollection(c);
+    expect(r.errors.some((e) => e.includes('Missing deposit-progress approval'))).toBe(true);
+  });
+
+  it('rejects when success approval missing (no mustOwnTokens)', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[2].approvalCriteria.mustOwnTokens = [];
+    const r = validateCrowdfundCollection(c);
+    expect(r.errors.some((e) => e.includes('Missing success approval'))).toBe(true);
+  });
+
+  it('rejects when refund missing', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[3].approvalCriteria.mustOwnTokens = [];
+    const r = validateCrowdfundCollection(c);
+    expect(r.errors.some((e) => e.includes('Missing refund approval'))).toBe(true);
+  });
+});
+
+describe('validateCrowdfundCollection — deposit-refund rules', () => {
+  it('rejects when overridesFromOutgoingApprovals false', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.overridesFromOutgoingApprovals = false;
+    expect(
+      validateCrowdfundCollection(c).errors
+    ).toContain('Deposit-refund: overridesFromOutgoingApprovals must be true');
+  });
+
+  it('rejects when requireToEqualsInitiatedBy false', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.requireToEqualsInitiatedBy = false;
+    expect(
+      validateCrowdfundCollection(c).errors
+    ).toContain('Deposit-refund: requireToEqualsInitiatedBy must be true');
+  });
+
+  it('rejects when allowAmountScaling false', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.predeterminedBalances.incrementedBalances.allowAmountScaling = false;
+    expect(validateCrowdfundCollection(c).errors).toContain('Deposit-refund: allowAmountScaling must be true');
+  });
+
+  it('rejects when coinTransfers is missing on deposit-refund', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.coinTransfers = [];
+    expect(validateCrowdfundCollection(c).errors).toContain('Deposit-refund: must have coinTransfers');
+  });
+});
+
+describe('validateCrowdfundCollection — deposit-progress rules', () => {
+  it('rejects when overridesFromOutgoingApprovals false', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[1].approvalCriteria.overridesFromOutgoingApprovals = false;
+    expect(
+      validateCrowdfundCollection(c).errors
+    ).toContain('Deposit-progress: overridesFromOutgoingApprovals must be true');
+  });
+
+  it('rejects when allowAmountScaling false', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[1].approvalCriteria.predeterminedBalances.incrementedBalances.allowAmountScaling = false;
+    expect(validateCrowdfundCollection(c).errors).toContain('Deposit-progress: allowAmountScaling must be true');
+  });
+});
+
+describe('validateCrowdfundCollection — success rules', () => {
+  it('rejects when initiatedByListId does not match crowdfunder', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[2].initiatedByListId = 'bb1someoneelse';
+    expect(validateCrowdfundCollection(c).errors).toContain('Success: initiatedByListId must be crowdfunder address');
+  });
+
+  it('rejects when overrideFromWithApproverAddress=false on success', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[2].approvalCriteria.coinTransfers[0].overrideFromWithApproverAddress = false;
+    expect(
+      validateCrowdfundCollection(c).errors
+    ).toContain('Success: coinTransfer must use overrideFromWithApproverAddress=true (escrow payout)');
+  });
+
+  it('rejects when mustOwnTokens checks token != 2', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[2].approvalCriteria.mustOwnTokens[0].tokenIds = [{ start: 1n, end: 1n }];
+    expect(validateCrowdfundCollection(c).errors).toContain(
+      'Success: mustOwnTokens must check token 2 (progress token)'
+    );
+  });
+
+  it('rejects when goal amount is 0', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[2].approvalCriteria.mustOwnTokens[0].amountRange.start = 0n;
+    expect(
+      validateCrowdfundCollection(c).errors
+    ).toContain('Success: mustOwnTokens amountRange.start must be > 0 (goal amount)');
+  });
+});
+
+describe('validateCrowdfundCollection — refund rules', () => {
+  it('rejects when overrideFromWithApproverAddress=false on refund', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[3].approvalCriteria.coinTransfers[0].overrideFromWithApproverAddress = false;
+    expect(
+      validateCrowdfundCollection(c).errors
+    ).toContain('Refund: coinTransfer must use overrideFromWithApproverAddress=true');
+  });
+
+  it('rejects when overrideToWithInitiator=false on refund', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[3].approvalCriteria.coinTransfers[0].overrideToWithInitiator = false;
+    expect(
+      validateCrowdfundCollection(c).errors
+    ).toContain('Refund: coinTransfer must use overrideToWithInitiator=true (pay back contributor)');
+  });
+
+  it('rejects refund.mustOwnTokens checking wrong token', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[3].approvalCriteria.mustOwnTokens[0].tokenIds = [{ start: 1n, end: 1n }];
+    expect(validateCrowdfundCollection(c).errors).toContain(
+      'Refund: mustOwnTokens must check token 2 (progress token)'
+    );
+  });
+});
+
+describe('validateCrowdfundCollection — denom cross-check', () => {
+  it('rejects when success denom differs from deposit denom', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[2].approvalCriteria.coinTransfers[0].coins[0].denom = 'uusdc';
+    expect(validateCrowdfundCollection(c).errors).toContain('Success denom must match deposit denom');
+  });
+
+  it('rejects when refund denom differs from deposit denom', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[3].approvalCriteria.coinTransfers[0].coins[0].denom = 'uusdc';
+    expect(validateCrowdfundCollection(c).errors).toContain('Refund denom must match deposit denom');
+  });
+
+  it('accepts when all three denoms match', () => {
+    expect(validateCrowdfundCollection(makeValidCollection()).valid).toBe(true);
+  });
+});
+
+describe('validateCrowdfundCollection — details output', () => {
+  it('populates details when valid', () => {
+    const r = validateCrowdfundCollection(makeValidCollection());
+    expect(r.details).toBeDefined();
+    expect(r.details?.crowdfunderAddress).toBe(CROWDFUNDER);
+    expect(r.details?.depositDenom).toBe('ubadge');
+    expect(r.details?.deadlineTime).toBe(1000n);
+    expect(r.details?.goalAmount).toBe(100n);
+  });
+
+  it('returns empty details when approvals missing (early-return path)', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = c.collectionApprovals.slice(0, 2);
+    const r = validateCrowdfundCollection(c);
+    expect(r.valid).toBe(false);
+    expect(r.details).toEqual({});
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/core/invoices.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/invoices.spec.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for invoices.ts — Invoice protocol shape checks.
+ *
+ * Covers:
+ *   - doesCollectionFollowInvoiceProtocol
+ *   - isInvoiceApproval
+ *
+ * Invoices are payments from an initiator to a fixed recipient — the
+ * opposite coinTransfer direction from Quests. overrideFromWithApproverAddress
+ * and overrideToWithInitiator MUST BE false because the payer is the
+ * initiator and the recipient is the approval's target address.
+ */
+
+import {
+  doesCollectionFollowInvoiceProtocol,
+  isInvoiceApproval
+} from './invoices.js';
+
+// ---------------------------------------------------------------------------
+// doesCollectionFollowInvoiceProtocol
+// ---------------------------------------------------------------------------
+
+describe('doesCollectionFollowInvoiceProtocol', () => {
+  it('returns false if "Invoices" standard missing', () => {
+    expect(
+      doesCollectionFollowInvoiceProtocol({ standards: [], validTokenIds: [{ start: 1n, end: 1n }] } as any)
+    ).toBe(false);
+  });
+
+  it('returns true for Invoices + [{1,1}]', () => {
+    expect(
+      doesCollectionFollowInvoiceProtocol({
+        standards: ['Invoices'],
+        validTokenIds: [{ start: 1n, end: 1n }]
+      } as any)
+    ).toBe(true);
+  });
+
+  it('rejects when validTokenIds != [{1,1}]', () => {
+    expect(
+      doesCollectionFollowInvoiceProtocol({
+        standards: ['Invoices'],
+        validTokenIds: [{ start: 1n, end: 2n }]
+      } as any)
+    ).toBe(false);
+    expect(
+      doesCollectionFollowInvoiceProtocol({ standards: ['Invoices'], validTokenIds: [] } as any)
+    ).toBe(false);
+    expect(
+      doesCollectionFollowInvoiceProtocol({
+        standards: ['Invoices'],
+        validTokenIds: [
+          { start: 1n, end: 1n },
+          { start: 2n, end: 2n }
+        ]
+      } as any)
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isInvoiceApproval
+// ---------------------------------------------------------------------------
+
+const makeValidInvoiceApproval = (): any => ({
+  fromListId: 'Mint',
+  approvalCriteria: {
+    maxNumTransfers: { overallMaxNumTransfers: 10n },
+    coinTransfers: [
+      {
+        // Invoices send INITIATOR -> RECIPIENT. No override.
+        overrideFromWithApproverAddress: false,
+        overrideToWithInitiator: false,
+        coins: [{ denom: 'ubadge', amount: 1000n }]
+      }
+    ],
+    predeterminedBalances: {
+      incrementedBalances: {
+        startBalances: [{ tokenIds: [{ start: 1n, end: 1n }], amount: 1n }],
+        incrementTokenIdsBy: 0n,
+        incrementOwnershipTimesBy: 0n,
+        durationFromTimestamp: 0n,
+        allowOverrideTimestamp: false,
+        allowAmountScaling: false,
+        recurringOwnershipTimes: {
+          startTime: 0n,
+          intervalLength: 0n,
+          chargePeriodLength: 0n
+        }
+      }
+    },
+    requireToEqualsInitiatedBy: false
+  }
+});
+
+describe('isInvoiceApproval — happy path', () => {
+  it('accepts a canonical invoice approval', () => {
+    expect(isInvoiceApproval(makeValidInvoiceApproval())).toBe(true);
+  });
+
+  it('accepts invoice with no merkleChallenges', () => {
+    // merkleChallenges is optional for invoices
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.merkleChallenges = undefined;
+    expect(isInvoiceApproval(a)).toBe(true);
+  });
+
+  it('accepts invoice WITH one valid merkleChallenge', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.merkleChallenges = [{ maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: false }];
+    expect(isInvoiceApproval(a)).toBe(true);
+  });
+
+  it('accepts invoice with zero coinTransfers (optional)', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.coinTransfers = [];
+    expect(isInvoiceApproval(a)).toBe(true);
+  });
+});
+
+describe('isInvoiceApproval — core rejections', () => {
+  it('rejects when approvalCriteria is missing', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria = undefined;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when fromListId != "Mint"', () => {
+    const a = makeValidInvoiceApproval();
+    a.fromListId = 'bb1anything';
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when overallMaxNumTransfers is 0 or missing', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.maxNumTransfers.overallMaxNumTransfers = 0n;
+    expect(isInvoiceApproval(a)).toBe(false);
+
+    const b = makeValidInvoiceApproval();
+    b.approvalCriteria.maxNumTransfers = undefined;
+    expect(isInvoiceApproval(b)).toBe(false);
+  });
+
+  it('accepts any positive overallMaxNumTransfers (no upper bound enforced)', () => {
+    // Note invoices allow any positive n — unlike scheduled-payments which is 1-only
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.maxNumTransfers.overallMaxNumTransfers = 1n;
+    expect(isInvoiceApproval(a)).toBe(true);
+
+    a.approvalCriteria.maxNumTransfers.overallMaxNumTransfers = 9999n;
+    expect(isInvoiceApproval(a)).toBe(true);
+  });
+});
+
+describe('isInvoiceApproval — merkleChallenges', () => {
+  it('rejects when there are >1 merkleChallenges', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.merkleChallenges = [
+      { maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: false },
+      { maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: false }
+    ];
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when maxUsesPerLeaf is not 1', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.merkleChallenges = [{ maxUsesPerLeaf: 5n, useCreatorAddressAsLeaf: false }];
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when useCreatorAddressAsLeaf=true', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.merkleChallenges = [{ maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: true }];
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+});
+
+describe('isInvoiceApproval — coinTransfers direction', () => {
+  it('rejects when there are more than 1 coinTransfers', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.coinTransfers = [
+      { overrideFromWithApproverAddress: false, overrideToWithInitiator: false, coins: [{ denom: 'u', amount: 1n }] },
+      { overrideFromWithApproverAddress: false, overrideToWithInitiator: false, coins: [{ denom: 'u', amount: 1n }] }
+    ];
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when coinTransfer.coins.length != 1', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.coinTransfers[0].coins = [
+      { denom: 'ubadge', amount: 1n },
+      { denom: 'uusdc', amount: 1n }
+    ];
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects overrideFromWithApproverAddress=true (invoice direction is initiator→addr)', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.coinTransfers[0].overrideFromWithApproverAddress = true;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects overrideToWithInitiator=true (invoice direction is initiator→addr)', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.coinTransfers[0].overrideToWithInitiator = true;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+});
+
+describe('isInvoiceApproval — incrementedBalances shape', () => {
+  it('rejects when incrementedBalances is missing', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances = { incrementedBalances: undefined };
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalances.length != 1', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances = [];
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalance tokenIds != [{1,1}]', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].tokenIds = [
+      { start: 2n, end: 2n }
+    ];
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalance tokenIds span more than 1', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].tokenIds = [
+      { start: 1n, end: 5n }
+    ];
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalance amount != 1', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].amount = 2n;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when incrementTokenIdsBy != 0', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementTokenIdsBy = 1n;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when incrementOwnershipTimesBy != 0', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementOwnershipTimesBy = 1n;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when durationFromTimestamp != 0', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.durationFromTimestamp = 1n;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when allowOverrideTimestamp=true', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.allowOverrideTimestamp = true;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when allowAmountScaling=true (invoice amounts are fixed)', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.allowAmountScaling = true;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when recurringOwnershipTimes.startTime != 0', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.startTime = 1n;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when recurringOwnershipTimes.intervalLength != 0', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.intervalLength = 1n;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+
+  it('rejects when recurringOwnershipTimes.chargePeriodLength != 0', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.chargePeriodLength = 1n;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+});
+
+describe('isInvoiceApproval — misc', () => {
+  it('rejects when requireToEqualsInitiatedBy=true', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.requireToEqualsInitiatedBy = true;
+    expect(isInvoiceApproval(a)).toBe(false);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/core/quests.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/quests.spec.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for quests.ts — Quest protocol shape checks.
+ *
+ * Covers:
+ *   - doesCollectionFollowProtocol (generic "standard exists" check)
+ *   - doesCollectionFollowQuestProtocol (Quest standard + [{1,1}] tokens)
+ *   - isQuestApproval (per-approval shape check)
+ */
+
+import {
+  doesCollectionFollowProtocol,
+  doesCollectionFollowQuestProtocol,
+  isQuestApproval
+} from './quests.js';
+
+// ---------------------------------------------------------------------------
+// doesCollectionFollowProtocol
+// ---------------------------------------------------------------------------
+
+describe('doesCollectionFollowProtocol', () => {
+  it('returns false for null / undefined collection', () => {
+    expect(doesCollectionFollowProtocol(null as any, 'Quests')).toBe(false);
+    expect(doesCollectionFollowProtocol(undefined as any, 'Quests')).toBe(false);
+  });
+
+  it('returns false when standards does not include the protocol', () => {
+    expect(doesCollectionFollowProtocol({ standards: [] } as any, 'Quests')).toBe(false);
+    expect(doesCollectionFollowProtocol({ standards: ['Other'] } as any, 'Quests')).toBe(false);
+  });
+
+  it('returns true when standards includes the protocol exactly', () => {
+    expect(doesCollectionFollowProtocol({ standards: ['Quests'] } as any, 'Quests')).toBe(true);
+  });
+
+  it('is case-sensitive', () => {
+    expect(doesCollectionFollowProtocol({ standards: ['quests'] } as any, 'Quests')).toBe(false);
+    expect(doesCollectionFollowProtocol({ standards: ['QUESTS'] } as any, 'Quests')).toBe(false);
+  });
+
+  it('accepts multi-standard collection', () => {
+    expect(doesCollectionFollowProtocol({ standards: ['Other', 'Quests', 'Extra'] } as any, 'Quests')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// doesCollectionFollowQuestProtocol
+// ---------------------------------------------------------------------------
+
+describe('doesCollectionFollowQuestProtocol', () => {
+  it('returns false if standard missing', () => {
+    expect(
+      doesCollectionFollowQuestProtocol({ standards: [], validTokenIds: [{ start: 1n, end: 1n }] } as any)
+    ).toBe(false);
+  });
+
+  it('returns true when standard=Quests and validTokenIds=[{1,1}]', () => {
+    expect(
+      doesCollectionFollowQuestProtocol({ standards: ['Quests'], validTokenIds: [{ start: 1n, end: 1n }] } as any)
+    ).toBe(true);
+  });
+
+  it('returns false when validTokenIds has more than 1 range', () => {
+    expect(
+      doesCollectionFollowQuestProtocol({
+        standards: ['Quests'],
+        validTokenIds: [
+          { start: 1n, end: 1n },
+          { start: 3n, end: 3n }
+        ]
+      } as any)
+    ).toBe(false);
+  });
+
+  it('returns false when validTokenIds spans more than 1 token', () => {
+    expect(
+      doesCollectionFollowQuestProtocol({ standards: ['Quests'], validTokenIds: [{ start: 1n, end: 2n }] } as any)
+    ).toBe(false);
+  });
+
+  it('returns false when validTokenIds is not [1..1]', () => {
+    expect(
+      doesCollectionFollowQuestProtocol({ standards: ['Quests'], validTokenIds: [{ start: 2n, end: 2n }] } as any)
+    ).toBe(false);
+  });
+
+  it('returns false when validTokenIds is empty', () => {
+    expect(doesCollectionFollowQuestProtocol({ standards: ['Quests'], validTokenIds: [] } as any)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isQuestApproval
+// ---------------------------------------------------------------------------
+
+const makeValidQuestApproval = (): any => ({
+  fromListId: 'Mint',
+  approvalCriteria: {
+    merkleChallenges: [{ maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: false }],
+    maxNumTransfers: { overallMaxNumTransfers: 100n },
+    coinTransfers: [
+      {
+        overrideFromWithApproverAddress: true,
+        overrideToWithInitiator: true,
+        coins: [{ denom: 'ubadge', amount: 1n }]
+      }
+    ],
+    predeterminedBalances: {
+      incrementedBalances: {
+        startBalances: [{ tokenIds: [{ start: 1n, end: 1n }], amount: 1n }],
+        incrementTokenIdsBy: 0n,
+        incrementOwnershipTimesBy: 0n,
+        durationFromTimestamp: 0n,
+        allowOverrideTimestamp: false,
+        allowAmountScaling: false,
+        recurringOwnershipTimes: {
+          startTime: 0n,
+          intervalLength: 0n,
+          chargePeriodLength: 0n
+        }
+      }
+    },
+    requireToEqualsInitiatedBy: false
+  }
+});
+
+describe('isQuestApproval — happy path', () => {
+  it('accepts a canonical quest approval', () => {
+    expect(isQuestApproval(makeValidQuestApproval())).toBe(true);
+  });
+
+  it('accepts approval with zero coinTransfers', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.coinTransfers = [];
+    expect(isQuestApproval(a)).toBe(true);
+  });
+});
+
+describe('isQuestApproval — rejections', () => {
+  it('rejects when approvalCriteria is missing', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria = undefined;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when fromListId is not "Mint"', () => {
+    const a = makeValidQuestApproval();
+    a.fromListId = '!Mint';
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when merkleChallenges is missing', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.merkleChallenges = undefined;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when merkleChallenges.length != 1', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.merkleChallenges = [
+      { maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: false },
+      { maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: false }
+    ];
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when maxUsesPerLeaf is not 1', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.merkleChallenges[0].maxUsesPerLeaf = 2n;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when useCreatorAddressAsLeaf is true', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.merkleChallenges[0].useCreatorAddressAsLeaf = true;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when mustOwnTokens is non-empty', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.mustOwnTokens = [{}];
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when overallMaxNumTransfers is 0 or missing', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.maxNumTransfers.overallMaxNumTransfers = 0n;
+    expect(isQuestApproval(a)).toBe(false);
+
+    const b = makeValidQuestApproval();
+    b.approvalCriteria.maxNumTransfers = undefined;
+    expect(isQuestApproval(b)).toBe(false);
+  });
+
+  it('rejects when overallMaxNumTransfers < 0 (defensive)', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.maxNumTransfers.overallMaxNumTransfers = -1n;
+    // -1n passes `!n` but hits `n <= 0n`
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when there are more than 1 coinTransfers', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.coinTransfers = [
+      { overrideFromWithApproverAddress: true, overrideToWithInitiator: true, coins: [{ denom: 'u', amount: 1n }] },
+      { overrideFromWithApproverAddress: true, overrideToWithInitiator: true, coins: [{ denom: 'u', amount: 1n }] }
+    ];
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when coinTransfer.coins.length != 1', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.coinTransfers[0].coins = [
+      { denom: 'ubadge', amount: 1n },
+      { denom: 'uusdc', amount: 1n }
+    ];
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when overrideFromWithApproverAddress=false', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.coinTransfers[0].overrideFromWithApproverAddress = false;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when overrideToWithInitiator=false', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.coinTransfers[0].overrideToWithInitiator = false;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when incrementedBalances is missing', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances = { incrementedBalances: undefined };
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalances.length != 1', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances = [];
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalance tokenIds span more than 1', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].tokenIds = [
+      { start: 1n, end: 2n }
+    ];
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalance tokenIds != [{1,1}]', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].tokenIds = [
+      { start: 2n, end: 2n }
+    ];
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalance amount != 1', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].amount = 2n;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when incrementTokenIdsBy != 0', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementTokenIdsBy = 1n;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when incrementOwnershipTimesBy != 0', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementOwnershipTimesBy = 1n;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when durationFromTimestamp != 0', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.durationFromTimestamp = 1n;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when allowOverrideTimestamp is true', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.allowOverrideTimestamp = true;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when allowAmountScaling is true (incompatible with quests)', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.allowAmountScaling = true;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when recurringOwnershipTimes.startTime != 0', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.startTime = 1n;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when recurringOwnershipTimes.intervalLength != 0', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.intervalLength = 1n;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when recurringOwnershipTimes.chargePeriodLength != 0', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.chargePeriodLength = 1n;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+
+  it('rejects when requireToEqualsInitiatedBy is true', () => {
+    const a = makeValidQuestApproval();
+    a.approvalCriteria.requireToEqualsInitiatedBy = true;
+    expect(isQuestApproval(a)).toBe(false);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/core/review-normalize.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/review-normalize.spec.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for review-normalize.ts — the normalization pipeline used by every
+ * review consumer (auditCollection, verifyStandardsCompliance). Covers:
+ *
+ *   extractCollectionValue — unwrap tx ({messages:[...]}) / msg ({typeUrl, value})
+ *                            / array / bare collection.
+ *   normalizeForReview    — run the MsgUniversalUpdateCollection + BigIntify
+ *                            conversion, mirror aliasPaths fields, and
+ *                            reattach WithDetails inline metadata that the
+ *                            proto class drops.
+ *
+ * normalizeForReview must be idempotent and non-mutating on the input.
+ */
+
+import { extractCollectionValue, normalizeForReview } from './review-normalize.js';
+
+// ---------------------------------------------------------------------------
+// extractCollectionValue
+// ---------------------------------------------------------------------------
+
+describe('extractCollectionValue', () => {
+  it('returns primitives unchanged', () => {
+    expect(extractCollectionValue(null)).toBe(null);
+    expect(extractCollectionValue(undefined)).toBe(undefined);
+    expect(extractCollectionValue(42)).toBe(42);
+    expect(extractCollectionValue('abc')).toBe('abc');
+    expect(extractCollectionValue(true)).toBe(true);
+  });
+
+  it('unwraps a transaction with messages[0].value', () => {
+    const tx = { messages: [{ typeUrl: '/some.MsgType', value: { creator: 'bb1a', name: 'x' } }] };
+    expect(extractCollectionValue(tx)).toEqual({ creator: 'bb1a', name: 'x' });
+  });
+
+  it('unwraps a bare array of messages (non-object wrapper)', () => {
+    const arr = [{ typeUrl: '/some.MsgType', value: { a: 1 } }];
+    expect(extractCollectionValue(arr)).toEqual({ a: 1 });
+  });
+
+  it('falls back to the message itself if value is missing', () => {
+    const tx = { messages: [{ creator: 'bb1x' }] };
+    expect(extractCollectionValue(tx)).toEqual({ creator: 'bb1x' });
+  });
+
+  it('returns input when messages is an empty array', () => {
+    const tx = { messages: [] };
+    expect(extractCollectionValue(tx)).toBe(tx);
+  });
+
+  it('unwraps a single message with {typeUrl, value}', () => {
+    const msg = { typeUrl: '/some.MsgType', value: { creator: 'bb1y' } };
+    expect(extractCollectionValue(msg)).toEqual({ creator: 'bb1y' });
+  });
+
+  it('returns a bare object (no messages / no value) as-is', () => {
+    const raw = { creator: 'bb1z', name: 'My Collection' };
+    expect(extractCollectionValue(raw)).toBe(raw);
+  });
+
+  it('ignores value when it is not an object (e.g. string)', () => {
+    const msg = { typeUrl: '/some.MsgType', value: 'not-an-object' };
+    // typeUrl check requires value to be an object; this falls through
+    expect(extractCollectionValue(msg)).toBe(msg);
+  });
+
+  it('ignores messages when it is not an array', () => {
+    const tx = { messages: 'not-an-array' };
+    expect(extractCollectionValue(tx)).toBe(tx);
+  });
+
+  it('prefers messages over value when both present', () => {
+    const tx = { messages: [{ value: { a: 1 } }], value: { a: 2 } };
+    expect(extractCollectionValue(tx)).toEqual({ a: 1 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeForReview — primitives / fallback
+// ---------------------------------------------------------------------------
+
+describe('normalizeForReview — primitives', () => {
+  it('returns primitives unchanged after extraction', () => {
+    expect(normalizeForReview(null)).toBe(null);
+    expect(normalizeForReview(undefined)).toBe(undefined);
+    expect(normalizeForReview(42)).toBe(42);
+    expect(normalizeForReview('abc')).toBe('abc');
+  });
+
+  it('empty object goes through normalization without throwing', () => {
+    const r = normalizeForReview({});
+    expect(r).toBeDefined();
+    expect(typeof r).toBe('object');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeForReview — mirrored aliasPaths fields
+// ---------------------------------------------------------------------------
+
+describe('normalizeForReview — aliasPath field mirroring', () => {
+  it('mirrors aliasPathsToAdd from aliasPaths on input, both present on output', () => {
+    const collection = {
+      creator: 'bb1abc',
+      aliasPaths: [{ some: 'entry' }]
+    };
+    const normalized = normalizeForReview(collection);
+    // The Msg class carries aliasPathsToAdd; we also re-copy it into aliasPaths.
+    expect(normalized.aliasPathsToAdd).toBeDefined();
+    expect(normalized.aliasPaths).toBeDefined();
+  });
+
+  it('mirrors aliasPaths when only aliasPathsToAdd is set', () => {
+    const collection = {
+      creator: 'bb1abc',
+      aliasPathsToAdd: [{ some: 'entry' }]
+    };
+    const normalized = normalizeForReview(collection);
+    expect(normalized.aliasPaths).toBeDefined();
+    expect(normalized.aliasPathsToAdd).toBeDefined();
+  });
+
+  it('mirrors cosmosCoinWrapperPathsToAdd field', () => {
+    const collection = {
+      creator: 'bb1abc',
+      cosmosCoinWrapperPaths: [{ some: 'wrapper' }]
+    };
+    const normalized = normalizeForReview(collection);
+    expect(normalized.cosmosCoinWrapperPathsToAdd).toBeDefined();
+    // cosmosCoinWrapperPaths may or may not survive conversion; mirroring
+    // ensures at least one side is present for downstream checks.
+    expect(
+      Boolean(normalized.cosmosCoinWrapperPaths) || Boolean(normalized.cosmosCoinWrapperPathsToAdd)
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeForReview — _meta sidecar preservation
+// ---------------------------------------------------------------------------
+
+describe('normalizeForReview — _meta preservation', () => {
+  it('preserves _meta on the output', () => {
+    const collection = {
+      creator: 'bb1abc',
+      _meta: { metadataPlaceholders: [{ k: 'placeholder' }] }
+    };
+    const normalized = normalizeForReview(collection);
+    expect(normalized._meta).toEqual({ metadataPlaceholders: [{ k: 'placeholder' }] });
+  });
+
+  it('does not copy _meta when it is a primitive', () => {
+    const collection = {
+      creator: 'bb1abc',
+      _meta: 'not-an-object'
+    };
+    const normalized = normalizeForReview(collection);
+    // Check: the reattach helper only copies when typeof _meta === 'object'.
+    // Strings should not propagate onto the output.
+    expect(normalized._meta).not.toBe('not-an-object');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeForReview — transaction/message unwrapping
+// ---------------------------------------------------------------------------
+
+describe('normalizeForReview — extraction', () => {
+  it('unwraps a transaction and normalizes', () => {
+    const tx = {
+      messages: [
+        {
+          typeUrl: '/badges.MsgUniversalUpdateCollection',
+          value: { creator: 'bb1abc' }
+        }
+      ]
+    };
+    const normalized = normalizeForReview(tx);
+    expect(normalized.creator).toBe('bb1abc');
+  });
+
+  it('unwraps a raw message { typeUrl, value }', () => {
+    const msg = { typeUrl: '/any', value: { creator: 'bb1xyz' } };
+    const normalized = normalizeForReview(msg);
+    expect(normalized.creator).toBe('bb1xyz');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeForReview — idempotency
+// ---------------------------------------------------------------------------
+
+describe('normalizeForReview — idempotency', () => {
+  it('passing an already-normalized value through again yields the same shape', () => {
+    const input = { creator: 'bb1abc', aliasPaths: [{ x: 1 }] };
+    const first = normalizeForReview(input);
+    const second = normalizeForReview(first);
+    // Both should have the same sets of keys (no data lost/added on re-run).
+    expect(Object.keys(second).sort()).toEqual(Object.keys(first).sort());
+    expect(second.creator).toBe(first.creator);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeForReview — non-mutation of input
+// ---------------------------------------------------------------------------
+
+describe('normalizeForReview — does not mutate input', () => {
+  it('leaves the original collection object untouched', () => {
+    const original = {
+      creator: 'bb1abc',
+      aliasPaths: [{ some: 'v' }]
+    };
+    const snapshot = JSON.stringify(original);
+    normalizeForReview(original);
+    expect(JSON.stringify(original)).toBe(snapshot);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeForReview — WithDetails inline metadata reattachment
+// ---------------------------------------------------------------------------
+
+describe('normalizeForReview — inline metadata reattachment', () => {
+  it('reattaches collectionMetadata.metadata (WithDetails inline field)', () => {
+    const input = {
+      creator: 'bb1abc',
+      collectionMetadata: {
+        uri: 'ipfs://x',
+        customData: '',
+        metadata: { name: 'InlineName', description: 'desc', image: 'img' }
+      }
+    };
+    const normalized = normalizeForReview(input);
+    expect(normalized.collectionMetadata?.metadata).toEqual({
+      name: 'InlineName',
+      description: 'desc',
+      image: 'img'
+    });
+  });
+
+  it('reattaches approval details onto collectionApprovals', () => {
+    const input = {
+      creator: 'bb1abc',
+      collectionApprovals: [
+        {
+          approvalId: 'a1',
+          fromListId: 'Mint',
+          toListId: 'All',
+          initiatedByListId: 'All',
+          details: { name: 'Approval A', description: 'd', image: 'img' }
+        }
+      ]
+    };
+    const normalized = normalizeForReview(input);
+    expect(Array.isArray(normalized.collectionApprovals)).toBe(true);
+    expect(normalized.collectionApprovals[0].details).toEqual({
+      name: 'Approval A',
+      description: 'd',
+      image: 'img'
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeForReview — fallback on unknown shapes
+// ---------------------------------------------------------------------------
+
+describe('normalizeForReview — fallback path', () => {
+  it('returns the mirrored-but-not-crashed value when MsgUniversalUpdateCollection cannot handle the shape', () => {
+    // Force a value that is object but hostile to the class constructor —
+    // a cyclic structure. The try/catch in normalizeForReview should fall
+    // back to the mirrored raw object rather than throwing.
+    const cyclic: any = { creator: 'bb1abc' };
+    cyclic.self = cyclic;
+    let r: any;
+    expect(() => {
+      r = normalizeForReview(cyclic);
+    }).not.toThrow();
+    expect(r).toBeDefined();
+    // Creator should still be accessible either on the converted obj or the
+    // fallback mirrored raw.
+    expect(r.creator).toBe('bb1abc');
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/core/scheduled-payments.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/scheduled-payments.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for scheduled-payments.ts — Scheduled Payment approval shape check.
+ *
+ * Scheduled payments are one-shot (maxNumTransfers=1) approvals that can
+ * contain 1 OR 2 coin transfers (payment + optional tip). Unlike invoices,
+ * scheduled payments MUST override from with approver address (pay from
+ * escrow on approval settle). They also do not restrict the override-to
+ * direction, so only overridesFromOutgoingApprovals is mandatory.
+ */
+
+import { isScheduledPaymentApproval } from './scheduled-payments.js';
+
+const makeValid = (): any => ({
+  fromListId: 'Mint',
+  approvalCriteria: {
+    maxNumTransfers: { overallMaxNumTransfers: 1n },
+    coinTransfers: [{ coins: [{ denom: 'ubadge', amount: 1000n }] }],
+    predeterminedBalances: {
+      incrementedBalances: {
+        startBalances: [{ tokenIds: [{ start: 1n, end: 1n }], amount: 1n }],
+        incrementTokenIdsBy: 0n,
+        incrementOwnershipTimesBy: 0n,
+        durationFromTimestamp: 0n,
+        allowOverrideTimestamp: false,
+        allowAmountScaling: false,
+        recurringOwnershipTimes: { startTime: 0n, intervalLength: 0n, chargePeriodLength: 0n }
+      }
+    },
+    overridesFromOutgoingApprovals: true,
+    requireToEqualsInitiatedBy: false
+  }
+});
+
+describe('isScheduledPaymentApproval — happy path', () => {
+  it('accepts a canonical single-coin-transfer scheduled payment', () => {
+    expect(isScheduledPaymentApproval(makeValid())).toBe(true);
+  });
+
+  it('accepts a scheduled payment with 2 coinTransfers (payment + tip)', () => {
+    const a = makeValid();
+    a.approvalCriteria.coinTransfers = [
+      { coins: [{ denom: 'ubadge', amount: 1000n }] },
+      { coins: [{ denom: 'ubadge', amount: 50n }] }
+    ];
+    expect(isScheduledPaymentApproval(a)).toBe(true);
+  });
+
+  it('accepts with optional merkleChallenge satisfying constraints', () => {
+    const a = makeValid();
+    a.approvalCriteria.merkleChallenges = [{ maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: false }];
+    expect(isScheduledPaymentApproval(a)).toBe(true);
+  });
+});
+
+describe('isScheduledPaymentApproval — structural rejections', () => {
+  it('rejects when approvalCriteria is missing', () => {
+    const a = makeValid();
+    a.approvalCriteria = undefined;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects when fromListId != Mint', () => {
+    const a = makeValid();
+    a.fromListId = '!Mint';
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+});
+
+describe('isScheduledPaymentApproval — merkleChallenges', () => {
+  it('rejects when merkleChallenges.length > 1', () => {
+    const a = makeValid();
+    a.approvalCriteria.merkleChallenges = [
+      { maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: false },
+      { maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: false }
+    ];
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects merkleChallenge with maxUsesPerLeaf != 1', () => {
+    const a = makeValid();
+    a.approvalCriteria.merkleChallenges = [{ maxUsesPerLeaf: 2n, useCreatorAddressAsLeaf: false }];
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects merkleChallenge with useCreatorAddressAsLeaf=true', () => {
+    const a = makeValid();
+    a.approvalCriteria.merkleChallenges = [{ maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: true }];
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+});
+
+describe('isScheduledPaymentApproval — maxNumTransfers', () => {
+  it('rejects when overallMaxNumTransfers is missing/0', () => {
+    const a = makeValid();
+    a.approvalCriteria.maxNumTransfers.overallMaxNumTransfers = 0n;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+
+    const b = makeValid();
+    b.approvalCriteria.maxNumTransfers = undefined;
+    expect(isScheduledPaymentApproval(b)).toBe(false);
+  });
+
+  it('rejects when overallMaxNumTransfers > 1 (scheduled payments are one-time)', () => {
+    const a = makeValid();
+    a.approvalCriteria.maxNumTransfers.overallMaxNumTransfers = 2n;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+});
+
+describe('isScheduledPaymentApproval — coinTransfers', () => {
+  it('rejects zero coinTransfers (at least payment required)', () => {
+    const a = makeValid();
+    a.approvalCriteria.coinTransfers = [];
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('accepts 3+ coinTransfers (function does not cap upper bound)', () => {
+    // Note the spec in the source comment says 1-2 (payment + tip) but the
+    // code has no upper-bound check. Pinning current behavior. If the
+    // intent was to cap at 2, the function should be updated.
+    const a = makeValid();
+    a.approvalCriteria.coinTransfers = [
+      { coins: [{ denom: 'u', amount: 1n }] },
+      { coins: [{ denom: 'u', amount: 1n }] },
+      { coins: [{ denom: 'u', amount: 1n }] }
+    ];
+    expect(isScheduledPaymentApproval(a)).toBe(true);
+  });
+});
+
+describe('isScheduledPaymentApproval — incrementedBalances', () => {
+  it('rejects when missing', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances = { incrementedBalances: undefined };
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects when allowAmountScaling=true', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.allowAmountScaling = true;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalances.length != 1', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances = [];
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalance tokenIds != [{1,1}]', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].tokenIds = [
+      { start: 2n, end: 2n }
+    ];
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalance tokenIds span more than 1', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].tokenIds = [
+      { start: 1n, end: 3n }
+    ];
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects when startBalance amount != 1', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].amount = 2n;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects any incrementTokenIdsBy != 0', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementTokenIdsBy = 1n;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects any incrementOwnershipTimesBy != 0', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementOwnershipTimesBy = 1n;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects any durationFromTimestamp != 0', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.durationFromTimestamp = 1n;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects allowOverrideTimestamp=true', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.allowOverrideTimestamp = true;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects recurringOwnershipTimes.startTime != 0', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.startTime = 1n;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects recurringOwnershipTimes.intervalLength != 0', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.intervalLength = 1n;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects recurringOwnershipTimes.chargePeriodLength != 0', () => {
+    const a = makeValid();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.chargePeriodLength = 1n;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+});
+
+describe('isScheduledPaymentApproval — override/require', () => {
+  it('rejects when overridesFromOutgoingApprovals is false', () => {
+    const a = makeValid();
+    a.approvalCriteria.overridesFromOutgoingApprovals = false;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+
+  it('rejects when requireToEqualsInitiatedBy is true', () => {
+    const a = makeValid();
+    a.approvalCriteria.requireToEqualsInitiatedBy = true;
+    expect(isScheduledPaymentApproval(a)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds eight spec files for previously-untested `src/core` protocol validators and helpers — 235 new tests, all passing.
- Full SDK test suite goes from 44 suites / 1516 tests to 53 suites / 1751 tests.
- Targets: `bounties.ts` (31), `auctions.ts` (21), `crowdfunds.ts` (31), `quests.ts` (40), `invoices.ts` (32), `scheduled-payments.ts` (27), `blankCriteria.ts` (13), `review-normalize.ts` (24).

## What's covered

Each spec exhaustively covers every branch in its target:
- Protocol validators (Bounty, Auction, Crowdfund) — happy path + every error condition (standard missing, wrong `validTokenIds`, wrong approval count, wrong `fromListId`/`toListId`, missing overrides, mismatched denoms/amounts/verifiers, wrong expiration timing).
- Approval shape matchers (`isQuestApproval`, `isInvoiceApproval`, `isScheduledPaymentApproval`) — every reject path and the distinct `coinTransfer` direction contract for each standard (invoices initiator→addr, quests/payments addr→initiator via overrides).
- `blankCriteria` — fresh refs per call, id threading, full shape defaults, mutation isolation.
- `review-normalize` — `extractCollectionValue` unwrap precedence, `normalizeForReview` idempotency + non-mutation + aliasPaths / cosmosCoinWrapperPaths mirroring, `_meta` sidecar preservation, WithDetails inline metadata reattachment (collection metadata + approval details), and the try/catch fallback path on cyclic/hostile input.

## Test plan

- [x] `npm test` on branch: 53 suites / 1751 tests, 0 failures.
- [x] Each new spec runs in isolation: `npx jest src/core/<file>.spec.ts`.
- [x] No existing tests regressed.

Tracking ticket: autopilot `backlog/0243-testing-core-protocol-validators.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)