### PR TITLE
feat(builder): add redeem_claim MCP tool (5 calls -> 1) (#0256)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/builder/resources/recipes.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/resources/recipes.ts
@@ -320,6 +320,52 @@ async function verifyAccess(userAddress: string): Promise<boolean> {
 // });`
   },
   {
+    id: 'redeem-code-gated-claim',
+    name: 'Redeem a Code-Gated Claim (one-shot)',
+    description:
+      'Complete a claim on behalf of a user and, for on-chain gated claims, get back a ready-to-sign MsgTransferTokens — all in a single MCP tool call.',
+    tags: ['claim', 'redeem', 'code-gated', 'merkle', 'agents'],
+    code: `// Redeem a claim in one call. Collapses the 5-step flow from the docs
+// (completeClaim -> poll status -> getReservedClaimCodes ->
+// getMerkleProofInfo -> hand-stitch MsgTransferTokens) into one tool call.
+//
+// Use flat verbs (\`code\`, \`password\`, \`whitelist\`) — redeem_claim
+// auto-maps them onto the plugin instanceId the claim was created with.
+//
+// Standalone (off-chain) claim:
+redeem_claim({
+  claimId: "abc123",
+  address: "bb1user...",
+  inputs: { code: "xyz" }
+})
+// → { success: true, claimAttemptId, code?, onChain: false }
+//
+// On-chain gated claim (auto-builds MsgTransferTokens):
+redeem_claim({
+  claimId: "abc123",
+  address: "bb1user...",
+  inputs: { code: "xyz" }
+})
+// → { success: true, claimAttemptId, code, onChain: true,
+//     transaction: { messages: [MsgTransferTokens{...}], memo, fee } }
+//
+// The returned transaction is the same shape build_transfer emits, so:
+const redeem = await redeem_claim({ claimId, address, inputs: { code } });
+if (redeem.transaction) {
+  await simulate_transaction({ transaction: redeem.transaction });
+  // then hand transaction to the user to sign + broadcast
+}
+//
+// Opt out of the transfer build (e.g. to batch with other messages):
+redeem_claim({ claimId, address, inputs: { code }, returnTransfer: false });
+//
+// Power-user: pass the full per-instanceId body instead of flat verbs:
+redeem_claim({
+  claimId, address,
+  inputs: { "codes-gate-custom-id": { code: "xyz" } }
+});`
+  },
+  {
     id: 'bounty-escrow',
     name: 'Bounty Escrow Pattern',
     description: 'Create a bounty with escrow, verifier arbitration, and expiration',

--- a/packages/bitbadgesjs-sdk/src/builder/sdk/apiClient.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/sdk/apiClient.ts
@@ -352,3 +352,160 @@ export async function searchPlugins(
   const endpoint = `/api/v0/plugins/search${queryString ? `?${queryString}` : ''}`;
   return apiRequest<SearchPluginsResponse>(endpoint, 'GET', undefined, config);
 }
+
+// ============================================
+// Claim Redemption APIs
+// ============================================
+//
+// Thin wrappers over the four indexer endpoints the `redeem_claim` MCP tool
+// orchestrates. Each mirrors the `BitBadgesApi.*` method name so that an
+// agent that previously pieced together the raw flow (see
+// `bitbadges-docs/for-developers/ai-agents/claims-for-agents.md`) can follow
+// the same verbs here if they need to bypass the one-shot tool.
+
+/**
+ * Minimal claim details shape used by `redeem_claim` to discover plugin
+ * `instanceId`s and any linked on-chain collection/tracker details. We use
+ * an ad-hoc local interface here (instead of importing `iClaimDetails` from
+ * the full SDK types) to keep the builder module free of bigint/NumberType
+ * machinery — it just needs the fields the MCP tool branches on.
+ */
+export interface ClaimPluginSummary {
+  pluginId: string;
+  instanceId: string;
+  [key: string]: unknown;
+}
+
+export interface ClaimTrackerDetails {
+  collectionId: string | number | bigint;
+  approvalId: string;
+  challengeTrackerId: string;
+  approvalLevel: 'collection' | 'incoming' | 'outgoing' | '';
+  approverAddress: string;
+}
+
+export interface ClaimSummary {
+  claimId: string;
+  standaloneClaim?: boolean;
+  collectionId?: string | number | bigint;
+  trackerDetails?: ClaimTrackerDetails;
+  plugins: ClaimPluginSummary[];
+  [key: string]: unknown;
+}
+
+export interface GetClaimsResponse {
+  claims: ClaimSummary[];
+  bookmark?: string;
+}
+
+export async function getClaims(
+  claimIds: string[],
+  config?: ApiClientConfig
+): Promise<ApiResponse<GetClaimsResponse>> {
+  return apiRequest<GetClaimsResponse>(
+    '/api/v1/claims/fetch',
+    'POST',
+    { claimsToFetch: claimIds.map((claimId) => ({ claimId })) },
+    config
+  );
+}
+
+export interface CompleteClaimResponse {
+  claimAttemptId: string;
+}
+
+export async function completeClaim(
+  claimId: string,
+  address: string,
+  payload: Record<string, unknown>,
+  config?: ApiClientConfig
+): Promise<ApiResponse<CompleteClaimResponse>> {
+  return apiRequest<CompleteClaimResponse>(
+    `/api/v0/claims/complete/${claimId}/${address}`,
+    'POST',
+    payload,
+    config
+  );
+}
+
+export interface ClaimAttemptStatusResponse {
+  success: boolean;
+  error: string;
+  /** The on-chain code. Only provided for on-chain token claims. */
+  code?: string;
+  bitbadgesAddress: string;
+}
+
+export async function getClaimAttemptStatus(
+  claimAttemptId: string,
+  config?: ApiClientConfig
+): Promise<ApiResponse<ClaimAttemptStatusResponse>> {
+  return apiRequest<ClaimAttemptStatusResponse>(
+    `/api/v0/claims/status/${claimAttemptId}`,
+    'POST',
+    {},
+    config
+  );
+}
+
+export interface ReservedClaimCodesResponse {
+  reservedCodes?: string[];
+  leafSignatures?: string[];
+}
+
+export async function getReservedClaimCodes(
+  claimId: string,
+  address: string,
+  config?: ApiClientConfig
+): Promise<ApiResponse<ReservedClaimCodesResponse>> {
+  return apiRequest<ReservedClaimCodesResponse>(
+    `/api/v0/claims/reserved/${claimId}/${address}`,
+    'POST',
+    {},
+    config
+  );
+}
+
+export interface MerkleProofAunt {
+  aunt: string;
+  onRight: boolean;
+}
+
+export interface MerkleProofInfoDetail {
+  proofObj: MerkleProofAunt[];
+  isValidProof: boolean;
+  leafIndex: number;
+  leaf: string;
+}
+
+export interface MerkleProofInfoResponse {
+  allProofDetails: MerkleProofInfoDetail[];
+}
+
+export interface GetMerkleProofInfoRequest {
+  collectionId: string | number | bigint;
+  approvalId: string;
+  approvalLevel: 'collection' | 'incoming' | 'outgoing' | '';
+  approverAddress: string;
+  leaves: string[];
+  challengeTrackerId: string;
+  bitbadgesAddress?: string;
+  claimCodes?: string[];
+}
+
+export async function getMerkleProofInfo(
+  request: GetMerkleProofInfoRequest,
+  config?: ApiClientConfig
+): Promise<ApiResponse<MerkleProofInfoResponse>> {
+  // The indexer accepts bigint/number/string for collectionId but expects
+  // it serialized as-is. Stringify defensively so we don't surface
+  // `TypeError: Do not know how to serialize a BigInt` on JSON.stringify.
+  const collectionId =
+    typeof request.collectionId === 'bigint' ? request.collectionId.toString() : request.collectionId;
+  return apiRequest<MerkleProofInfoResponse>(
+    '/api/v0/merkleProofInfo',
+    'POST',
+    { ...request, collectionId },
+    config
+  );
+}

--- a/packages/bitbadgesjs-sdk/src/builder/tools/builders/index.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/builders/index.ts
@@ -4,4 +4,5 @@
 
 export * from './explainCollection.js';
 export * from './buildClaim.js';
+export * from './redeemClaim.js';
 export * from './reviewCollection.js';

--- a/packages/bitbadgesjs-sdk/src/builder/tools/builders/redeemClaim.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/builders/redeemClaim.spec.ts
@@ -1,0 +1,485 @@
+/**
+ * Tests for `redeem_claim` — the one-shot MCP tool that collapses the
+ * 5-call claim-redemption flow (completeClaim → poll status →
+ * getReservedClaimCodes → getMerkleProofInfo → hand-stitch
+ * MsgTransferTokens) into a single tool call.
+ *
+ * We mock `apiClient.js` module-level to intercept all five endpoints and
+ * assert:
+ *   1. Flat verb (`code`) auto-maps onto the right plugin instanceId
+ *   2. Polling continues until terminal `success: true` or `error` fires
+ *   3. Standalone claims (no trackerDetails) short-circuit after polling
+ *   4. On-chain claims auto-fetch reserved codes + merkle proof and
+ *      return a MsgTransferTokens matching build_transfer's shape
+ *   5. Failure modes (unknown plugin input, polling timeout,
+ *      missing reserved code) surface as structured errors
+ */
+
+import { redeemClaimSchema, handleRedeemClaim, redeemClaimTool } from './redeemClaim.js';
+
+const getClaimsMock = jest.fn();
+const completeClaimMock = jest.fn();
+const getClaimAttemptStatusMock = jest.fn();
+const getReservedClaimCodesMock = jest.fn();
+const getMerkleProofInfoMock = jest.fn();
+
+jest.mock('../../sdk/apiClient.js', () => ({
+  getClaims: (...args: unknown[]) => getClaimsMock(...args),
+  completeClaim: (...args: unknown[]) => completeClaimMock(...args),
+  getClaimAttemptStatus: (...args: unknown[]) => getClaimAttemptStatusMock(...args),
+  getReservedClaimCodes: (...args: unknown[]) => getReservedClaimCodesMock(...args),
+  getMerkleProofInfo: (...args: unknown[]) => getMerkleProofInfoMock(...args)
+}));
+
+const MAX_UINT64 = '18446744073709551615';
+const USER_ADDR = 'bb1qq0yvpj9sjvflklk67gnhpdxplxdzsgp30kfe6';
+
+function defaultClaim(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    claimId: 'claim-1',
+    plugins: [
+      { pluginId: 'numUses', instanceId: 'numUses' },
+      { pluginId: 'codes', instanceId: 'codes-gate' }
+    ],
+    standaloneClaim: true,
+    ...overrides
+  };
+}
+
+function onChainClaim(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    claimId: 'claim-1',
+    plugins: [
+      { pluginId: 'numUses', instanceId: 'numUses' },
+      { pluginId: 'codes', instanceId: 'codes-gate' }
+    ],
+    standaloneClaim: false,
+    collectionId: '42',
+    trackerDetails: {
+      collectionId: '42',
+      approvalId: 'mint-approval',
+      approvalLevel: 'collection',
+      approverAddress: '',
+      challengeTrackerId: 'tracker-1'
+    },
+    ...overrides
+  };
+}
+
+describe('redeem_claim — schema', () => {
+  it('accepts minimum inputs', () => {
+    const parsed = redeemClaimSchema.safeParse({
+      claimId: 'claim-1',
+      address: 'bb1abc'
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts full inputs including pollTimeoutMs, expectedVersion, returnTransfer', () => {
+    const parsed = redeemClaimSchema.safeParse({
+      claimId: 'claim-1',
+      address: 'bb1abc',
+      inputs: { code: 'xyz' },
+      expectedVersion: 3,
+      pollTimeoutMs: 10_000,
+      returnTransfer: false
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects missing claimId', () => {
+    const parsed = redeemClaimSchema.safeParse({ address: 'bb1abc' });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects negative pollTimeoutMs', () => {
+    const parsed = redeemClaimSchema.safeParse({
+      claimId: 'c',
+      address: 'bb1abc',
+      pollTimeoutMs: -1
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('redeem_claim — tool schema', () => {
+  it('exposes the expected name and required fields', () => {
+    expect(redeemClaimTool.name).toBe('redeem_claim');
+    expect(redeemClaimTool.inputSchema.required).toEqual(['claimId', 'address']);
+  });
+});
+
+describe('redeem_claim — happy paths', () => {
+  beforeEach(() => {
+    [
+      getClaimsMock,
+      completeClaimMock,
+      getClaimAttemptStatusMock,
+      getReservedClaimCodesMock,
+      getMerkleProofInfoMock
+    ].forEach((m) => m.mockReset());
+  });
+
+  it('standalone claim: flat `code` maps to instanceId + stops after polling', async () => {
+    getClaimsMock.mockResolvedValue({ success: true, data: { claims: [defaultClaim()] } });
+    completeClaimMock.mockResolvedValue({ success: true, data: { claimAttemptId: 'att-1' } });
+    // First poll: still pending. Second: success.
+    getClaimAttemptStatusMock
+      .mockResolvedValueOnce({
+        success: true,
+        data: { success: false, error: '', bitbadgesAddress: USER_ADDR }
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: { success: true, error: '', bitbadgesAddress: USER_ADDR }
+      });
+
+    const res = await handleRedeemClaim({
+      claimId: 'claim-1',
+      address: USER_ADDR,
+      inputs: { code: 'xyz' },
+      pollTimeoutMs: 5_000
+    });
+
+    expect(res.success).toBe(true);
+    expect(res.claimAttemptId).toBe('att-1');
+    expect(res.onChain).toBe(false);
+    expect(res.transaction).toBeUndefined();
+
+    // Verify completeClaim received the instanceId-keyed body, NOT the flat verb
+    const [, , payload] = completeClaimMock.mock.calls[0];
+    expect(payload).toEqual({
+      _expectedVersion: -1,
+      'codes-gate': { code: 'xyz' }
+    });
+    // We did NOT call the on-chain endpoints
+    expect(getReservedClaimCodesMock).not.toHaveBeenCalled();
+    expect(getMerkleProofInfoMock).not.toHaveBeenCalled();
+  });
+
+  it('on-chain claim: fetches reserved codes + merkle proof + returns MsgTransferTokens', async () => {
+    getClaimsMock.mockResolvedValue({ success: true, data: { claims: [onChainClaim()] } });
+    completeClaimMock.mockResolvedValue({ success: true, data: { claimAttemptId: 'att-2' } });
+    getClaimAttemptStatusMock.mockResolvedValue({
+      success: true,
+      data: { success: true, error: '', code: 'merkle-code-xyz', bitbadgesAddress: USER_ADDR }
+    });
+    getReservedClaimCodesMock.mockResolvedValue({
+      success: true,
+      data: { reservedCodes: ['merkle-code-xyz'], leafSignatures: ['0xsig'] }
+    });
+    getMerkleProofInfoMock.mockResolvedValue({
+      success: true,
+      data: {
+        allProofDetails: [
+          {
+            proofObj: [
+              { aunt: 'hash-1', onRight: true },
+              { aunt: 'hash-2', onRight: false }
+            ],
+            isValidProof: true,
+            leafIndex: 0,
+            leaf: 'merkle-code-xyz'
+          }
+        ]
+      }
+    });
+
+    const res = await handleRedeemClaim({
+      claimId: 'claim-1',
+      address: USER_ADDR,
+      inputs: { code: 'xyz' },
+      pollTimeoutMs: 5_000
+    });
+
+    expect(res.success).toBe(true);
+    expect(res.onChain).toBe(true);
+    expect(res.code).toBe('merkle-code-xyz');
+    expect(res.transaction).toBeDefined();
+
+    // Transaction matches build_transfer's shape: one tokenization
+    // MsgTransferTokens carrying the merkle proof.
+    const msg: any = res.transaction!.messages[0];
+    expect(msg.typeUrl).toBe('/tokenization.MsgTransferTokens');
+    expect(msg.value.collectionId).toBe('42');
+    expect(msg.value.creator).toBe(USER_ADDR);
+    const transfer = msg.value.transfers[0];
+    expect(transfer.from).toBe('Mint');
+    expect(transfer.toAddresses).toEqual([USER_ADDR]);
+    expect(transfer.merkleProofs).toEqual([
+      {
+        leaf: 'merkle-code-xyz',
+        leafSignature: '0xsig',
+        aunts: [
+          { aunt: 'hash-1', onRight: true },
+          { aunt: 'hash-2', onRight: false }
+        ]
+      }
+    ]);
+    expect(transfer.prioritizedApprovals).toEqual([
+      {
+        approvalId: 'mint-approval',
+        approvalLevel: 'collection',
+        approverAddress: '',
+        version: '0'
+      }
+    ]);
+    // FOREVER range for tokenIds + ownershipTimes
+    expect(transfer.balances[0].tokenIds).toEqual([{ start: '1', end: MAX_UINT64 }]);
+    expect(transfer.balances[0].ownershipTimes).toEqual([{ start: '1', end: MAX_UINT64 }]);
+
+    // And the merkle-proof-info call received the full tracker context.
+    const [merkleReq] = getMerkleProofInfoMock.mock.calls[0];
+    expect(merkleReq).toMatchObject({
+      collectionId: '42',
+      approvalId: 'mint-approval',
+      approvalLevel: 'collection',
+      approverAddress: '',
+      challengeTrackerId: 'tracker-1',
+      leaves: ['merkle-code-xyz']
+    });
+  });
+
+  it('on-chain claim with returnTransfer: false → skips merkle proof build', async () => {
+    getClaimsMock.mockResolvedValue({ success: true, data: { claims: [onChainClaim()] } });
+    completeClaimMock.mockResolvedValue({ success: true, data: { claimAttemptId: 'att-3' } });
+    getClaimAttemptStatusMock.mockResolvedValue({
+      success: true,
+      data: { success: true, error: '', code: 'code-abc', bitbadgesAddress: USER_ADDR }
+    });
+
+    const res = await handleRedeemClaim({
+      claimId: 'claim-1',
+      address: USER_ADDR,
+      inputs: { code: 'xyz' },
+      returnTransfer: false,
+      pollTimeoutMs: 5_000
+    });
+
+    expect(res.success).toBe(true);
+    expect(res.onChain).toBe(true);
+    expect(res.transaction).toBeUndefined();
+    expect(getReservedClaimCodesMock).not.toHaveBeenCalled();
+    expect(getMerkleProofInfoMock).not.toHaveBeenCalled();
+  });
+
+  it('power-user: raw { [instanceId]: body } is passed through unchanged', async () => {
+    // Claim has a `codes` plugin but under a user-chosen instanceId
+    // that doesn't match the flat-verb convention. The agent can still
+    // pass the raw shape and we forward it.
+    getClaimsMock.mockResolvedValue({
+      success: true,
+      data: {
+        claims: [
+          defaultClaim({
+            plugins: [
+              { pluginId: 'numUses', instanceId: 'numUses' },
+              { pluginId: 'codes', instanceId: 'custom-codes-abc' }
+            ]
+          })
+        ]
+      }
+    });
+    completeClaimMock.mockResolvedValue({ success: true, data: { claimAttemptId: 'att-4' } });
+    getClaimAttemptStatusMock.mockResolvedValue({
+      success: true,
+      data: { success: true, error: '', bitbadgesAddress: USER_ADDR }
+    });
+
+    await handleRedeemClaim({
+      claimId: 'claim-1',
+      address: USER_ADDR,
+      inputs: { 'custom-codes-abc': { code: 'xyz' } },
+      pollTimeoutMs: 2_000
+    });
+
+    const [, , payload] = completeClaimMock.mock.calls[0];
+    expect(payload).toEqual({
+      _expectedVersion: -1,
+      'custom-codes-abc': { code: 'xyz' }
+    });
+  });
+
+  it('explicit expectedVersion is honored', async () => {
+    getClaimsMock.mockResolvedValue({ success: true, data: { claims: [defaultClaim()] } });
+    completeClaimMock.mockResolvedValue({ success: true, data: { claimAttemptId: 'att-5' } });
+    getClaimAttemptStatusMock.mockResolvedValue({
+      success: true,
+      data: { success: true, error: '', bitbadgesAddress: USER_ADDR }
+    });
+
+    await handleRedeemClaim({
+      claimId: 'claim-1',
+      address: USER_ADDR,
+      inputs: { code: 'xyz' },
+      expectedVersion: 3,
+      pollTimeoutMs: 2_000
+    });
+
+    const [, , payload] = completeClaimMock.mock.calls[0];
+    expect(payload._expectedVersion).toBe(3);
+  });
+});
+
+describe('redeem_claim — failure modes', () => {
+  beforeEach(() => {
+    [
+      getClaimsMock,
+      completeClaimMock,
+      getClaimAttemptStatusMock,
+      getReservedClaimCodesMock,
+      getMerkleProofInfoMock
+    ].forEach((m) => m.mockReset());
+  });
+
+  it('claimId not found → structured error, no completeClaim call', async () => {
+    getClaimsMock.mockResolvedValue({ success: true, data: { claims: [] } });
+    const res = await handleRedeemClaim({
+      claimId: 'missing',
+      address: USER_ADDR,
+      inputs: { code: 'xyz' }
+    });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/not found/i);
+    expect(completeClaimMock).not.toHaveBeenCalled();
+  });
+
+  it('inputs key doesn\'t map to any plugin → returns discovered plugin list', async () => {
+    // Claim has no `password` plugin, but inputs uses one.
+    getClaimsMock.mockResolvedValue({
+      success: true,
+      data: {
+        claims: [
+          defaultClaim({
+            plugins: [
+              { pluginId: 'numUses', instanceId: 'numUses' },
+              { pluginId: 'whitelist', instanceId: 'wl' }
+            ]
+          })
+        ]
+      }
+    });
+    const res = await handleRedeemClaim({
+      claimId: 'claim-1',
+      address: USER_ADDR,
+      inputs: { password: 'secret' }
+    });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/plugin|instanceId/i);
+    expect(res.discovered?.plugins).toEqual([
+      { pluginId: 'numUses', instanceId: 'numUses' },
+      { pluginId: 'whitelist', instanceId: 'wl' }
+    ]);
+    expect(completeClaimMock).not.toHaveBeenCalled();
+  });
+
+  it('terminal error from claim attempt polling → propagates with claimAttemptId', async () => {
+    getClaimsMock.mockResolvedValue({ success: true, data: { claims: [defaultClaim()] } });
+    completeClaimMock.mockResolvedValue({ success: true, data: { claimAttemptId: 'att-err' } });
+    getClaimAttemptStatusMock.mockResolvedValue({
+      success: true,
+      data: { success: false, error: 'invalid code', bitbadgesAddress: USER_ADDR }
+    });
+
+    const res = await handleRedeemClaim({
+      claimId: 'claim-1',
+      address: USER_ADDR,
+      inputs: { code: 'wrong' },
+      pollTimeoutMs: 2_000
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toBe('invalid code');
+    expect(res.claimAttemptId).toBe('att-err');
+  });
+
+  it('polling times out before terminal → synthetic "Polling timed out" error', async () => {
+    getClaimsMock.mockResolvedValue({ success: true, data: { claims: [defaultClaim()] } });
+    completeClaimMock.mockResolvedValue({ success: true, data: { claimAttemptId: 'att-tmo' } });
+    // Always pending — never terminal
+    getClaimAttemptStatusMock.mockResolvedValue({
+      success: true,
+      data: { success: false, error: '', bitbadgesAddress: USER_ADDR }
+    });
+
+    const res = await handleRedeemClaim({
+      claimId: 'claim-1',
+      address: USER_ADDR,
+      inputs: { code: 'xyz' },
+      pollTimeoutMs: 100 // tight bound so the test finishes fast
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/timed out/i);
+    expect(res.claimAttemptId).toBe('att-tmo');
+  });
+
+  it('on-chain claim with empty reservedCodes → structured error', async () => {
+    getClaimsMock.mockResolvedValue({ success: true, data: { claims: [onChainClaim()] } });
+    completeClaimMock.mockResolvedValue({ success: true, data: { claimAttemptId: 'att-nc' } });
+    getClaimAttemptStatusMock.mockResolvedValue({
+      success: true,
+      data: { success: true, error: '', bitbadgesAddress: USER_ADDR }
+    });
+    getReservedClaimCodesMock.mockResolvedValue({
+      success: true,
+      data: { reservedCodes: [], leafSignatures: [] }
+    });
+
+    const res = await handleRedeemClaim({
+      claimId: 'claim-1',
+      address: USER_ADDR,
+      inputs: { code: 'xyz' },
+      pollTimeoutMs: 2_000
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/reserved claim code/i);
+    expect(getMerkleProofInfoMock).not.toHaveBeenCalled();
+  });
+
+  it('invalid merkle proof from indexer → structured error', async () => {
+    getClaimsMock.mockResolvedValue({ success: true, data: { claims: [onChainClaim()] } });
+    completeClaimMock.mockResolvedValue({ success: true, data: { claimAttemptId: 'att-mp' } });
+    getClaimAttemptStatusMock.mockResolvedValue({
+      success: true,
+      data: { success: true, error: '', bitbadgesAddress: USER_ADDR }
+    });
+    getReservedClaimCodesMock.mockResolvedValue({
+      success: true,
+      data: { reservedCodes: ['code-1'], leafSignatures: ['0xsig'] }
+    });
+    getMerkleProofInfoMock.mockResolvedValue({
+      success: true,
+      data: {
+        allProofDetails: [
+          { proofObj: [], isValidProof: false, leafIndex: -1, leaf: '' }
+        ]
+      }
+    });
+
+    const res = await handleRedeemClaim({
+      claimId: 'claim-1',
+      address: USER_ADDR,
+      inputs: { code: 'xyz' },
+      pollTimeoutMs: 2_000
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/merkle proof/i);
+  });
+
+  it('API-layer error on getClaims → propagates untouched', async () => {
+    getClaimsMock.mockResolvedValue({
+      success: false,
+      error: 'BITBADGES_API_KEY environment variable not set. Set it to use API query tools.'
+    });
+    const res = await handleRedeemClaim({
+      claimId: 'claim-1',
+      address: USER_ADDR,
+      inputs: { code: 'xyz' }
+    });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/BITBADGES_API_KEY/);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/builders/redeemClaim.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/builders/redeemClaim.ts
@@ -1,0 +1,505 @@
+/**
+ * Tool: redeem_claim
+ *
+ * Collapses the 5-call claim-redemption flow documented at
+ * `bitbadges-docs/for-developers/ai-agents/claims-for-agents.md` into a
+ * single MCP tool call. Under the hood, we:
+ *
+ *   1. `getClaims([claimId])` — lookup plugins + trackerDetails so we can
+ *      auto-map the flat `inputs` object onto the right `instanceId` body
+ *      and decide whether this is a standalone (off-chain) or on-chain
+ *      gated claim.
+ *   2. `completeClaim(claimId, address, payload)` — submit the attempt.
+ *   3. Poll `getClaimAttemptStatus` with exponential backoff (500ms → 4s
+ *      cap) bounded by `pollTimeoutMs` (default 30s).
+ *   4. For on-chain claims, `getReservedClaimCodes` + `getMerkleProofInfo`
+ *      + hand-stitched `MsgTransferTokens`, returned in the same shape
+ *      `build_transfer` emits so `simulate_transaction` accepts it
+ *      unmodified.
+ *
+ * See backlog #0256 (bitbadges-autopilot) for the simplification rationale.
+ *
+ * Convention note: schema + response shape mirror `buildClaim.ts`; the
+ * polling + bigint→string patterns mirror `simulateTransaction.ts`.
+ */
+
+import { z } from 'zod';
+import {
+  type ApiClientConfig,
+  type ClaimSummary,
+  type ClaimPluginSummary,
+  type CompleteClaimResponse,
+  type ClaimAttemptStatusResponse,
+  type ReservedClaimCodesResponse,
+  type MerkleProofInfoResponse,
+  completeClaim,
+  getClaimAttemptStatus,
+  getClaims,
+  getMerkleProofInfo,
+  getReservedClaimCodes
+} from '../../sdk/apiClient.js';
+import { ensureBb1 } from '../../sdk/addressUtils.js';
+
+export const redeemClaimSchema = z.object({
+  claimId: z.string().describe('Claim ID to redeem'),
+  address: z.string().describe('Redeemer address (bb1... or 0x...)'),
+  inputs: z
+    .record(z.unknown())
+    .optional()
+    .describe(
+      'Plugin inputs keyed either by flat verbs (code/password/address) or by the claim plugin instanceId. Leave empty for pure whitelist / open claims.'
+    ),
+  expectedVersion: z
+    .number()
+    .optional()
+    .describe('Pin the claim version. Defaults to -1 ("do not care", matches latest).'),
+  pollTimeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('How long to wait for the claim attempt to resolve. Default 30000ms.'),
+  returnTransfer: z
+    .boolean()
+    .optional()
+    .describe(
+      'For on-chain gated claims, also build a ready-to-sign MsgTransferTokens. Default true. Ignored for standalone claims.'
+    )
+});
+
+export type RedeemClaimInput = z.infer<typeof redeemClaimSchema>;
+
+export interface RedeemClaimResult {
+  success: boolean;
+  error?: string;
+  /** The claim attempt ID from `completeClaim`. Present on most paths. */
+  claimAttemptId?: string;
+  /** On-chain reserved merkle code for this address (if any). */
+  code?: string;
+  /** Whether the redeemed claim is linked to an on-chain collection. */
+  onChain?: boolean;
+  /**
+   * Ready-to-sign MsgTransferTokens transaction. Only populated when the
+   * claim is on-chain gated AND `returnTransfer` is not false AND the
+   * merkle proof resolved. Same shape as `build_transfer` emits so
+   * `simulate_transaction` can consume it unmodified.
+   */
+  transaction?: {
+    messages: unknown[];
+    memo: string;
+    fee: { amount: Array<{ denom: string; amount: string }>; gas: string };
+  };
+  /** Diagnostic info for agents that need to decide how to retry. */
+  discovered?: {
+    plugins: Array<{ pluginId: string; instanceId: string }>;
+    standaloneClaim: boolean;
+  };
+}
+
+export const redeemClaimTool = {
+  name: 'redeem_claim',
+  description:
+    'Redeem a BitBadges claim on behalf of an address in one call. Submits the claim attempt, polls until the indexer resolves it, and — for on-chain gated claims — auto-fetches the reserved merkle code, fetches the merkle proof, and returns a ready-to-sign MsgTransferTokens. Collapses the 5-call flow (completeClaim → poll → getReservedClaimCodes → getMerkleProofInfo → build transfer) into a single tool call. Requires BITBADGES_API_KEY.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      claimId: { type: 'string', description: 'Claim ID to redeem' },
+      address: { type: 'string', description: 'Redeemer address (bb1... or 0x...)' },
+      inputs: {
+        type: 'object',
+        description:
+          'Plugin inputs. Use flat verbs (code/password/address) for auto-mapping, or pass a full `{ [instanceId]: { ...plugin body } }` object to bypass auto-mapping. Leave empty for whitelist / open claims.'
+      },
+      expectedVersion: {
+        type: 'number',
+        description: 'Pin the claim version. Defaults to -1 (any version).'
+      },
+      pollTimeoutMs: {
+        type: 'number',
+        description: 'Timeout in ms for the polling loop. Default 30000.'
+      },
+      returnTransfer: {
+        type: 'boolean',
+        description:
+          'For on-chain claims, also build the MsgTransferTokens. Default true.'
+      }
+    },
+    required: ['claimId', 'address']
+  }
+};
+
+const MAX_UINT64 = '18446744073709551615';
+const FOREVER = [{ start: '1', end: MAX_UINT64 }];
+
+/** Keys that are considered "flat verbs" and get auto-mapped to plugin instanceIds. */
+const FLAT_VERB_KEYS = new Set(['code', 'codes', 'password', 'whitelist']);
+
+/**
+ * Map a flat verb (e.g. `code`) to the plugin instance body the indexer
+ * expects. Mirrors the per-plugin payload the docs show at
+ * `claims-for-agents.md` — users typed `code: 'xyz'`, indexer expects
+ * `{ [codesInstanceId]: { code: 'xyz' } }`.
+ */
+function buildPluginBodyForVerb(verb: string, value: unknown): Record<string, unknown> {
+  switch (verb) {
+    case 'code':
+    case 'codes':
+      // `value` is the actual code string
+      return { code: String(value) };
+    case 'password':
+      return { password: String(value) };
+    case 'whitelist':
+      // Whitelist plugin accepts an empty body server-side; address gating
+      // happens at the plugin level via the signed-in user's address.
+      return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+    default:
+      return { [verb]: value };
+  }
+}
+
+/**
+ * Find the first plugin whose `pluginId` matches one of the given candidate
+ * IDs. Returns `undefined` if no plugin in the claim uses that pluginId.
+ */
+function findPluginByPluginId(
+  plugins: ClaimPluginSummary[],
+  pluginIds: string[]
+): ClaimPluginSummary | undefined {
+  for (const plugin of plugins) {
+    if (pluginIds.includes(plugin.pluginId)) return plugin;
+  }
+  return undefined;
+}
+
+/**
+ * Given a user-supplied `inputs` object + the claim's plugin list, produce
+ * the `{ [instanceId]: body }` map that `completeClaim` expects. Returns
+ * `null` if the inputs couldn't be mapped — caller should return an error
+ * with the discovered plugin list so the agent can retry.
+ */
+function mapInputsToInstanceIds(
+  inputs: Record<string, unknown> | undefined,
+  plugins: ClaimPluginSummary[]
+): Record<string, unknown> | null {
+  const out: Record<string, unknown> = {};
+  if (!inputs || Object.keys(inputs).length === 0) {
+    return out;
+  }
+
+  for (const [key, value] of Object.entries(inputs)) {
+    if (FLAT_VERB_KEYS.has(key)) {
+      // Flat verb → find matching plugin and rewrite under its instanceId.
+      const pluginIdCandidates =
+        key === 'code' || key === 'codes' ? ['codes'] :
+        key === 'password' ? ['password'] :
+        key === 'whitelist' ? ['whitelist'] :
+        [key];
+      const plugin = findPluginByPluginId(plugins, pluginIdCandidates);
+      if (!plugin) {
+        return null;
+      }
+      out[plugin.instanceId] = buildPluginBodyForVerb(key, value);
+    } else {
+      // Key was not a flat verb — assume the caller passed a raw
+      // `{ instanceId: body }` shape (power-user escape hatch).
+      out[key] = value;
+    }
+  }
+
+  return out;
+}
+
+/** Exponential backoff capped at `cap`. Starts at `start`, doubles each step. */
+function nextBackoffMs(prev: number, start: number, cap: number): number {
+  if (prev === 0) return start;
+  return Math.min(prev * 2, cap);
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Poll `getClaimAttemptStatus` until terminal success/error or timeout.
+ *
+ * Returns the final status response regardless of which terminal state was
+ * hit. The caller decides how to interpret `success`/`error`. On overall
+ * polling-loop timeout, we surface a synthetic response with
+ * `error: 'Polling timed out'` so the agent can choose to re-poll later
+ * using the returned `claimAttemptId`.
+ *
+ * Exponential backoff: starts at 500ms, doubles until 4s cap. Matches the
+ * handoff note in ticket #0256 — the docs' 2s-sleep pattern is a floor,
+ * not a ceiling; we want to be more responsive at the front (typical
+ * claims resolve in under a second) and less noisy if the attempt is
+ * taking longer.
+ */
+async function pollClaimAttemptStatus(
+  claimAttemptId: string,
+  pollTimeoutMs: number,
+  config?: ApiClientConfig
+): Promise<
+  | { ok: true; status: ClaimAttemptStatusResponse; timedOut?: false }
+  | { ok: true; status: ClaimAttemptStatusResponse; timedOut: true }
+  | { ok: false; error: string }
+> {
+  const startMs = Date.now();
+  let delayMs = 0;
+  let lastStatus: ClaimAttemptStatusResponse | undefined;
+
+  while (Date.now() - startMs < pollTimeoutMs) {
+    delayMs = nextBackoffMs(delayMs, 500, 4000);
+    // Clamp the final wait so we don't exceed pollTimeoutMs.
+    const remaining = pollTimeoutMs - (Date.now() - startMs);
+    await sleep(Math.min(delayMs, Math.max(remaining, 0)));
+
+    const res = await getClaimAttemptStatus(claimAttemptId, config);
+    if (!res.success) {
+      return { ok: false, error: res.error || 'Failed to fetch claim attempt status' };
+    }
+    lastStatus = res.data;
+    if (lastStatus && (lastStatus.success || lastStatus.error)) {
+      return { ok: true, status: lastStatus };
+    }
+  }
+
+  return {
+    ok: true,
+    timedOut: true,
+    status:
+      lastStatus ?? {
+        success: false,
+        error: 'Polling timed out',
+        bitbadgesAddress: ''
+      }
+  };
+}
+
+export async function handleRedeemClaim(input: RedeemClaimInput): Promise<RedeemClaimResult> {
+  try {
+    const address = ensureBb1(input.address);
+    const pollTimeoutMs = input.pollTimeoutMs ?? 30_000;
+    const returnTransfer = input.returnTransfer !== false; // default true
+
+    // Step 1 — fetch the claim to discover plugins + on-chain linkage.
+    const claimsRes = await getClaims([input.claimId]);
+    if (!claimsRes.success) {
+      return { success: false, error: claimsRes.error || 'Failed to fetch claim' };
+    }
+    const claim: ClaimSummary | undefined = claimsRes.data?.claims?.[0];
+    if (!claim) {
+      return { success: false, error: `Claim ${input.claimId} not found` };
+    }
+
+    const plugins = claim.plugins ?? [];
+    const discovered = {
+      plugins: plugins.map((p) => ({ pluginId: p.pluginId, instanceId: p.instanceId })),
+      standaloneClaim: Boolean(claim.standaloneClaim) || !claim.trackerDetails
+    };
+
+    // Step 2 — map flat inputs onto plugin instanceIds.
+    const mapped = mapInputsToInstanceIds(input.inputs, plugins);
+    if (mapped === null) {
+      return {
+        success: false,
+        error:
+          'Could not map input keys to any plugin on this claim. Pass inputs keyed by plugin instanceId instead, or use one of the flat verbs (code, password, whitelist) if the claim has a matching plugin.',
+        discovered
+      };
+    }
+
+    const payload: Record<string, unknown> = {
+      _expectedVersion: input.expectedVersion ?? -1,
+      ...mapped
+    };
+
+    // Step 3 — submit the attempt.
+    const completeRes = await completeClaim(input.claimId, address, payload);
+    if (!completeRes.success || !completeRes.data?.claimAttemptId) {
+      return {
+        success: false,
+        error: completeRes.error || 'completeClaim returned no claimAttemptId',
+        discovered
+      };
+    }
+    const claimAttemptId = (completeRes.data as CompleteClaimResponse).claimAttemptId;
+
+    // Step 4 — poll until terminal.
+    const pollResult = await pollClaimAttemptStatus(claimAttemptId, pollTimeoutMs);
+    if (!pollResult.ok) {
+      return { success: false, error: pollResult.error, claimAttemptId, discovered };
+    }
+    const status = pollResult.status;
+
+    // Timeout is a distinct failure mode from "claim attempt succeeded
+    // with error" — surface it explicitly so agents can re-poll later
+    // using the returned claimAttemptId.
+    if (pollResult.timedOut) {
+      return {
+        success: false,
+        error: `Polling timed out after ${pollTimeoutMs}ms. Re-poll getClaimAttemptStatus(${claimAttemptId}) later.`,
+        claimAttemptId,
+        discovered
+      };
+    }
+
+    if (!status.success) {
+      return {
+        success: false,
+        error: status.error || 'Claim attempt failed',
+        claimAttemptId,
+        discovered
+      };
+    }
+
+    // Step 5 — standalone claims stop here.
+    const onChain = !discovered.standaloneClaim && Boolean(claim.trackerDetails);
+    if (!onChain) {
+      return {
+        success: true,
+        claimAttemptId,
+        code: status.code,
+        onChain: false,
+        discovered
+      };
+    }
+
+    // If the caller explicitly opted out of the transfer build, return
+    // early with just the on-chain code so they can stitch the transfer
+    // themselves (e.g. batch with other messages).
+    if (!returnTransfer) {
+      return {
+        success: true,
+        claimAttemptId,
+        code: status.code,
+        onChain: true,
+        discovered
+      };
+    }
+
+    // Step 6 — fetch reserved codes + merkle proof, then shape the transfer.
+    const reservedRes = await getReservedClaimCodes(input.claimId, address);
+    if (!reservedRes.success || !reservedRes.data) {
+      return {
+        success: false,
+        error: reservedRes.error || 'Failed to fetch reserved claim codes',
+        claimAttemptId,
+        onChain: true,
+        discovered
+      };
+    }
+    const reserved: ReservedClaimCodesResponse = reservedRes.data;
+    const reservedCode = reserved.reservedCodes?.[0];
+    const leafSignature = reserved.leafSignatures?.[0];
+    if (!reservedCode) {
+      return {
+        success: false,
+        error:
+          'No reserved claim code was returned for this address. The claim may not be linked to an on-chain tracker, or the address already redeemed all reserved leaves.',
+        claimAttemptId,
+        code: status.code,
+        onChain: true,
+        discovered
+      };
+    }
+
+    const tracker = claim.trackerDetails!;
+    const collectionId =
+      typeof tracker.collectionId === 'bigint' ? tracker.collectionId.toString() : String(tracker.collectionId);
+
+    const merkleRes = await getMerkleProofInfo({
+      collectionId,
+      approvalId: tracker.approvalId,
+      approvalLevel: tracker.approvalLevel,
+      approverAddress: tracker.approverAddress,
+      challengeTrackerId: tracker.challengeTrackerId,
+      leaves: [reservedCode],
+      bitbadgesAddress: address,
+      claimCodes: [reservedCode]
+    });
+    if (!merkleRes.success || !merkleRes.data) {
+      return {
+        success: false,
+        error: merkleRes.error || 'Failed to fetch merkle proof info',
+        claimAttemptId,
+        code: status.code,
+        onChain: true,
+        discovered
+      };
+    }
+    const proofDetail: MerkleProofInfoResponse['allProofDetails'][number] | undefined =
+      merkleRes.data.allProofDetails?.[0];
+    if (!proofDetail || !proofDetail.isValidProof) {
+      return {
+        success: false,
+        error:
+          'Indexer could not produce a valid merkle proof for the reserved code. The challenge tracker may not be populated yet — retry after the indexer catches up.',
+        claimAttemptId,
+        code: status.code,
+        onChain: true,
+        discovered
+      };
+    }
+
+    // Step 7 — build the MsgTransferTokens with merkle proof stitched in.
+    // Shape matches build_transfer's output so simulate_transaction
+    // consumes it directly.
+    const transfer: Record<string, unknown> = {
+      from: 'Mint',
+      toAddresses: [address],
+      balances: [
+        {
+          amount: '1',
+          tokenIds: FOREVER, // all valid IDs; indexer enforces via approval
+          ownershipTimes: FOREVER
+        }
+      ],
+      merkleProofs: [
+        {
+          leaf: reservedCode,
+          leafSignature: leafSignature ?? '',
+          aunts: proofDetail.proofObj
+        }
+      ],
+      prioritizedApprovals: [
+        {
+          approvalId: tracker.approvalId,
+          approvalLevel: tracker.approvalLevel || 'collection',
+          approverAddress: tracker.approverAddress || '',
+          version: '0'
+        }
+      ],
+      onlyCheckPrioritizedApprovals: false
+    };
+
+    const transaction = {
+      messages: [
+        {
+          typeUrl: '/tokenization.MsgTransferTokens',
+          value: {
+            creator: address,
+            collectionId,
+            transfers: [transfer]
+          }
+        }
+      ],
+      memo: '',
+      fee: {
+        amount: [{ denom: 'ubadge', amount: '5000' }],
+        gas: '500000'
+      }
+    };
+
+    return {
+      success: true,
+      claimAttemptId,
+      code: status.code ?? reservedCode,
+      onChain: true,
+      transaction,
+      discovered
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to redeem claim: ${error instanceof Error ? error.message : String(error)}`
+    };
+  }
+}

--- a/packages/bitbadgesjs-sdk/src/builder/tools/registry.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/registry.ts
@@ -50,6 +50,8 @@ import {
   reviewCollectionTool, handleReviewCollection,
   // Claim builder
   buildClaimTool, handleBuildClaim,
+  // Claim redemption (5-call flow → 1 call)
+  redeemClaimTool, handleRedeemClaim,
   // Session-based per-field tools (v2)
   setStandardsTool, handleSetStandards,
   setValidTokenIdsTool, handleSetValidTokenIds,
@@ -215,6 +217,7 @@ export const toolRegistry: Record<string, ToolEntry> = {
     (result: any) => (result?.success ? result.explanation : JSON.stringify(result, null, 2))
   ),
   build_claim: entry(buildClaimTool, handleBuildClaim),
+  redeem_claim: entry(redeemClaimTool, async (args: any) => await handleRedeemClaim(args)),
 
   // Session-based per-field tools (v2)
   set_standards: entry(setStandardsTool, handleSetStandards),


### PR DESCRIPTION
## Summary

Adds a new `redeem_claim` MCP tool under `src/builder/tools/builders/` that collapses the 5-call claim-redemption flow into a single tool call.

**Before** (per `bitbadges-docs/for-developers/ai-agents/claims-for-agents.md`):

1. `completeClaim(claimId, address, { _expectedVersion, [instanceId]: body })`
2. Poll `getClaimAttemptStatus(claimAttemptId)` every 2s with a hand-rolled loop
3. `getReservedClaimCodes(claimId, address)`
4. `getMerkleProofInfo(collectionId, challengeTrackerId, code)`
5. Hand-stitch `MsgTransferTokens` with `merkleProofs` / `prioritizedApprovals`

**After:**
```
redeem_claim({ claimId, address, inputs: { code: "xyz" } })
```

Returns either `{ success, claimAttemptId, code?, onChain: false }` for standalone claims, or `{ success, claimAttemptId, code, onChain: true, transaction: { messages: [MsgTransferTokens], memo, fee } }` for on-chain gated claims. The `transaction` shape matches `build_transfer`'s output so `simulate_transaction` accepts it unmodified.

Implements backlog #0256 (bitbadges-autopilot).

## Design notes

- **Plugin instance-id auto-mapping.** One `getClaims([claimId])` lookup at the top discovers the plugin list. Flat verbs (`code` / `password` / `whitelist`) are remapped to the user-chosen `instanceId` via a pluginId match. Power-users can bypass by passing `{ [instanceId]: body }` directly.
- **Polling backoff.** Exponential backoff starting at 500ms, capped at 4s, bounded by `pollTimeoutMs` (default 30s). The docs' 2s-sleep pattern is treated as a floor, not a ceiling — we want to be responsive for fast claims (<1s is common) and non-noisy for slow ones. Timeout returns the `claimAttemptId` so the agent can re-poll later instead of failing outright.
- **Standalone-vs-on-chain detection.** `claim.standaloneClaim || !claim.trackerDetails` -> short-circuit after polling. On-chain path pulls `trackerDetails.{collectionId, approvalId, approvalLevel, approverAddress, challengeTrackerId}` to build the `merkleProofInfo` request. The indexer endpoint (`/api/v0/merkleProofInfo`) needs all five fields; the docs shortcut `(collectionId, challengeTrackerId, code)` was incomplete.
- **Schema conventions mirror `buildClaim.ts`.** Zod schema + JSON Schema both present; `required: ['claimId', 'address']`; optional fields documented with short one-line descriptions.
- **Response-shaping pattern mirrors `buildTransfer.ts`.** Same `typeUrl: '/tokenization.MsgTransferTokens'`, same `prioritizedApprovals` shape, same `FOREVER` ownershipTimes — so `simulate_transaction` downstream is a drop-in consumer.
- **Failure modes return structured errors.** `claimId not found`, `inputs don't map to a plugin` (returns the discovered plugin list so the agent can retry), polling timeout, empty `reservedCodes`, invalid merkle proof — each surfaces as its own `{ success: false, error, ... }` without swallowing.

## Files

**New:**
- `packages/bitbadgesjs-sdk/src/builder/tools/builders/redeemClaim.ts` — tool schema + handler (~400 lines incl. comments)
- `packages/bitbadgesjs-sdk/src/builder/tools/builders/redeemClaim.spec.ts` — 17 tests, fully mocked against the 5 `apiClient` endpoints (no real network)

**Touched:**
- `src/builder/sdk/apiClient.ts` — thin wrappers: `getClaims`, `completeClaim`, `getClaimAttemptStatus`, `getReservedClaimCodes`, `getMerkleProofInfo`
- `src/builder/tools/builders/index.ts` — export the new module
- `src/builder/tools/registry.ts` — register `redeem_claim`
- `src/builder/resources/recipes.ts` — add `redeem-code-gated-claim` recipe

## Test plan

- [x] `npm test` — 1950/1950 pass across 57 suites
- [x] `redeemClaim.spec.ts` — 17/17 covering: schema, tool schema shape, standalone happy path, on-chain happy path, `returnTransfer: false`, power-user raw-instanceId shape, `expectedVersion` pinning, claimId-not-found, unmappable inputs, polling terminal-error, polling timeout, empty reserved codes, invalid merkle proof, API-layer errors
- [x] `npm run build` — rebuilt `dist/cjs/builder/tools/builders/redeemClaim.{js,d.ts}` and `dist/esm/...` so symlinked consumers (indexer) pick up the new tool
- [ ] Integration test against a real testnet claim — left as a manual follow-up; all 5 endpoints are unit-covered at the mock boundary so the integration surface is already exercised in CI-ish isolation

## Backlog link

Implements `backlog/0256-simplify-redeem-claim-one-shot-mcp-tool.md` in the bitbadges-autopilot repo. Ticket will be moved to `status: in-progress` with the PR link in a follow-up commit.