### PR TITLE
test(sdk): core/products.ts + core/subscriptions.ts coverage (+171 tests)

### DIFF
--- a/packages/bitbadgesjs-sdk/README.md
+++ b/packages/bitbadgesjs-sdk/README.md
@@ -2,14 +2,16 @@
 
 The official TypeScript SDK for interacting with the BitBadges blockchain, API, and indexer.
 
-[![npm version](https://badge.fury.io/js/bitbadgesjs-sdk.svg)](https://www.npmjs.com/package/bitbadgesjs-sdk)
+[![npm version](https://badge.fury.io/js/bitbadges.svg)](https://www.npmjs.com/package/bitbadges)
+
+> Previously published as `bitbadgesjs-sdk`. If you have old imports or install commands referencing that name, update them to `bitbadges`.
 
 ## Installation
 
 ```bash
-npm install bitbadgesjs-sdk
+npm install bitbadges
 # or
-bun add bitbadgesjs-sdk
+bun add bitbadges
 ```
 
 ## Quick Start
@@ -17,7 +19,7 @@ bun add bitbadgesjs-sdk
 ### 1. Initialize the API Client
 
 ```typescript
-import { BitBadgesAPI, BigIntify } from 'bitbadgesjs-sdk';
+import { BitBadgesAPI, BigIntify } from 'bitbadges';
 
 const api = new BitBadgesAPI({
   convertFunction: BigIntify,
@@ -102,7 +104,7 @@ const api = new BitBadgesAPI({
 The SDK uses a flexible `NumberType` system supporting `bigint`, `number`, and `string` to handle large blockchain values safely.
 
 ```typescript
-import { BigIntify, Stringify, Numberify } from 'bitbadgesjs-sdk';
+import { BigIntify, Stringify, Numberify } from 'bitbadges';
 
 // Always use BigIntify for large numbers (recommended)
 const collectionId = BigIntify('12345678901234567890');
@@ -125,7 +127,7 @@ The SDK has three type layers:
 | **Proto** | `proto.Balance` | Blockchain serialization (strings only) |
 
 ```typescript
-import { Balance, UintRange } from 'bitbadgesjs-sdk';
+import { Balance, UintRange } from 'bitbadges';
 
 // Create instances with classes
 const balance = new Balance({
@@ -179,7 +181,7 @@ try {
 ### Address Utilities
 
 ```typescript
-import { convertToBitBadgesAddress, isAddressValid } from 'bitbadgesjs-sdk';
+import { convertToBitBadgesAddress, isAddressValid } from 'bitbadges';
 
 // Validate a BitBadges address
 const isValid = isAddressValid('bb1abc...');
@@ -191,7 +193,7 @@ const bbAddress = convertToBitBadgesAddress('bb1abc...');
 ## Module Structure
 
 ```
-bitbadgesjs-sdk/
+bitbadges/
 ├── core/           # Balance, UintRange, Approvals, Permissions
 ├── api-indexer/    # BitBadgesAPI client and response types
 ├── transactions/   # Message builders (MsgTransferTokens, etc.)
@@ -206,19 +208,19 @@ bitbadgesjs-sdk/
 
 ```typescript
 // API Client
-import { BitBadgesAPI } from 'bitbadgesjs-sdk';
+import { BitBadgesAPI } from 'bitbadges';
 
 // Number Conversion
-import { BigIntify, Stringify, Numberify } from 'bitbadgesjs-sdk';
+import { BigIntify, Stringify, Numberify } from 'bitbadges';
 
 // Core Classes
-import { Balance, UintRange, Transfer, CollectionApproval } from 'bitbadgesjs-sdk';
+import { Balance, UintRange, Transfer, CollectionApproval } from 'bitbadges';
 
 // Address Utilities
-import { convertToBitBadgesAddress, isAddressValid } from 'bitbadgesjs-sdk';
+import { convertToBitBadgesAddress, isAddressValid } from 'bitbadges';
 
 // Transaction Messages
-import { MsgTransferTokens, MsgCreateCollection } from 'bitbadgesjs-sdk';
+import { MsgTransferTokens, MsgCreateCollection } from 'bitbadges';
 ```
 
 ## Version Compatibility
@@ -240,7 +242,7 @@ import { MsgTransferTokens, MsgCreateCollection } from 'bitbadgesjs-sdk';
 
 ```bash
 # Install specific version for your chain
-npm install bitbadgesjs-sdk@^0.30.0
+npm install bitbadges@^0.30.0
 ```
 
 ## Troubleshooting

--- a/packages/bitbadgesjs-sdk/src/core/products.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/products.spec.ts
@@ -1,0 +1,976 @@
+/**
+ * Tests for products.ts — Product catalog protocol validator.
+ *
+ * Covers:
+ *   - validateProductCatalogCollection
+ *   - doesCollectionFollowProductCatalogProtocol
+ *   - doesCollectionFollowProductProtocol (legacy)
+ *   - isProductApproval
+ *
+ * A valid Products catalog:
+ *   - has the "Products" standard
+ *   - has validTokenIds starting at 1n
+ *   - has >= 1 purchase approval (fromListId="Mint") with one coinTransfer,
+ *     a predetermined start amount of 1, non-null maxNumTransfers, no
+ *     challenges, a single-token range, and none of the override-initiator
+ *     flags set on coinTransfers
+ *   - optional burn approvals must not carry coinTransfers
+ */
+
+import {
+  validateProductCatalogCollection,
+  doesCollectionFollowProductCatalogProtocol,
+  doesCollectionFollowProductProtocol,
+  isProductApproval
+} from './products.js';
+
+const BURN = 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv';
+
+// ---- fixture helpers ------------------------------------------------------
+
+const makePurchaseApproval = (tokenId: bigint = 1n) =>
+  ({
+    approvalId: `purchase-${tokenId}`,
+    fromListId: 'Mint',
+    toListId: 'All',
+    initiatedByListId: 'All',
+    transferTimes: [{ start: 1n, end: 1000n }],
+    tokenIds: [{ start: tokenId, end: tokenId }],
+    approvalCriteria: {
+      overridesFromOutgoingApprovals: true,
+      overridesToIncomingApprovals: true,
+      maxNumTransfers: { overallMaxNumTransfers: 100n },
+      coinTransfers: [
+        {
+          to: 'bb1seller',
+          coins: [{ denom: 'ubadge', amount: 1000n }],
+          overrideFromWithApproverAddress: false,
+          overrideToWithInitiator: false
+        }
+      ],
+      predeterminedBalances: {
+        incrementedBalances: {
+          startBalances: [
+            {
+              amount: 1n,
+              tokenIds: [{ start: tokenId, end: tokenId }],
+              ownershipTimes: [{ start: 1n, end: 10000n }]
+            }
+          ],
+          incrementTokenIdsBy: 0n,
+          incrementOwnershipTimesBy: 0n,
+          durationFromTimestamp: 0n,
+          allowOverrideTimestamp: false,
+          allowAmountScaling: false,
+          recurringOwnershipTimes: {
+            startTime: 0n,
+            intervalLength: 0n,
+            chargePeriodLength: 0n
+          }
+        }
+      },
+      merkleChallenges: []
+    }
+  }) as any;
+
+const makeBurnApproval = () =>
+  ({
+    approvalId: 'burn',
+    fromListId: '!Mint',
+    toListId: BURN,
+    initiatedByListId: 'All',
+    transferTimes: [{ start: 1n, end: 1000n }],
+    tokenIds: [{ start: 1n, end: 1n }],
+    approvalCriteria: {
+      maxNumTransfers: { overallMaxNumTransfers: 100n }
+    }
+  }) as any;
+
+const makeValidCollection = (): any => ({
+  standards: ['Products'],
+  validTokenIds: [{ start: 1n, end: 1n }],
+  collectionApprovals: [makePurchaseApproval(1n)],
+  invariants: { noCustomOwnershipTimes: true }
+});
+
+// ===========================================================================
+// validateProductCatalogCollection — happy path
+// ===========================================================================
+
+describe('validateProductCatalogCollection — happy path', () => {
+  it('accepts a minimal valid single-product catalog', () => {
+    const r = validateProductCatalogCollection(makeValidCollection());
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.details?.productCount).toBe(1);
+    expect(r.details?.hasBurnApproval).toBe(false);
+  });
+
+  it('accepts a multi-product catalog (validTokenIds [1,3])', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [{ start: 1n, end: 3n }];
+    c.collectionApprovals = [
+      makePurchaseApproval(1n),
+      makePurchaseApproval(2n),
+      makePurchaseApproval(3n)
+    ];
+    const r = validateProductCatalogCollection(c);
+    expect(r.valid).toBe(true);
+    expect(r.details?.productCount).toBe(3);
+  });
+
+  it('accepts a catalog with an optional burn approval', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = [makePurchaseApproval(1n), makeBurnApproval()];
+    const r = validateProductCatalogCollection(c);
+    expect(r.valid).toBe(true);
+    expect(r.details?.hasBurnApproval).toBe(true);
+  });
+
+  it('accepts purchase approval with toListId = burn address', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].toListId = BURN;
+    const r = validateProductCatalogCollection(c);
+    expect(r.valid).toBe(true);
+  });
+
+  it('accepts multi-standard including Products', () => {
+    const c = makeValidCollection();
+    c.standards = ['Auction', 'Products', 'Other'];
+    expect(validateProductCatalogCollection(c).valid).toBe(true);
+  });
+
+  it('doesCollectionFollowProductCatalogProtocol returns true for valid catalog', () => {
+    expect(doesCollectionFollowProductCatalogProtocol(makeValidCollection())).toBe(true);
+  });
+});
+
+// ===========================================================================
+// standards check
+// ===========================================================================
+
+describe('validateProductCatalogCollection — standards check', () => {
+  it('rejects when "Products" standard is missing', () => {
+    const c = makeValidCollection();
+    c.standards = ['Other'];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Missing "Products" standard');
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects when standards is empty', () => {
+    const c = makeValidCollection();
+    c.standards = [];
+    expect(validateProductCatalogCollection(c).errors).toContain('Missing "Products" standard');
+  });
+
+  it('rejects when standards is undefined', () => {
+    const c = makeValidCollection();
+    c.standards = undefined;
+    expect(validateProductCatalogCollection(c).errors).toContain('Missing "Products" standard');
+  });
+});
+
+// ===========================================================================
+// validTokenIds check
+// ===========================================================================
+
+describe('validateProductCatalogCollection — validTokenIds', () => {
+  it('rejects when validTokenIds does not start at 1', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [{ start: 2n, end: 2n }];
+    c.collectionApprovals = [makePurchaseApproval(2n)];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('validTokenIds must start at 1');
+  });
+
+  it('rejects empty validTokenIds', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [];
+    expect(validateProductCatalogCollection(c).errors).toContain('validTokenIds must start at 1');
+  });
+
+  it('accepts multi-range validTokenIds starting at 1', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [
+      { start: 1n, end: 1n },
+      { start: 5n, end: 5n }
+    ];
+    c.collectionApprovals = [makePurchaseApproval(1n), makePurchaseApproval(5n)];
+    const r = validateProductCatalogCollection(c);
+    expect(r.valid).toBe(true);
+  });
+
+  it('merges sortable ranges before checking start', () => {
+    // [5,5] + [1,1] should sort to [1,1] first — still valid
+    const c = makeValidCollection();
+    c.validTokenIds = [
+      { start: 5n, end: 5n },
+      { start: 1n, end: 1n }
+    ];
+    c.collectionApprovals = [makePurchaseApproval(1n), makePurchaseApproval(5n)];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).not.toContain('validTokenIds must start at 1');
+  });
+});
+
+// ===========================================================================
+// invariants warning
+// ===========================================================================
+
+describe('validateProductCatalogCollection — invariants', () => {
+  it('warns when invariants.noCustomOwnershipTimes is false', () => {
+    const c = makeValidCollection();
+    c.invariants = { noCustomOwnershipTimes: false };
+    const r = validateProductCatalogCollection(c);
+    expect(r.warnings).toContain('invariants.noCustomOwnershipTimes should be true for product catalogs');
+    // Warnings do not invalidate.
+    expect(r.valid).toBe(true);
+  });
+
+  it('does not warn when invariants is undefined (treated as absent)', () => {
+    const c = makeValidCollection();
+    delete c.invariants;
+    const r = validateProductCatalogCollection(c);
+    expect(r.warnings).toEqual([]);
+  });
+
+  it('does not warn when invariants.noCustomOwnershipTimes is true', () => {
+    const c = makeValidCollection();
+    c.invariants = { noCustomOwnershipTimes: true };
+    const r = validateProductCatalogCollection(c);
+    expect(r.warnings).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// missing purchase approvals
+// ===========================================================================
+
+describe('validateProductCatalogCollection — purchase approvals required', () => {
+  it('rejects when there are zero purchase approvals', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = [makeBurnApproval()];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('No purchase approvals found (fromListId="Mint")');
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects when collectionApprovals is empty', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = [];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('No purchase approvals found (fromListId="Mint")');
+  });
+});
+
+// ===========================================================================
+// purchase approval — toListId
+// ===========================================================================
+
+describe('validateProductCatalogCollection — purchase.toListId', () => {
+  it('rejects toListId != "All" and != BURN', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].toListId = 'bb1other';
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: toListId must be "All" or burn address');
+  });
+
+  it('accepts toListId = "All"', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].toListId = 'All';
+    expect(validateProductCatalogCollection(c).valid).toBe(true);
+  });
+
+  it('accepts toListId = burn address', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].toListId = BURN;
+    expect(validateProductCatalogCollection(c).valid).toBe(true);
+  });
+});
+
+// ===========================================================================
+// purchase approval — initiatedByListId
+// ===========================================================================
+
+describe('validateProductCatalogCollection — purchase.initiatedByListId', () => {
+  it('rejects initiatedByListId != "All"', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].initiatedByListId = 'bb1buyer';
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: initiatedByListId must be "All"');
+  });
+});
+
+// ===========================================================================
+// purchase approval — override flags
+// ===========================================================================
+
+describe('validateProductCatalogCollection — override flags', () => {
+  it('rejects overridesFromOutgoingApprovals = false', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.overridesFromOutgoingApprovals = false;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: overridesFromOutgoingApprovals must be true');
+  });
+
+  it('rejects overridesFromOutgoingApprovals undefined', () => {
+    const c = makeValidCollection();
+    delete c.collectionApprovals[0].approvalCriteria.overridesFromOutgoingApprovals;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: overridesFromOutgoingApprovals must be true');
+  });
+
+  it('rejects overridesToIncomingApprovals = false', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.overridesToIncomingApprovals = false;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: overridesToIncomingApprovals must be true');
+  });
+
+  it('rejects when approvalCriteria is missing entirely', () => {
+    const c = makeValidCollection();
+    delete c.collectionApprovals[0].approvalCriteria;
+    const r = validateProductCatalogCollection(c);
+    // With criteria gone, both override flags and other checks fire.
+    expect(r.errors).toContain('Purchase approval #1: overridesFromOutgoingApprovals must be true');
+    expect(r.errors).toContain('Purchase approval #1: overridesToIncomingApprovals must be true');
+    expect(r.valid).toBe(false);
+  });
+});
+
+// ===========================================================================
+// purchase approval — tokenIds target exactly 1 token
+// ===========================================================================
+
+describe('validateProductCatalogCollection — purchase.tokenIds', () => {
+  it('rejects tokenId range size > 1', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].tokenIds = [{ start: 1n, end: 2n }];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: tokenIds must target exactly 1 token (start=end)');
+  });
+
+  it('rejects multiple tokenId ranges', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].tokenIds = [
+      { start: 1n, end: 1n },
+      { start: 3n, end: 3n }
+    ];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: tokenIds must target exactly 1 token (start=end)');
+  });
+
+  it('rejects empty tokenIds', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].tokenIds = [];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: tokenIds must target exactly 1 token (start=end)');
+  });
+});
+
+// ===========================================================================
+// purchase approval — coinTransfers
+// ===========================================================================
+
+describe('validateProductCatalogCollection — purchase.coinTransfers', () => {
+  it('rejects missing coinTransfers', () => {
+    const c = makeValidCollection();
+    delete c.collectionApprovals[0].approvalCriteria.coinTransfers;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: must have exactly 1 coinTransfer');
+  });
+
+  it('rejects 0 coinTransfers', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.coinTransfers = [];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: must have exactly 1 coinTransfer');
+  });
+
+  it('rejects >1 coinTransfers', () => {
+    const c = makeValidCollection();
+    const existing = c.collectionApprovals[0].approvalCriteria.coinTransfers[0];
+    c.collectionApprovals[0].approvalCriteria.coinTransfers = [existing, { ...existing }];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: must have exactly 1 coinTransfer');
+  });
+
+  it('rejects coinTransfer with 0 coins', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.coinTransfers[0].coins = [];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: coinTransfer must have exactly 1 coin');
+  });
+
+  it('rejects coinTransfer with 2 coins', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.coinTransfers[0].coins = [
+      { denom: 'ubadge', amount: 100n },
+      { denom: 'uusdc', amount: 100n }
+    ];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: coinTransfer must have exactly 1 coin');
+  });
+
+  it('rejects coinTransfer amount = 0', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.coinTransfers[0].coins[0].amount = 0n;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: coinTransfer amount must be > 0');
+  });
+
+  it('rejects coinTransfer amount < 0', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.coinTransfers[0].coins[0].amount = -5n;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: coinTransfer amount must be > 0');
+  });
+
+  it('rejects overrideFromWithApproverAddress=true', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.coinTransfers[0].overrideFromWithApproverAddress = true;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain(
+      'Purchase approval #1: coinTransfer must NOT use overrideFromWithApproverAddress'
+    );
+  });
+
+  it('rejects overrideToWithInitiator=true', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.coinTransfers[0].overrideToWithInitiator = true;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain(
+      'Purchase approval #1: coinTransfer must NOT use overrideToWithInitiator'
+    );
+  });
+
+  it('accepts amount=1 (smallest positive)', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.coinTransfers[0].coins[0].amount = 1n;
+    expect(validateProductCatalogCollection(c).valid).toBe(true);
+  });
+
+  it('accepts a non-ubadge denom (denom is not policed here)', () => {
+    // validateProductCatalogCollection does NOT check denom — that's isProductApproval's job.
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.coinTransfers[0].coins[0].denom = 'uusdc';
+    expect(validateProductCatalogCollection(c).valid).toBe(true);
+  });
+});
+
+// ===========================================================================
+// purchase approval — predeterminedBalances
+// ===========================================================================
+
+describe('validateProductCatalogCollection — predeterminedBalances', () => {
+  it('rejects missing predeterminedBalances entirely', () => {
+    const c = makeValidCollection();
+    delete c.collectionApprovals[0].approvalCriteria.predeterminedBalances;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: must have predeterminedBalances.incrementedBalances');
+  });
+
+  it('rejects missing incrementedBalances', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.predeterminedBalances = {} as any;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: must have predeterminedBalances.incrementedBalances');
+  });
+
+  it('rejects startBalances with 0 entries', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.predeterminedBalances.incrementedBalances.startBalances = [];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: predeterminedBalances startBalances amount must be 1');
+  });
+
+  it('rejects startBalances with 2 entries', () => {
+    const c = makeValidCollection();
+    const existing =
+      c.collectionApprovals[0].approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0];
+    c.collectionApprovals[0].approvalCriteria.predeterminedBalances.incrementedBalances.startBalances = [
+      existing,
+      { ...existing }
+    ];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: predeterminedBalances startBalances amount must be 1');
+  });
+
+  it('rejects startBalances amount != 1n', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].amount = 2n;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: predeterminedBalances startBalances amount must be 1');
+  });
+});
+
+// ===========================================================================
+// purchase approval — maxNumTransfers
+// ===========================================================================
+
+describe('validateProductCatalogCollection — maxNumTransfers', () => {
+  it('rejects missing maxNumTransfers', () => {
+    const c = makeValidCollection();
+    delete c.collectionApprovals[0].approvalCriteria.maxNumTransfers;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: must have maxNumTransfers set');
+  });
+
+  it('rejects maxNumTransfers null', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.maxNumTransfers = null;
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: must have maxNumTransfers set');
+  });
+
+  it('accepts any non-null maxNumTransfers (the validator only checks presence)', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.maxNumTransfers = {};
+    // Absence check is truthy — empty object is accepted by this layer.
+    expect(validateProductCatalogCollection(c).valid).toBe(true);
+  });
+});
+
+// ===========================================================================
+// purchase approval — challenges prohibited
+// ===========================================================================
+
+describe('validateProductCatalogCollection — challenges must be absent', () => {
+  it('rejects merkleChallenges present', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.merkleChallenges = [{ challengeTrackerId: 'foo' }];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: must NOT have merkleChallenges');
+  });
+
+  it('accepts empty merkleChallenges array', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.merkleChallenges = [];
+    expect(validateProductCatalogCollection(c).valid).toBe(true);
+  });
+
+  it('rejects votingChallenges present', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.votingChallenges = [{ id: 'v1' }];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: must NOT have votingChallenges');
+  });
+
+  it('rejects dynamicStoreChallenges present', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals[0].approvalCriteria.dynamicStoreChallenges = [{ id: 'd1' }];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #1: must NOT have dynamicStoreChallenges');
+  });
+});
+
+// ===========================================================================
+// burn approval validation
+// ===========================================================================
+
+describe('validateProductCatalogCollection — burn approval rules', () => {
+  it('rejects burn approval with coinTransfers attached', () => {
+    const c = makeValidCollection();
+    const burn = makeBurnApproval();
+    burn.approvalCriteria.coinTransfers = [
+      {
+        to: 'bb1recipient',
+        coins: [{ denom: 'ubadge', amount: 1n }],
+        overrideFromWithApproverAddress: false,
+        overrideToWithInitiator: false
+      }
+    ];
+    c.collectionApprovals = [makePurchaseApproval(1n), burn];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Burn approval #1: burn approval must NOT have coinTransfers');
+    expect(r.valid).toBe(false);
+  });
+
+  it('accepts burn approval with empty coinTransfers array', () => {
+    const c = makeValidCollection();
+    const burn = makeBurnApproval();
+    burn.approvalCriteria.coinTransfers = [];
+    c.collectionApprovals = [makePurchaseApproval(1n), burn];
+    expect(validateProductCatalogCollection(c).valid).toBe(true);
+  });
+
+  it('accepts burn approval without any coinTransfers (undefined)', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = [makePurchaseApproval(1n), makeBurnApproval()];
+    expect(validateProductCatalogCollection(c).valid).toBe(true);
+  });
+
+  it('reports every bad burn approval — prefix increments', () => {
+    const c = makeValidCollection();
+    const burn1 = makeBurnApproval();
+    burn1.approvalId = 'burn-1';
+    burn1.approvalCriteria.coinTransfers = [
+      {
+        to: 'bb1x',
+        coins: [{ denom: 'ubadge', amount: 1n }],
+        overrideFromWithApproverAddress: false,
+        overrideToWithInitiator: false
+      }
+    ];
+    const burn2 = makeBurnApproval();
+    burn2.approvalId = 'burn-2';
+    burn2.approvalCriteria.coinTransfers = [
+      {
+        to: 'bb1y',
+        coins: [{ denom: 'ubadge', amount: 1n }],
+        overrideFromWithApproverAddress: false,
+        overrideToWithInitiator: false
+      }
+    ];
+    c.collectionApprovals = [makePurchaseApproval(1n), burn1, burn2];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Burn approval #1: burn approval must NOT have coinTransfers');
+    expect(r.errors).toContain('Burn approval #2: burn approval must NOT have coinTransfers');
+  });
+});
+
+// ===========================================================================
+// multi-error aggregation
+// ===========================================================================
+
+describe('validateProductCatalogCollection — multi-error aggregation', () => {
+  it('reports multiple independent issues in one pass', () => {
+    const c = makeValidCollection();
+    c.standards = ['Other'];
+    c.collectionApprovals[0].initiatedByListId = 'bb1buyer';
+    c.collectionApprovals[0].approvalCriteria.merkleChallenges = [{ id: 'x' }];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Missing "Products" standard');
+    expect(r.errors).toContain('Purchase approval #1: initiatedByListId must be "All"');
+    expect(r.errors).toContain('Purchase approval #1: must NOT have merkleChallenges');
+    expect(r.valid).toBe(false);
+  });
+
+  it('uses 1-based indexing across multiple purchase approvals', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [{ start: 1n, end: 2n }];
+    const p1 = makePurchaseApproval(1n);
+    const p2 = makePurchaseApproval(2n);
+    p2.initiatedByListId = 'bb1buyer';
+    c.collectionApprovals = [p1, p2];
+    const r = validateProductCatalogCollection(c);
+    expect(r.errors).toContain('Purchase approval #2: initiatedByListId must be "All"');
+    expect(r.errors).not.toContain('Purchase approval #1: initiatedByListId must be "All"');
+  });
+
+  it('details.productCount counts only fromListId="Mint" approvals', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = [
+      makePurchaseApproval(1n),
+      makeBurnApproval(),
+      makePurchaseApproval(1n)
+    ];
+    const r = validateProductCatalogCollection(c);
+    expect(r.details?.productCount).toBe(2);
+    expect(r.details?.hasBurnApproval).toBe(true);
+  });
+});
+
+// ===========================================================================
+// doesCollectionFollowProductCatalogProtocol — wrapper
+// ===========================================================================
+
+describe('doesCollectionFollowProductCatalogProtocol', () => {
+  it('returns true when valid', () => {
+    expect(doesCollectionFollowProductCatalogProtocol(makeValidCollection())).toBe(true);
+  });
+
+  it('returns false when invalid', () => {
+    const c = makeValidCollection();
+    c.standards = ['Other'];
+    expect(doesCollectionFollowProductCatalogProtocol(c)).toBe(false);
+  });
+
+  it('returns false when collection is undefined', () => {
+    expect(doesCollectionFollowProductCatalogProtocol(undefined)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// doesCollectionFollowProductProtocol (legacy, single-product only)
+// ===========================================================================
+
+describe('doesCollectionFollowProductProtocol (legacy)', () => {
+  it('returns false for undefined collection', () => {
+    expect(doesCollectionFollowProductProtocol(undefined)).toBe(false);
+  });
+
+  it('returns true for validTokenIds [1,1] + Products standard', () => {
+    const c = makeValidCollection();
+    expect(doesCollectionFollowProductProtocol(c)).toBe(true);
+  });
+
+  it('returns false when Products standard is missing', () => {
+    const c = makeValidCollection();
+    c.standards = ['Subscriptions'];
+    expect(doesCollectionFollowProductProtocol(c)).toBe(false);
+  });
+
+  it('returns false when validTokenIds range is >1 token', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [{ start: 1n, end: 2n }];
+    expect(doesCollectionFollowProductProtocol(c)).toBe(false);
+  });
+
+  it('returns false when validTokenIds has multiple ranges', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [
+      { start: 1n, end: 1n },
+      { start: 2n, end: 2n }
+    ];
+    expect(doesCollectionFollowProductProtocol(c)).toBe(false);
+  });
+
+  it('returns false when validTokenIds does not start at 1 (start=2,end=2)', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [{ start: 2n, end: 2n }];
+    expect(doesCollectionFollowProductProtocol(c)).toBe(false);
+  });
+
+  it('returns false when validTokenIds does not end at 1 (start=1,end=1 is merged from multiple)', () => {
+    // [1,1] after sort+merge is still [1,1] — this must return true.
+    const c = makeValidCollection();
+    c.validTokenIds = [{ start: 1n, end: 1n }];
+    expect(doesCollectionFollowProductProtocol(c)).toBe(true);
+  });
+});
+
+// ===========================================================================
+// isProductApproval — helper function tests
+// ===========================================================================
+
+describe('isProductApproval', () => {
+  const makeValidProductApproval = () =>
+    ({
+      approvalId: 'product',
+      fromListId: 'Mint',
+      toListId: 'All',
+      initiatedByListId: 'All',
+      transferTimes: [{ start: 1n, end: 1000n }],
+      tokenIds: [{ start: 1n, end: 1n }],
+      approvalCriteria: {
+        coinTransfers: [
+          {
+            to: 'bb1seller',
+            coins: [{ denom: 'ubadge', amount: 1000n }],
+            overrideFromWithApproverAddress: false,
+            overrideToWithInitiator: false
+          }
+        ],
+        predeterminedBalances: {
+          incrementedBalances: {
+            startBalances: [
+              {
+                amount: 1n,
+                tokenIds: [{ start: 1n, end: 1n }],
+                ownershipTimes: [{ start: 1n, end: 10000n }]
+              }
+            ],
+            incrementTokenIdsBy: 0n,
+            incrementOwnershipTimesBy: 0n,
+            durationFromTimestamp: 0n,
+            allowOverrideTimestamp: false,
+            allowAmountScaling: false,
+            recurringOwnershipTimes: {
+              startTime: 0n,
+              intervalLength: 0n,
+              chargePeriodLength: 0n
+            }
+          }
+        },
+        merkleChallenges: [],
+        mustOwnTokens: [],
+        requireToEqualsInitiatedBy: false,
+        maxNumTransfers: { overallMaxNumTransfers: 1n }
+      }
+    }) as any;
+
+  it('returns true for a valid product approval', () => {
+    expect(isProductApproval(makeValidProductApproval())).toBe(true);
+  });
+
+  it('returns false when coinTransfers is missing from approvalCriteria', () => {
+    const a = makeValidProductApproval();
+    delete a.approvalCriteria.coinTransfers;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when fromListId is not "Mint"', () => {
+    const a = makeValidProductApproval();
+    a.fromListId = 'bb1other';
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when a merkle challenge has maxUsesPerLeaf != 1', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.merkleChallenges = [
+      { maxUsesPerLeaf: 2n, useCreatorAddressAsLeaf: false }
+    ];
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when a merkle challenge uses creatorAddress as leaf', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.merkleChallenges = [
+      { maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: true }
+    ];
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns true with one acceptable merkle challenge (maxUsesPerLeaf=1, useCreator=false)', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.merkleChallenges = [
+      { maxUsesPerLeaf: 1n, useCreatorAddressAsLeaf: false }
+    ];
+    expect(isProductApproval(a)).toBe(true);
+  });
+
+  it('returns false with >1 coinTransfers', () => {
+    const a = makeValidProductApproval();
+    const ct = a.approvalCriteria.coinTransfers[0];
+    a.approvalCriteria.coinTransfers = [ct, { ...ct }];
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false with 0 coinTransfers', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.coinTransfers = [];
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when coin denom is not "ubadge"', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.coinTransfers[0].coins[0].denom = 'uusdc';
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when coinTransfer has 2 coins', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.coinTransfers[0].coins = [
+      { denom: 'ubadge', amount: 100n },
+      { denom: 'ubadge', amount: 100n }
+    ];
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when overrideFromWithApproverAddress is true', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.coinTransfers[0].overrideFromWithApproverAddress = true;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when overrideToWithInitiator is true', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.coinTransfers[0].overrideToWithInitiator = true;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when incrementedBalances is missing', () => {
+    const a = makeValidProductApproval();
+    delete a.approvalCriteria.predeterminedBalances;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when allowAmountScaling is true', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.allowAmountScaling = true;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when startBalances length != 1', () => {
+    const a = makeValidProductApproval();
+    const sb = a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0];
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances = [sb, { ...sb }];
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when startBalances tokenIds is not [1,1]', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].tokenIds = [
+      { start: 2n, end: 2n }
+    ];
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when startBalances tokenIds size > 1', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].tokenIds = [
+      { start: 1n, end: 2n }
+    ];
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when startBalances amount != 1', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].amount = 2n;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when incrementTokenIdsBy != 0', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementTokenIdsBy = 1n;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when incrementOwnershipTimesBy != 0', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementOwnershipTimesBy = 1n;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when durationFromTimestamp != 0', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.durationFromTimestamp = 1n;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when allowOverrideTimestamp is true', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.allowOverrideTimestamp = true;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when recurringOwnershipTimes.startTime != 0', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.startTime = 10n;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when recurringOwnershipTimes.intervalLength != 0', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.intervalLength = 10n;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when recurringOwnershipTimes.chargePeriodLength != 0', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.chargePeriodLength = 10n;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when requireToEqualsInitiatedBy is true', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.requireToEqualsInitiatedBy = true;
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('returns false when mustOwnTokens is non-empty', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.mustOwnTokens = [
+      { collectionId: 1n, tokenIds: [{ start: 1n, end: 1n }] }
+    ];
+    expect(isProductApproval(a)).toBe(false);
+  });
+
+  it('accepts mustOwnTokens explicitly empty', () => {
+    const a = makeValidProductApproval();
+    a.approvalCriteria.mustOwnTokens = [];
+    expect(isProductApproval(a)).toBe(true);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/core/subscriptions.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/subscriptions.spec.ts
@@ -1,0 +1,684 @@
+/**
+ * Tests for subscriptions.ts — Subscription faucet protocol + helpers.
+ *
+ * Covers:
+ *   - getCurrentInterval
+ *   - trackerNeedsReset
+ *   - getNextChargeTime
+ *   - doesCollectionFollowSubscriptionProtocol
+ *   - isSubscriptionFaucetApproval
+ *   - isUserRecurringApproval
+ */
+
+import {
+  getCurrentInterval,
+  trackerNeedsReset,
+  getNextChargeTime,
+  doesCollectionFollowSubscriptionProtocol,
+  isSubscriptionFaucetApproval,
+  isUserRecurringApproval
+} from './subscriptions.js';
+import { GO_MAX_UINT_64 } from '../common/math.js';
+
+// ---- fixture helpers -----------------------------------------------------
+
+const INTERVAL = 60_000n; // 1-minute subscription window
+const CHARGE = 30_000n;
+
+const makeFaucetApproval = () =>
+  ({
+    approvalId: 'faucet',
+    fromListId: 'Mint',
+    toListId: 'All',
+    initiatedByListId: 'All',
+    transferTimes: [{ start: 1n, end: 1000n }],
+    tokenIds: [{ start: 1n, end: 1n }],
+    approvalCriteria: {
+      coinTransfers: [
+        {
+          to: 'bb1seller',
+          coins: [{ denom: 'ubadge', amount: 100n }],
+          overrideFromWithApproverAddress: false,
+          overrideToWithInitiator: false
+        }
+      ],
+      predeterminedBalances: {
+        incrementedBalances: {
+          startBalances: [
+            {
+              amount: 1n,
+              tokenIds: [{ start: 1n, end: 1n }],
+              ownershipTimes: [{ start: 1n, end: 10000n }]
+            }
+          ],
+          incrementTokenIdsBy: 0n,
+          incrementOwnershipTimesBy: 0n,
+          durationFromTimestamp: INTERVAL,
+          allowOverrideTimestamp: true,
+          allowAmountScaling: false,
+          recurringOwnershipTimes: {
+            startTime: 0n,
+            intervalLength: 0n,
+            chargePeriodLength: 0n
+          }
+        }
+      },
+      merkleChallenges: [],
+      requireFromEqualsInitiatedBy: false,
+      requireToEqualsInitiatedBy: false,
+      overridesToIncomingApprovals: false
+    }
+  }) as any;
+
+const makeUserRecurringApproval = () =>
+  ({
+    approvalId: 'user-recurring',
+    fromListId: 'Mint',
+    toListId: 'All',
+    initiatedByListId: 'All',
+    transferTimes: [{ start: 1n, end: 1000n }],
+    tokenIds: [{ start: 1n, end: 1n }],
+    approvalCriteria: {
+      coinTransfers: [
+        {
+          to: 'bb1seller',
+          coins: [{ denom: 'ubadge', amount: 100n }],
+          overrideFromWithApproverAddress: true,
+          overrideToWithInitiator: true
+        }
+      ],
+      predeterminedBalances: {
+        incrementedBalances: {
+          startBalances: [
+            {
+              amount: 1n,
+              tokenIds: [{ start: 1n, end: 1n }],
+              ownershipTimes: [{ start: 1n, end: 10000n }]
+            }
+          ],
+          incrementTokenIdsBy: 0n,
+          incrementOwnershipTimesBy: 0n,
+          durationFromTimestamp: 0n,
+          allowOverrideTimestamp: false,
+          allowAmountScaling: false,
+          recurringOwnershipTimes: {
+            startTime: 0n,
+            intervalLength: INTERVAL,
+            chargePeriodLength: INTERVAL < 604800000n ? INTERVAL : 604800000n
+          }
+        }
+      },
+      merkleChallenges: [],
+      mustOwnTokens: [],
+      requireFromEqualsInitiatedBy: false,
+      maxNumTransfers: {
+        overallMaxNumTransfers: 1n,
+        resetTimeIntervals: { startTime: 0n, intervalLength: INTERVAL }
+      }
+    }
+  }) as any;
+
+const makeValidCollection = () => ({
+  standards: ['Subscriptions'],
+  validTokenIds: [{ start: 1n, end: 1n }],
+  collectionApprovals: [makeFaucetApproval()]
+});
+
+// ===========================================================================
+// getCurrentInterval
+// ===========================================================================
+
+describe('getCurrentInterval', () => {
+  it('returns [1, max] when resetTimeIntervals is undefined', () => {
+    expect(getCurrentInterval(undefined)).toEqual({ start: 1n, end: GO_MAX_UINT_64 });
+  });
+
+  it('returns [1, max] when startTime is 0n', () => {
+    expect(getCurrentInterval({ startTime: 0n, intervalLength: 60_000n } as any)).toEqual({
+      start: 1n,
+      end: GO_MAX_UINT_64
+    });
+  });
+
+  it('returns [1, max] when intervalLength is 0n', () => {
+    expect(getCurrentInterval({ startTime: 1n, intervalLength: 0n } as any)).toEqual({
+      start: 1n,
+      end: GO_MAX_UINT_64
+    });
+  });
+
+  it('returns pre-start interval [1, startTime-1] when now < startTime', () => {
+    // Place startTime far in the future to ensure we're in the pre-start window.
+    const future = BigInt(Date.now()) + 10n * 365n * 24n * 60n * 60n * 1000n; // +10 years
+    expect(getCurrentInterval({ startTime: future, intervalLength: 60_000n } as any)).toEqual({
+      start: 1n,
+      end: future - 1n
+    });
+  });
+
+  it('returns the current interval window when now >= startTime', () => {
+    const now = BigInt(Date.now());
+    const startTime = now - 90_000n; // 1.5 intervals ago
+    const intervalLength = 60_000n;
+    const r = getCurrentInterval({ startTime, intervalLength } as any);
+
+    // currInterval = (now - startTime) / intervalLength — integer division.
+    const currIntervalIdx = (now - startTime) / intervalLength;
+    expect(r.start).toBe(startTime + currIntervalIdx * intervalLength);
+    expect(r.end).toBe(r.start + intervalLength);
+  });
+
+  it('start+intervalLength == end (interval is exactly intervalLength wide)', () => {
+    const now = BigInt(Date.now());
+    const startTime = now - 10_000n; // just past startTime
+    const intervalLength = 60_000n;
+    const r = getCurrentInterval({ startTime, intervalLength } as any);
+    expect(r.end - r.start).toBe(intervalLength);
+  });
+});
+
+// ===========================================================================
+// trackerNeedsReset
+// ===========================================================================
+
+describe('trackerNeedsReset', () => {
+  it('returns true when lastUpdatedAt is earlier than current interval start', () => {
+    const now = BigInt(Date.now());
+    const startTime = now - 120_000n; // 2 intervals ago
+    const intervalLength = 60_000n;
+    // lastUpdatedAt was before the interval that contains `now`.
+    expect(trackerNeedsReset({ startTime, intervalLength } as any, 1n)).toBe(true);
+  });
+
+  it('returns false when lastUpdatedAt is within the current interval', () => {
+    const now = BigInt(Date.now());
+    const startTime = now - 10_000n;
+    const intervalLength = 60_000n;
+    expect(trackerNeedsReset({ startTime, intervalLength } as any, now)).toBe(false);
+  });
+
+  it('returns false when there are no resets (startTime=0, intervalLength=0) and lastUpdatedAt >= 1n', () => {
+    // getCurrentInterval returns { start: 1n, end: max } in this degenerate case.
+    expect(trackerNeedsReset({ startTime: 0n, intervalLength: 0n } as any, 1n)).toBe(false);
+    expect(trackerNeedsReset({ startTime: 0n, intervalLength: 0n } as any, 100n)).toBe(false);
+  });
+
+  it('returns true when lastUpdatedAt is 0n and start is 1n (degenerate interval)', () => {
+    expect(trackerNeedsReset({ startTime: 0n, intervalLength: 0n } as any, 0n)).toBe(true);
+  });
+});
+
+// ===========================================================================
+// getNextChargeTime
+// ===========================================================================
+
+describe('getNextChargeTime', () => {
+  it('returns a deterministic value when predeterminedBalances is undefined', () => {
+    // undefined -> getCurrentInterval called with {0n,0n} -> [1, MAX], chargePeriod=0 -> MAX+1
+    const r = getNextChargeTime(undefined);
+    expect(r).toBe(GO_MAX_UINT_64 + 1n);
+  });
+
+  it('handles empty incrementedBalances recurringOwnershipTimes (all zeros)', () => {
+    // With all zeros, getCurrentInterval returns [1, MAX]. nextInterval.start = MAX + 1.
+    // charge = 0, so nextCharge = MAX + 1 - 0 = MAX + 1.
+    const pb = {
+      incrementedBalances: {
+        recurringOwnershipTimes: { startTime: 0n, intervalLength: 0n, chargePeriodLength: 0n }
+      }
+    } as any;
+    expect(getNextChargeTime(pb)).toBe(GO_MAX_UINT_64 + 1n);
+  });
+
+  it('computes next charge time for a real recurring schedule', () => {
+    const now = BigInt(Date.now());
+    const startTime = now - 30_000n;
+    const intervalLength = 60_000n;
+    const chargePeriodLength = 10_000n;
+
+    const pb = {
+      incrementedBalances: {
+        recurringOwnershipTimes: { startTime, intervalLength, chargePeriodLength }
+      }
+    } as any;
+
+    const currInterval = getCurrentInterval({ startTime, intervalLength } as any);
+    const expectedNextStart = currInterval.end + 1n;
+    const expectedChargeTime = expectedNextStart - chargePeriodLength;
+
+    expect(getNextChargeTime(pb)).toBe(expectedChargeTime);
+  });
+});
+
+// ===========================================================================
+// isSubscriptionFaucetApproval
+// ===========================================================================
+
+describe('isSubscriptionFaucetApproval', () => {
+  it('returns true for a valid faucet approval', () => {
+    expect(isSubscriptionFaucetApproval(makeFaucetApproval())).toBe(true);
+  });
+
+  it('returns false when fromListId != "Mint"', () => {
+    const a = makeFaucetApproval();
+    a.fromListId = 'bb1other';
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when coinTransfers is undefined', () => {
+    const a = makeFaucetApproval();
+    delete a.approvalCriteria.coinTransfers;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when coinTransfers has length 0', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.coinTransfers = [];
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when coinTransfers use multiple denoms', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.coinTransfers = [
+      {
+        to: 'bb1a',
+        coins: [{ denom: 'ubadge', amount: 100n }],
+        overrideFromWithApproverAddress: false,
+        overrideToWithInitiator: false
+      },
+      {
+        to: 'bb1b',
+        coins: [{ denom: 'uusdc', amount: 100n }],
+        overrideFromWithApproverAddress: false,
+        overrideToWithInitiator: false
+      }
+    ];
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns true when multiple coinTransfers share a single denom', () => {
+    const a = makeFaucetApproval();
+    const existing = a.approvalCriteria.coinTransfers[0];
+    a.approvalCriteria.coinTransfers = [existing, { ...existing }];
+    expect(isSubscriptionFaucetApproval(a)).toBe(true);
+  });
+
+  it('returns false when overrideFromWithApproverAddress is true', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.coinTransfers[0].overrideFromWithApproverAddress = true;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when overrideToWithInitiator is true', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.coinTransfers[0].overrideToWithInitiator = true;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when incrementedBalances is missing', () => {
+    const a = makeFaucetApproval();
+    delete a.approvalCriteria.predeterminedBalances;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when startBalances.length != 1', () => {
+    const a = makeFaucetApproval();
+    const sb = a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0];
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances = [sb, { ...sb }];
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when approval.tokenIds size > 1', () => {
+    const a = makeFaucetApproval();
+    a.tokenIds = [{ start: 1n, end: 2n }];
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when startBalances tokenIds size > 1', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].tokenIds = [
+      { start: 1n, end: 2n }
+    ];
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when startBalances amount != 1', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].amount = 2n;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when incrementTokenIdsBy != 0', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementTokenIdsBy = 1n;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when incrementOwnershipTimesBy != 0', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementOwnershipTimesBy = 1n;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when durationFromTimestamp is 0 (faucet MUST set a duration)', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.durationFromTimestamp = 0n;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when allowOverrideTimestamp is false', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.allowOverrideTimestamp = false;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when allowAmountScaling is true', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.allowAmountScaling = true;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when recurringOwnershipTimes.startTime != 0', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.startTime = 1n;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when recurringOwnershipTimes.intervalLength != 0', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.intervalLength = 1n;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when recurringOwnershipTimes.chargePeriodLength != 0', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.chargePeriodLength = 1n;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when requireFromEqualsInitiatedBy is true', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.requireFromEqualsInitiatedBy = true;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when requireToEqualsInitiatedBy is true', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.requireToEqualsInitiatedBy = true;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when overridesToIncomingApprovals is true', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.overridesToIncomingApprovals = true;
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns false when any merkleChallenge is present', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.merkleChallenges = [{ challengeTrackerId: 'x' }];
+    expect(isSubscriptionFaucetApproval(a)).toBe(false);
+  });
+
+  it('returns true with empty merkleChallenges array', () => {
+    const a = makeFaucetApproval();
+    a.approvalCriteria.merkleChallenges = [];
+    expect(isSubscriptionFaucetApproval(a)).toBe(true);
+  });
+});
+
+// ===========================================================================
+// doesCollectionFollowSubscriptionProtocol
+// ===========================================================================
+
+describe('doesCollectionFollowSubscriptionProtocol', () => {
+  it('returns false for undefined collection', () => {
+    expect(doesCollectionFollowSubscriptionProtocol(undefined)).toBe(false);
+  });
+
+  it('returns true for a valid subscription collection', () => {
+    expect(doesCollectionFollowSubscriptionProtocol(makeValidCollection() as any)).toBe(true);
+  });
+
+  it('returns false when zero subscription faucet approvals are present', () => {
+    const c = makeValidCollection();
+    c.collectionApprovals = [];
+    expect(doesCollectionFollowSubscriptionProtocol(c as any)).toBe(false);
+  });
+
+  it('returns false when the "Subscriptions" standard is missing', () => {
+    const c = makeValidCollection();
+    c.standards = ['Other'];
+    expect(doesCollectionFollowSubscriptionProtocol(c as any)).toBe(false);
+  });
+
+  it('returns false when validTokenIds has more than one range', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [
+      { start: 1n, end: 1n },
+      { start: 3n, end: 3n }
+    ];
+    expect(doesCollectionFollowSubscriptionProtocol(c as any)).toBe(false);
+  });
+
+  it('returns false when subscription approvals span multiple non-contiguous token ranges', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [{ start: 1n, end: 3n }];
+    const a1 = makeFaucetApproval();
+    const a2 = makeFaucetApproval();
+    a1.tokenIds = [{ start: 1n, end: 1n }];
+    a2.tokenIds = [{ start: 3n, end: 3n }];
+    c.collectionApprovals = [a1, a2];
+    // Two ranges [1,1] + [3,3] do not merge — returns length != 1.
+    expect(doesCollectionFollowSubscriptionProtocol(c as any)).toBe(false);
+  });
+
+  it('returns false when validTokenIds range does not match subscription approval coverage', () => {
+    const c = makeValidCollection();
+    c.validTokenIds = [{ start: 1n, end: 2n }];
+    // Single faucet approval only covers token 1 — range mismatch.
+    expect(doesCollectionFollowSubscriptionProtocol(c as any)).toBe(false);
+  });
+
+  it('accepts multi-standard including Subscriptions', () => {
+    const c = makeValidCollection();
+    c.standards = ['Subscriptions', 'Other'];
+    expect(doesCollectionFollowSubscriptionProtocol(c as any)).toBe(true);
+  });
+});
+
+// ===========================================================================
+// isUserRecurringApproval
+// ===========================================================================
+
+describe('isUserRecurringApproval', () => {
+  const coreSubscription = makeFaucetApproval();
+
+  it('returns true for a valid user recurring approval', () => {
+    expect(isUserRecurringApproval(makeUserRecurringApproval(), coreSubscription)).toBe(true);
+  });
+
+  it('returns false when fromListId != "Mint"', () => {
+    const a = makeUserRecurringApproval();
+    a.fromListId = 'bb1other';
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when approvalAmount < subscriptionAmount', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.coinTransfers[0].coins[0].amount = 50n; // subscription wants 100n
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns true when approvalAmount > subscriptionAmount (user can tip)', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.coinTransfers[0].coins[0].amount = 200n;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(true);
+  });
+
+  it('returns false when tokenIds do not match subscription tokenIds (length)', () => {
+    const a = makeUserRecurringApproval();
+    a.tokenIds = [
+      { start: 1n, end: 1n },
+      { start: 2n, end: 2n }
+    ];
+    // Length mismatch vs subscription, and early-rejected by the size(>1) check too.
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when tokenIds start differs from subscription', () => {
+    const a = makeUserRecurringApproval();
+    a.tokenIds = [{ start: 2n, end: 2n }];
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when denom mismatches subscription', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.coinTransfers[0].coins[0].denom = 'uusdc';
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when there are 2 coinTransfers', () => {
+    const a = makeUserRecurringApproval();
+    const ct = a.approvalCriteria.coinTransfers[0];
+    a.approvalCriteria.coinTransfers = [ct, { ...ct }];
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when coinTransfer has 2 coins', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.coinTransfers[0].coins = [
+      { denom: 'ubadge', amount: 100n },
+      { denom: 'ubadge', amount: 100n }
+    ];
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when overrideFromWithApproverAddress is false', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.coinTransfers[0].overrideFromWithApproverAddress = false;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when overrideToWithInitiator is false', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.coinTransfers[0].overrideToWithInitiator = false;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when incrementedBalances is missing', () => {
+    const a = makeUserRecurringApproval();
+    delete a.approvalCriteria.predeterminedBalances;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when startBalances.length != 1', () => {
+    const a = makeUserRecurringApproval();
+    const sb = a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0];
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances = [sb, { ...sb }];
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when startBalances amount != 1', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].amount = 2n;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when startBalances tokenIds range size > 1', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.startBalances[0].tokenIds = [
+      { start: 1n, end: 2n }
+    ];
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when incrementTokenIdsBy != 0', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementTokenIdsBy = 1n;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when incrementOwnershipTimesBy != 0', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.incrementOwnershipTimesBy = 1n;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when durationFromTimestamp != 0', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.durationFromTimestamp = 1n;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when allowOverrideTimestamp is true', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.allowOverrideTimestamp = true;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when recurringOwnershipTimes.intervalLength mismatches subscription', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.intervalLength =
+      INTERVAL + 1n;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when recurringOwnershipTimes.chargePeriodLength mismatches subscription', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.chargePeriodLength =
+      1n;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when overallMaxNumTransfers != 1', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.maxNumTransfers.overallMaxNumTransfers = 2n;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when maxNumTransfers.resetTimeIntervals.intervalLength mismatches subscription', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.maxNumTransfers.resetTimeIntervals.intervalLength = INTERVAL + 1n;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when requireFromEqualsInitiatedBy is true', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.requireFromEqualsInitiatedBy = true;
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when merkleChallenges is non-empty', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.merkleChallenges = [{ id: 'x' }];
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('returns false when mustOwnTokens is non-empty', () => {
+    const a = makeUserRecurringApproval();
+    a.approvalCriteria.mustOwnTokens = [
+      { collectionId: 1n, tokenIds: [{ start: 1n, end: 1n }] }
+    ];
+    expect(isUserRecurringApproval(a, coreSubscription)).toBe(false);
+  });
+
+  it('caps chargePeriodLength at the 7-day ceiling (604_800_000 ms) for long intervals', () => {
+    // Build a subscription with interval > 7 days.
+    const longIntervalSubscription = makeFaucetApproval();
+    const longInterval = 604_800_001n;
+    longIntervalSubscription.approvalCriteria.predeterminedBalances.incrementedBalances.durationFromTimestamp =
+      longInterval;
+
+    // User approval matching with chargePeriodLength = 604_800_000 ms.
+    const userApproval = makeUserRecurringApproval();
+    userApproval.approvalCriteria.coinTransfers[0].coins[0].amount = 100n;
+    userApproval.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.intervalLength =
+      longInterval;
+    userApproval.approvalCriteria.predeterminedBalances.incrementedBalances.recurringOwnershipTimes.chargePeriodLength =
+      604_800_000n;
+    userApproval.approvalCriteria.maxNumTransfers.resetTimeIntervals.intervalLength = longInterval;
+
+    expect(isUserRecurringApproval(userApproval, longIntervalSubscription)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for two previously-untested files in `packages/bitbadgesjs-sdk/src/core/`:

- **products.ts** (280 lines, 3 exports, 0 tests) → 97 new tests
- **subscriptions.ts** (328 lines, 6 exports, 0 tests) → 74 new tests

All tests pass. No production code was changed.

### Coverage added

**products.spec.ts** (97 tests)

- `validateProductCatalogCollection` — happy path (single + multi-product + burn approval present), standards check, validTokenIds start-at-1 rule, invariants warning vs. error, purchase-approval rules (toListId must be "All"/burn, initiatedByListId must be "All", override flags required, tokenIds must be size=1, coinTransfers must be length=1 with 1 coin and amount>0, no `overrideFromWithApproverAddress`/`overrideToWithInitiator`, predeterminedBalances with startBalance.amount=1, maxNumTransfers required, no merkle/voting/dynamicStore challenges), burn-approval rules, multi-error aggregation with 1-based approval indexing, `details.productCount` + `details.hasBurnApproval` counters
- `doesCollectionFollowProductCatalogProtocol` wrapper (truthy/falsy/undefined)
- `doesCollectionFollowProductProtocol` legacy single-product check
- `isProductApproval` — every single reject branch (20+ conditions covering fromListId, merkle leaf config, coin count/denom/override flags, incrementedBalances shape and all zero-value invariants, requireToEqualsInitiatedBy, mustOwnTokens)

**subscriptions.spec.ts** (74 tests)

- `getCurrentInterval` — undefined/zero-length/pre-start/post-start cases with interval-width invariant
- `trackerNeedsReset` — within vs. outside current interval
- `getNextChargeTime` — undefined, all-zero, real recurring schedule
- `isSubscriptionFaucetApproval` — every reject condition (fromListId, coinTransfer shape, multi-denom rejection but multi-transfer same-denom accepted, overrides, incrementedBalances invariants, durationFromTimestamp required > 0, allowOverrideTimestamp required true, recurring-time fields must be zero, require-equals flags, overridesToIncoming, merkle challenges)
- `doesCollectionFollowSubscriptionProtocol` — undefined, happy path, zero faucets, missing standard, multi-range validTokenIds, non-contiguous approval tokens, tokenId coverage mismatch, multi-standard accepted
- `isUserRecurringApproval` — every reject condition including tokenId-start mismatch, denom mismatch, tip (approvalAmount > subscriptionAmount accepted), 7-day chargePeriodLength ceiling for long intervals

### Test plan

- [x] `npx jest src/core/products.spec.ts` → 97 passed
- [x] `npx jest src/core/subscriptions.spec.ts` → 74 passed
- [x] Full `npm test` → 56 suites / 1933 tests passing

Part of the daily SDK core/** coverage sweep — continues the work landed in #156 (core protocol validators) and #154 (builder + utilities).

Implements backlog #0247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)