### PR TITLE
docs(sdk): clean up BitBadgesAPI JSDoc stray fragment (backlog #0254)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/api-indexer/BitBadgesApi.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/BitBadgesApi.ts
@@ -293,12 +293,11 @@ import { DeleteConnectedAccountSuccessResponse, GetConnectedAccountsSuccessRespo
 /**
  * This is the BitBadgesAPI class which provides all typed API calls to the BitBadges API.
  * See official documentation for more details and examples. Must pass in a valid API key.
- *,
-  iGetDeveloperAppsPayload
+ *
  * convertFunction is used to convert any responses returned by the API to your desired NumberType.
  * ```typescript
  * import { BigIntify, Stringify, Numberify, BitBadgesAPI } from "bitbadges";
- * const BitBadgesApi = new BitBadgesAPI({ convertFunction: BigIntify, ....})
+ * const BitBadgesApi = new BitBadgesAPI({ convertFunction: BigIntify, apiKey: '...' });
  * const collections = await BitBadgesApi.getCollections(...);
  * ```
  *


### PR DESCRIPTION
## Summary

The class-level JSDoc for `BitBadgesAPI` in `src/api-indexer/BitBadgesApi.ts` contained a stray merge artifact (`*,` / `iGetDeveloperAppsPayload`) that was rendering as garbled description text on the published TypeDoc site and in every IDE hover tooltip for the class.

- Removed the stray `*, iGetDeveloperAppsPayload` fragment
- Fixed the `....})` (four dots) typo in the JSDoc code example — now shows a proper `apiKey: '...'` placeholder

Found by the friction-hunter agent walking the onboarding path as a new frontend dev (clicked from docs "SDK Reference" TypeDoc link). See backlog #0254 for full friction report.

## Test plan

- [x] JSDoc renders cleanly (no stray comma-fragment) on hover
- [ ] Re-run `npm run docs` and confirm the TypeDoc HTML for `BitBadgesAPI` no longer shows the fragment in the description
- [ ] `npm run build` passes

Implements backlog #0254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)