### PR TITLE
fix(builder): MCP skill-list sync + address-list dedup + fetch_docs simplification

### DIFF
--- a/packages/bitbadgesjs-sdk/src/builder/resources/skillInstructions.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/resources/skillInstructions.ts
@@ -1176,32 +1176,10 @@ When creating a Custom-2FA collection, follow these requirements:
 - Calculate expiration timestamps correctly (milliseconds since epoch)
 - Tokens automatically expire and can be purged after expiration`
   },
-  {
-    id: 'address-list',
-    name: 'Address List',
-    category: 'token-type',
-    description: 'On-chain managed address list where membership = owning x1 of token ID 1',
-    summary: `On-chain address list. Use per-field tools: set_standards(["Address List"]), add_approval (manager-add + manager-remove), set_permissions, set_invariants.
-
-- List membership = owning x1 of token ID 1
-- Manager can add (mint) and remove (burn) addresses
-- No peer-to-peer transfers
-- Requires TWO approvals: manager-add (minting) + manager-remove (burn to bb1qqq...s7gvmv)
-- After building, proceed with review_collection + validate_transaction as normal`,
-    instructions: `## Address List Token Type
-
-Use per-field tools to create this collection. It requires:
-1. set_standards(["Address List"])
-2. set_valid_token_ids([{ start: "1", end: "1" }])
-3. add_approval — manager-add: fromListId "Mint", toListId "All", initiatedByListId = manager address, overridesFromOutgoingApprovals: true, overridesToIncomingApprovals: true
-4. add_approval — manager-remove: fromListId "!Mint", toListId burn address (bb1qqq...s7gvmv), initiatedByListId = manager address, overridesFromOutgoingApprovals: true, overridesToIncomingApprovals: true
-5. set_permissions — lock canDeleteCollection, canUpdateStandards, canUpdateValidTokenIds
-6. set_invariants — noCustomOwnershipTimes: true, disablePoolCreation: true
-
-This creates a token collection where list membership = owning x1 of token ID 1. The manager can add (mint) and remove (burn) addresses. No peer-to-peer transfers.
-
-After building, proceed with review_collection and validate_transaction as normal.`
-  },
+  // NOTE: the previous short `address-list` entry lived here. The authoritative
+  // entry (with the frontend-required "manager-add" / "manager-remove" approvalIds
+  // and the burn address) is kept later in this array and is the only one that
+  // ships now. See backlog #0240.
   {
     id: 'bb-402',
     name: 'BB-402 Token-Gated Access',

--- a/packages/bitbadgesjs-sdk/src/builder/tools/registry.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/registry.spec.ts
@@ -17,6 +17,7 @@
  */
 
 import { callTool, toolRegistry } from './registry.js';
+import { getAllSkillInstructions, getSkillInstructions } from '../resources/index.js';
 
 describe('callTool — pre-flight arg validation', () => {
   describe('missing required field', () => {
@@ -144,6 +145,47 @@ describe('callTool — pre-flight arg validation', () => {
         }
       }
       expect(missing).toEqual([]);
+    });
+  });
+
+  describe('get_skill_instructions — description stays in sync with SKILL_INSTRUCTIONS (backlog #0241)', () => {
+    const entry = (toolRegistry as any).get_skill_instructions;
+    const tool = entry.tool;
+    const realIds = getAllSkillInstructions().map((s) => s.id).sort();
+
+    it('tool description lists every real skill ID', () => {
+      for (const id of realIds) {
+        expect(tool.description).toContain(id);
+      }
+    });
+
+    it('skillId parameter description lists every real skill ID', () => {
+      const paramDesc = tool.inputSchema.properties.skillId.description as string;
+      for (const id of realIds) {
+        expect(paramDesc).toContain(id);
+      }
+    });
+
+    it('tool description does not mention retired skills (ai-criteria-gate, verified)', () => {
+      expect(tool.description).not.toMatch(/ai-criteria-gate/);
+      expect(tool.description).not.toMatch(/\bverified\b/);
+    });
+  });
+
+  describe('address-list skill instruction (backlog #0240)', () => {
+    it('appears exactly once in SKILL_INSTRUCTIONS', () => {
+      const matches = getAllSkillInstructions().filter((s) => s.id === 'address-list');
+      expect(matches).toHaveLength(1);
+    });
+
+    it('getSkillInstructions returns the authoritative entry with manager-add + manager-remove approvalIds', () => {
+      const skill = getSkillInstructions('address-list');
+      expect(skill).not.toBeNull();
+      // The authoritative entry explicitly documents the EXACT approvalIds
+      // the frontend depends on.
+      expect(skill!.instructions).toMatch(/manager-add/);
+      expect(skill!.instructions).toMatch(/manager-remove/);
+      expect(skill!.instructions).toMatch(/bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv/);
     });
   });
 });

--- a/packages/bitbadgesjs-sdk/src/builder/tools/registry.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/registry.ts
@@ -123,18 +123,29 @@ function entry(tool: any, run: (args: any) => any, formatText?: (result: any) =>
   return { tool, run, formatText };
 }
 
-// Inline schemas for tools that were previously defined ad-hoc in server.ts
+// Inline schemas for tools that were previously defined ad-hoc in server.ts.
+//
+// The `get_skill_instructions` tool surface is derived from the live
+// `SKILL_INSTRUCTIONS` array at module init — see backlog #0241. A previous
+// hard-coded list drifted: it advertised two IDs that no longer existed and
+// omitted six that did, leading agents to request nonexistent skills and miss
+// curated ones (auto-mint, prediction-market, bounty, crowdfund, auction,
+// product-catalog). Computing the list here means every future skill addition
+// appears in the tool description automatically — no manual sync required.
+const availableSkillIds = getAllSkillInstructions()
+  .map((s) => s.id)
+  .sort();
+const skillIdList = availableSkillIds.join(', ');
+
 const getSkillInstructionsTool: ToolSchema = {
   name: 'get_skill_instructions',
-  description:
-    'Get detailed instructions for a specific skill. Skills: smart-token, fungible-token, nft-collection, quest, subscription, bb-402, ai-criteria-gate, minting, custom-2fa, immutability, liquidity-pools, payment-protocol, verified, tradable, address-list, burnable, multi-sig-voting, credit-token. Decision matrices are in bitbadges://recipes/all.',
+  description: `Get detailed instructions for a specific skill. Skills: ${skillIdList}. Decision matrices are in bitbadges://recipes/all.`,
   inputSchema: {
     type: 'object',
     properties: {
       skillId: {
         type: 'string',
-        description:
-          'Skill ID: smart-token, minting, liquidity-pools, fungible-token, nft-collection, quest, subscription, immutability, custom-2fa, address-list, bb-402, burnable, multi-sig-voting, ai-criteria-gate, verified, payment-protocol, tradable, credit-token'
+        description: `Skill ID. One of: ${skillIdList}.`
       }
     },
     required: ['skillId']

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/fetchDocs.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/fetchDocs.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for `fetch_docs`.
+ *
+ * Per backlog #0237, this tool now has a single source — the curated
+ * `llms-full.txt` export on docs.bitbadges.io — and a single algorithm:
+ * split on markdown headers, score sections by keyword, return top 3.
+ *
+ * We mock `global.fetch` and exercise:
+ *   - successful keyword match (header bonus + body hits)
+ *   - no-match miss returns a friendly error
+ *   - network failure is reported, not thrown
+ *   - cache hit avoids a second network call
+ */
+
+import { __resetFetchDocsCache, handleFetchDocs } from './fetchDocs.js';
+
+const SAMPLE_LLMS_FULL = `## Overview
+
+BitBadges is a programmable token standard.
+
+## Approvals
+
+Approvals describe who can transfer what between which lists. Approvals are
+the core primitive for transferability. An approval specifies transfer
+times, token IDs, and other criteria.
+
+## Minting
+
+Minting happens through approvals where the fromListId is "Mint".
+
+## Quest
+
+A quest rewards users with a token on completion.
+`;
+
+describe('handleFetchDocs', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    __resetFetchDocsCache();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    __resetFetchDocsCache();
+  });
+
+  function mockFetchOk(body: string) {
+    const mock = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => body
+    }));
+    (global as any).fetch = mock;
+    return mock;
+  }
+
+  it('returns ranked sections when the topic matches', async () => {
+    mockFetchOk(SAMPLE_LLMS_FULL);
+    const res = await handleFetchDocs({ topic: 'approvals' });
+    expect(res.success).toBe(true);
+    expect(res.url).toBe('https://docs.bitbadges.io/llms-full.txt');
+    expect(res.content).toContain('Approvals');
+    // Header bonus should float the Approvals section above others that
+    // also mention the word.
+    const first = (res.content || '').split('---')[0];
+    expect(first).toMatch(/Approvals/);
+  });
+
+  it('returns a friendly error when no section matches the topic', async () => {
+    mockFetchOk(SAMPLE_LLMS_FULL);
+    const res = await handleFetchDocs({ topic: 'xyznonexistentterm' });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/No docs sections matched/);
+    expect(res.error).toMatch(/xyznonexistentterm/);
+  });
+
+  it('reports HTTP failures without throwing', async () => {
+    (global as any).fetch = jest.fn(async () => ({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => ''
+    }));
+    const res = await handleFetchDocs({ topic: 'anything' });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/Failed to fetch docs/);
+    expect(res.error).toMatch(/500/);
+  });
+
+  it('reports network errors without throwing', async () => {
+    (global as any).fetch = jest.fn(async () => {
+      throw new Error('ECONNRESET');
+    });
+    const res = await handleFetchDocs({ topic: 'anything' });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/ECONNRESET/);
+  });
+
+  it('caches the llms-full.txt body across calls within the TTL', async () => {
+    const mock = mockFetchOk(SAMPLE_LLMS_FULL);
+    await handleFetchDocs({ topic: 'approvals' });
+    await handleFetchDocs({ topic: 'minting' });
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('short query tokens (<=2 chars) are filtered out of scoring', async () => {
+    // "is" and "a" are filtered; only longer terms score. So a query of
+    // "is a" against our fixture should match nothing.
+    mockFetchOk(SAMPLE_LLMS_FULL);
+    const res = await handleFetchDocs({ topic: 'is a' });
+    expect(res.success).toBe(false);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/fetchDocs.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/fetchDocs.ts
@@ -1,12 +1,24 @@
 /**
  * Tool: fetch_docs
- * Fetch live documentation from docs.bitbadges.io
+ *
+ * Search the curated `llms-full.txt` export on docs.bitbadges.io.
+ *
+ * History: this tool previously carried an 85-entry hardcoded topic → URL map
+ * plus an HTML-scraping pipeline (entity decoding, tag stripping, 10k-char
+ * truncation), with `llms-full.txt` search as a fallback only. Per backlog
+ * #0237 we deleted the map + HTML path and promoted `llms-full.txt` to the
+ * single source. The rationale is simple: `llms-full.txt` is the docs site's
+ * own LLM-optimized export, so (a) every new docs page is picked up
+ * automatically the next time the cache expires, (b) there is no
+ * HTML-structure coupling, and (c) the public schema and return shape are
+ * unchanged.
  */
-
 import { z } from 'zod';
 
 export const fetchDocsSchema = z.object({
-  topic: z.string().describe('The topic to search for (e.g., "claims", "approvals", "SDK usage")')
+  topic: z
+    .string()
+    .describe('Keywords, concept, or question — e.g. "claims", "approvals", "how do I mint"')
 });
 
 export type FetchDocsInput = z.infer<typeof fetchDocsSchema>;
@@ -21,322 +33,120 @@ export interface FetchDocsResult {
 
 export const fetchDocsTool = {
   name: 'fetch_docs',
-  description: 'Fetch live documentation from docs.bitbadges.io for a topic',
+  description:
+    'Search live BitBadges documentation by keyword. Ranks sections from the curated llms-full.txt export on docs.bitbadges.io and returns the top matches.',
   inputSchema: {
     type: 'object' as const,
     properties: {
       topic: {
         type: 'string',
-        description: 'The topic to search for (e.g., "claims", "approvals", "SDK usage")'
+        description:
+          'Keywords, concept, or question — e.g. "claims", "approvals", "how do I mint"'
       }
     },
     required: ['topic']
   }
 };
 
-/**
- * Map common topics to documentation URLs
- */
-const TOPIC_URL_MAP: Record<string, string> = {
-  // Core concepts
-  'approvals': 'https://docs.bitbadges.io/learn/transferability',
-  'transferability': 'https://docs.bitbadges.io/learn/transferability',
-  'permissions': 'https://docs.bitbadges.io/learn/permissions',
-  'balances': 'https://docs.bitbadges.io/for-developers/concepts/balances',
-  'minting': 'https://docs.bitbadges.io/learn/minting-and-circulating-supply',
-  'supply': 'https://docs.bitbadges.io/learn/minting-and-circulating-supply',
+const LLMS_FULL_URL = 'https://docs.bitbadges.io/llms-full.txt';
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const MAX_SECTIONS = 3;
+const MAX_SECTION_CHARS = 3000;
 
-  // SDK
-  'sdk': 'https://docs.bitbadges.io/for-developers/bitbadges-sdk/overview',
-  'sdk usage': 'https://docs.bitbadges.io/for-developers/bitbadges-sdk/overview',
-  'address conversion': 'https://docs.bitbadges.io/for-developers/bitbadges-sdk/common-snippets/address-conversions',
+let cache: { text: string; fetchedAt: number } | null = null;
 
-  // API
-  'api': 'https://docs.bitbadges.io/for-developers/bitbadges-api/api',
-  'api key': 'https://docs.bitbadges.io/for-developers/bitbadges-api/api',
-
-  // Claims
-  'claims': 'https://docs.bitbadges.io/for-developers/claim-builder/overview',
-  'claim builder': 'https://docs.bitbadges.io/for-developers/claim-builder/overview',
-
-  // Smart tokens
-  'smart tokens': 'https://docs.bitbadges.io/learn/ibc-backed-minting',
-  'ibc': 'https://docs.bitbadges.io/learn/ibc-backed-minting',
-  'backed minting': 'https://docs.bitbadges.io/learn/ibc-backed-minting',
-
-  // Messages
-  'messages': 'https://docs.bitbadges.io/x-tokenization/messages/README',
-  'msg': 'https://docs.bitbadges.io/x-tokenization/messages/README',
-  'msguniversalupdatecollection': 'https://docs.bitbadges.io/x-tokenization/messages/msg-universal-update-collection',
-  'msgtransfertokens': 'https://docs.bitbadges.io/x-tokenization/messages/msg-transfer-tokens',
-
-  // Examples
-  'examples': 'https://docs.bitbadges.io/x-tokenization/examples/README',
-
-  // Sign in
-  'sign in': 'https://docs.bitbadges.io/for-developers/sign-in-with-bitbadges/overview',
-  'siwbb': 'https://docs.bitbadges.io/for-developers/sign-in-with-bitbadges/overview',
-  'oauth': 'https://docs.bitbadges.io/for-developers/sign-in-with-bitbadges/overview',
-
-  // Blockchain
-  'blockchain': 'https://docs.bitbadges.io/for-developers/bitbadges-blockchain/run-a-node',
-  'node': 'https://docs.bitbadges.io/for-developers/bitbadges-blockchain/run-a-node',
-
-  // Overview
-  'overview': 'https://docs.bitbadges.io/overview/what-is-bitbadges',
-  'what is bitbadges': 'https://docs.bitbadges.io/overview/what-is-bitbadges',
-  'getting started': 'https://docs.bitbadges.io/for-developers/getting-started',
-
-  // AI Agents & Bots
-  'ai agents': 'https://docs.bitbadges.io/for-developers/ai-agents',
-  'ai': 'https://docs.bitbadges.io/for-developers/ai-agents',
-  'bots': 'https://docs.bitbadges.io/for-developers/ai-agents',
-  'builder': 'https://docs.bitbadges.io/for-developers/ai-agents/builder-tools',
-  'builder tools': 'https://docs.bitbadges.io/for-developers/ai-agents/builder-tools',
-  'mcp': 'https://docs.bitbadges.io/for-developers/ai-agents/builder-tools',
-  'mcp tools': 'https://docs.bitbadges.io/for-developers/ai-agents/builder-tools',
-  'bot examples': 'https://docs.bitbadges.io/for-developers/ai-agents/bot-examples',
-  'websocket': 'https://docs.bitbadges.io/for-developers/ai-agents/websocket-events',
-  'websocket events': 'https://docs.bitbadges.io/for-developers/ai-agents/websocket-events',
-  'machine discovery': 'https://docs.bitbadges.io/for-developers/ai-agents/capabilities-json',
-  'capabilities': 'https://docs.bitbadges.io/for-developers/ai-agents/capabilities-json',
-  'vault tutorial': 'https://docs.bitbadges.io/for-developers/ai-agents/openclaw-vault-tutorial',
-  'faucet': 'https://docs.bitbadges.io/for-developers/ai-agents/testnet-faucet',
-  'testnet faucet': 'https://docs.bitbadges.io/for-developers/ai-agents/testnet-faucet',
-
-  // Claims extended
-  'claims ai': 'https://docs.bitbadges.io/for-developers/claim-builder/leveraging-ai',
-  'leveraging ai': 'https://docs.bitbadges.io/for-developers/claim-builder/leveraging-ai',
-  'dynamic stores': 'https://docs.bitbadges.io/for-developers/claim-builder/dynamic-stores',
-  'plugins': 'https://docs.bitbadges.io/for-developers/claim-builder/custom-plugins-webhooks',
-  'webhooks': 'https://docs.bitbadges.io/for-developers/claim-builder/custom-plugins-webhooks',
-  'zapier': 'https://docs.bitbadges.io/for-developers/claim-builder/integrate-with-zapier',
-
-  // BB-402
-  'bb-402': 'https://docs.bitbadges.io/x-tokenization/bb-402-token-gated-api-access',
-  'token gated': 'https://docs.bitbadges.io/x-tokenization/bb-402-token-gated-api-access',
-  'gated api': 'https://docs.bitbadges.io/x-tokenization/bb-402-token-gated-api-access',
-
-  // EVM
-  'evm': 'https://docs.bitbadges.io/x-tokenization/evm-compatibility',
-  'evm compatibility': 'https://docs.bitbadges.io/x-tokenization/evm-compatibility',
-  'precompiles': 'https://docs.bitbadges.io/x-tokenization/evm-compatibility',
-  'solidity': 'https://docs.bitbadges.io/x-tokenization/evm-compatibility'
-};
-
-/**
- * Find the best matching URL for a topic
- */
-function findTopicUrl(topic: string): string | null {
-  const normalizedTopic = topic.toLowerCase().trim();
-
-  // Direct match
-  if (TOPIC_URL_MAP[normalizedTopic]) {
-    return TOPIC_URL_MAP[normalizedTopic];
+/** Fetch `llms-full.txt`, caching the body for CACHE_TTL_MS. Throws on HTTP failure. */
+async function loadLlmsFull(): Promise<string> {
+  if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
+    return cache.text;
   }
+  const response = await fetch(LLMS_FULL_URL, {
+    headers: { 'User-Agent': 'BitBadges-Builder/1.0' }
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+  const text = await response.text();
+  cache = { text, fetchedAt: Date.now() };
+  return text;
+}
 
-  // Partial match
-  for (const [key, url] of Object.entries(TOPIC_URL_MAP)) {
-    if (normalizedTopic.includes(key) || key.includes(normalizedTopic)) {
-      return url;
+/**
+ * Score a section against a set of search terms. Counts raw term occurrences
+ * and awards a bonus when a term appears in the section's header (first
+ * line). Tokens appear in both the numerator and the header bonus so a
+ * multi-word query like "address list" ranks sections with both tokens
+ * higher than those with only one.
+ */
+function scoreSection(section: string, terms: string[]): number {
+  if (terms.length === 0) return 0;
+  const lower = section.toLowerCase();
+  let score = 0;
+  for (const term of terms) {
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const matches = lower.match(new RegExp(escaped, 'g'));
+    if (matches) score += matches.length;
+  }
+  const headerMatch = section.match(/^#{1,3}\s+(.+)/);
+  if (headerMatch) {
+    const header = headerMatch[1].toLowerCase();
+    for (const term of terms) {
+      if (header.includes(term)) score += 5;
     }
   }
-
-  return null;
+  return score;
 }
 
-/**
- * Strip a block-level HTML tag (and its contents) from a string.
- *
- * Uses a tempered-greedy token so nested `<` characters inside the block are
- * consumed, and a flexible closing tag pattern that matches `</tag >` with
- * trailing whitespace. Runs in a loop until the output is stable so partial
- * bypasses like `<scr<script>ipt>...</script>` — where a single pass would
- * leave `<script>...` exposed after removing the inner match — are fully
- * eliminated.
- */
-function stripTagBlock(html: string, tag: string): string {
-  const re = new RegExp(
-    `<${tag}\\b[^<]*(?:(?!<\\/${tag}\\s*>)<[^<]*)*<\\/${tag}\\s*>`,
-    'gi'
-  );
-  let current = html;
-  while (true) {
-    const next = current.replace(re, '');
-    if (next === current) return next;
-    current = next;
-  }
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.substring(0, max) + '\n...[truncated]';
 }
 
-/**
- * Decode the handful of HTML entities we care about in a single pass.
- *
- * Doing sequential `.replace()` calls is unsafe because an earlier decode can
- * produce an entity-looking substring that a later decode then re-interprets
- * (e.g. `&amp;lt;` → `&lt;` → `<`). A single regex with a lookup table means
- * each source character position is decoded at most once.
- */
-const ENTITY_MAP: Record<string, string> = {
-  nbsp: ' ',
-  amp: '&',
-  lt: '<',
-  gt: '>',
-  quot: '"',
-  apos: "'"
-};
-function decodeHtmlEntities(input: string): string {
-  return input.replace(/&(nbsp|amp|lt|gt|quot|apos);/g, (_match, name: string) => ENTITY_MAP[name] ?? '');
-}
-
-/**
- * Fetch and extract content from a documentation page
- */
-async function fetchDocContent(url: string): Promise<string> {
-  try {
-    const response = await fetch(url, {
-      headers: {
-        'User-Agent': 'BitBadges-Builder/1.0',
-        'Accept': 'text/html,application/xhtml+xml'
-      }
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-    }
-
-    const html = await response.text();
-
-    // Remove script / style blocks (loop-stable, permissive closing tag).
-    let content = stripTagBlock(html, 'script');
-    content = stripTagBlock(content, 'style');
-
-    // Remove remaining HTML tags but keep text
-    content = content.replace(/<[^>]+>/g, ' ');
-
-    // Clean up whitespace
-    content = content.replace(/\s+/g, ' ').trim();
-
-    // Decode the small set of HTML entities we care about, in one pass so
-    // `&amp;lt;` does not double-unescape into `<`.
-    content = decodeHtmlEntities(content);
-
-    // Truncate to reasonable length
-    if (content.length > 10000) {
-      content = content.substring(0, 10000) + '...\n\n[Content truncated. Visit the URL for full documentation.]';
-    }
-
-    return content;
-  } catch (error) {
-    throw new Error(`Failed to fetch: ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-/**
- * Cache for llms-full.txt content (fetched once, reused)
- */
-let llmsFullTextCache: string | null = null;
-
-/**
- * Fetch llms-full.txt and search for relevant sections by keyword
- */
-async function fetchLlmsFullText(topic: string): Promise<string | null> {
-  // Fetch and cache
-  if (!llmsFullTextCache) {
-    const response = await fetch('https://docs.bitbadges.io/llms-full.txt', {
-      headers: { 'User-Agent': 'BitBadges-Builder/1.0' }
-    });
-    if (!response.ok) return null;
-    llmsFullTextCache = await response.text();
-  }
-
-  const text = llmsFullTextCache;
-  const topicLower = topic.toLowerCase();
-  const terms = topicLower.split(/\s+/).filter(t => t.length > 2);
-
-  // Split into sections by markdown headers
-  const sections = text.split(/(?=^#{1,3}\s)/m);
-
-  // Score each section by keyword relevance
-  const scored = sections
-    .map(section => {
-      let score = 0;
-      const sectionLower = section.toLowerCase();
-      for (const term of terms) {
-        const regex = new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
-        const matches = sectionLower.match(regex);
-        if (matches) score += matches.length;
-      }
-      // Bonus for header match
-      const headerMatch = section.match(/^#{1,3}\s+(.+)/);
-      if (headerMatch) {
-        const header = headerMatch[1].toLowerCase();
-        for (const term of terms) {
-          if (header.includes(term)) score += 5;
-        }
-      }
-      return { section, score };
-    })
-    .filter(s => s.score > 0)
-    .sort((a, b) => b.score - a.score);
-
-  if (scored.length === 0) return null;
-
-  // Return top 3 most relevant sections, truncated
-  let result = `# Search results for "${topic}" from docs.bitbadges.io\n\n`;
-  for (const s of scored.slice(0, 3)) {
-    const trimmed = s.section.trim();
-    result += trimmed.length > 3000 ? trimmed.substring(0, 3000) + '\n...[truncated]' : trimmed;
-    result += '\n\n---\n\n';
-  }
-
-  return result.length > 100 ? result : null;
+/** Test hook — drop the cached llms-full.txt body. Not part of the public MCP surface. */
+export function __resetFetchDocsCache(): void {
+  cache = null;
 }
 
 export async function handleFetchDocs(input: FetchDocsInput): Promise<FetchDocsResult> {
+  const { topic } = input;
   try {
-    const { topic } = input;
+    const text = await loadLlmsFull();
+    const sections = text.split(/(?=^#{1,3}\s)/m);
+    const terms = topic
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((t) => t.length > 2);
 
-    // Find matching URL
-    const url = findTopicUrl(topic);
+    const scored = sections
+      .map((section) => ({ section, score: scoreSection(section, terms) }))
+      .filter((s) => s.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, MAX_SECTIONS);
 
-    if (!url) {
-      // Fallback: search llms-full.txt for the topic
-      try {
-        const fallbackContent = await fetchLlmsFullText(topic);
-        if (fallbackContent) {
-          return {
-            success: true,
-            topic,
-            content: fallbackContent,
-            url: 'https://docs.bitbadges.io/llms-full.txt'
-          };
-        }
-      } catch {
-        // Fallback failed, continue to error
-      }
-
-      const availableTopics = Object.keys(TOPIC_URL_MAP).slice(0, 20).join(', ');
+    if (scored.length === 0) {
       return {
         success: false,
         topic,
-        error: `No documentation found for topic "${topic}". Try one of: ${availableTopics}. Or visit https://docs.bitbadges.io directly.`
+        error: `No docs sections matched "${topic}". Try broader keywords, or visit ${LLMS_FULL_URL} directly.`
       };
     }
 
-    // Fetch the content
-    const content = await fetchDocContent(url);
+    const header = `# Search results for "${topic}" from docs.bitbadges.io\n\n`;
+    const body = scored
+      .map((s) => truncate(s.section.trim(), MAX_SECTION_CHARS))
+      .join('\n\n---\n\n');
 
     return {
       success: true,
       topic,
-      content,
-      url
+      content: header + body,
+      url: LLMS_FULL_URL
     };
   } catch (error) {
     return {
       success: false,
-      topic: input.topic,
-      error: `Failed to fetch documentation: ${error instanceof Error ? error.message : String(error)}`
+      topic,
+      error: `Failed to fetch docs: ${error instanceof Error ? error.message : String(error)}`
     };
   }
 }


### PR DESCRIPTION
Resolves three related MCP-builder DX issues.

## Summary

- **Backlog #0241** — `get_skill_instructions` tool description in `registry.ts` hard-coded a stale skill list. It advertised two skills that no longer exist (`ai-criteria-gate`, `verified`) and omitted six that do (`auto-mint`, `prediction-market`, `bounty`, `crowdfund`, `auction`, `product-catalog`). The tool + parameter descriptions are now derived from `getAllSkillInstructions()` at module init, so future skills auto-appear and the list cannot drift.
- **Backlog #0240** — Two entries with `id: 'address-list'` shipped in `skillInstructions.ts`. `Array.find` was returning the shorter generic summary, hiding the authoritative entry that calls out the frontend-required exact approvalIds (`manager-add` / `manager-remove`) and the burn address. The short duplicate is deleted; the authoritative entry is now reachable via `getSkillInstructions('address-list')`.
- **Backlog #0237** — `fetchDocs.ts` carried an 85-entry hardcoded topic-to-URL map plus an HTML-scraping pipeline (~260 lines), with `llms-full.txt` search as a fallback. The map had to be manually updated every time a docs page shipped, and the fuzzy substring matcher was unpredictable. The map and HTML path are deleted. `fetch_docs` now always searches the curated `llms-full.txt` export (the docs site's own LLM-optimized dump). Public schema and return shape unchanged. Zero-maintenance docs integration going forward.

## Test plan

- [x] New `fetchDocs.spec.ts` covers keyword ranking, no-match miss, HTTP failure, network failure, cache hit, and short-token filtering
- [x] Extended `registry.spec.ts` asserts that `get_skill_instructions` description + param description list every real skill ID and mention zero retired ones, plus that `address-list` appears exactly once and its authoritative text is returned
- [x] `npm test` passes (1,543 tests across 46 suites)
- [x] `npm run build` clean (no TS errors, no circular deps)

## Backlog

- Closes #0237
- Closes #0240
- Closes #0241