### PR TITLE
fix(interpret): break circular import by moving interpret.ts to api-indexer/

### DIFF
--- a/packages/bitbadgesjs-sdk/src/api-indexer/index.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/index.ts
@@ -6,5 +6,7 @@ export * from './docs-types/index.js';
 export * from './BitBadgesApi.js';
 export * from './BitBadgesCollection.js';
 export * from './BitBadgesUserInfo.js';
+// Moved here from core/ to break a runtime circular import (see comment in core/index.ts).
+export * from './interpret.js';
 export * from './requests/index.js';
 export * from './responses/index.js';

--- a/packages/bitbadgesjs-sdk/src/api-indexer/interpret.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/interpret.spec.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for interpret.ts - interpretCollection function
  */
-import { BitBadgesCollection } from '../api-indexer/BitBadgesCollection.js';
-import type { iBitBadgesCollection } from '../api-indexer/BitBadgesCollection.js';
+import { BitBadgesCollection } from './BitBadgesCollection.js';
+import type { iBitBadgesCollection } from './BitBadgesCollection.js';
 import { interpretCollection, timestampToDate, durationToHuman, denomToHuman, amountToHuman } from './interpret.js';
 
 const GO_MAX = 18446744073709551615n;

--- a/packages/bitbadgesjs-sdk/src/api-indexer/interpret.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/interpret.ts
@@ -8,9 +8,9 @@
  */
 import type { NumberType } from '../common/string-numbers.js';
 import { GO_MAX_UINT_64 } from '../common/math.js';
-import type { iBitBadgesCollection } from '../api-indexer/BitBadgesCollection.js';
-import { BitBadgesCollection } from '../api-indexer/BitBadgesCollection.js';
-import { getMintApprovals, getNonMintApprovals } from './approval-utils.js';
+import type { iBitBadgesCollection } from './BitBadgesCollection.js';
+import { BitBadgesCollection } from './BitBadgesCollection.js';
+import { getMintApprovals, getNonMintApprovals } from '../core/approval-utils.js';
 import {
   big,
   permState,
@@ -34,7 +34,7 @@ import {
   durationToHuman,
   denomToHuman,
   amountToHuman
-} from './interpret-shared.js';
+} from '../core/interpret-shared.js';
 
 // Re-export helpers so existing consumers of interpret.js still work
 export { timestampToDate, durationToHuman, denomToHuman, amountToHuman };

--- a/packages/bitbadgesjs-sdk/src/builder/tools/builders/explainCollection.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/builders/explainCollection.ts
@@ -8,7 +8,7 @@
  * with builder-specific input normalization and developer/auditor extras on top.
  */
 
-import { interpretCollection } from '../../../core/interpret.js';
+import { interpretCollection } from '../../../api-indexer/interpret.js';
 import { BitBadgesCollection } from '../../../api-indexer/BitBadgesCollection.js';
 import type { NumberType } from '../../../common/string-numbers.js';
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/builder.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/builder.ts
@@ -1128,7 +1128,7 @@ addNetworkOptions(
           fetchedCollection ||
           (data && typeof data === 'object' && !data.typeUrl && !hasMessages && !data.value)
         ) {
-          const { interpretCollection } = await import('../../core/interpret.js');
+          const { interpretCollection } = await import('../../api-indexer/interpret.js');
           text = interpretCollection(data);
         } else {
           const txBody = firstCollectionMsg?.value ?? data.value ?? data;

--- a/packages/bitbadgesjs-sdk/src/cli/commands/sdk.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/sdk.ts
@@ -106,7 +106,7 @@ sdkCommand
     } else {
       data = readJsonInput(input);
     }
-    const { interpretCollection } = await import('../../core/interpret.js');
+    const { interpretCollection } = await import('../../api-indexer/interpret.js');
     const result = interpretCollection(data);
     if (opts.outputFile) {
       const fs = await import('fs');

--- a/packages/bitbadgesjs-sdk/src/core/index.ts
+++ b/packages/bitbadgesjs-sdk/src/core/index.ts
@@ -29,7 +29,11 @@ export * from './simulation.js';
 export * from './prediction-markets.js';
 export * from './bounties.js';
 export * from './auctions.js';
-export * from './interpret.js';
+// NOTE: interpret.js was moved to ../api-indexer/interpret.js to avoid a circular import
+// (interpretCollection depends on the BitBadgesCollection runtime class, whose module graph
+// transitively loads parts of core/, which produced a "Super expression must either be null
+// or a function" error at load time). api-indexer/index.ts now re-exports it, so top-level
+// `import { interpretCollection } from 'bitbadges'` still works.
 export * from './interpret-transaction.js';
 // Selectively re-export shared builders (helpers like timestampToDate are already re-exported by interpret.js)
 export {


### PR DESCRIPTION
## Summary

Fixes a runtime circular import that surfaces as \`TypeError: Super expression must either be null or a function\` when loading the SDK's CJS build. This error caused **37 test suites** to fail identically in \`bitbadges-indexer\` once its CI exit-code handling was fixed (see indexer PR #102).

## Root cause

- \`src/core/index.ts\` re-exported \`./interpret.js\` as runtime code.
- \`src/core/interpret.ts\` in turn imported \`BitBadgesCollection\` as a runtime value (not a type).
- \`BitBadgesCollection\`'s module graph transitively loads \`core/*\` again.
- By the time \`class BitBadgesCollection extends CollectionDoc\` evaluated, \`CollectionDoc\` was still undefined (its module hadn't finished loading) → "Super expression" error.

## Fix

\`interpret.ts\` operates on a \`BitBadgesCollection\` instance — it belongs next to that class, not in \`core/\`. Moved:

- \`src/core/interpret.ts\` → \`src/api-indexer/interpret.ts\`
- \`src/core/interpret.spec.ts\` → \`src/api-indexer/interpret.spec.ts\`

Re-exports updated so **the public API is unchanged**: top-level \`import { interpretCollection } from 'bitbadges'\` still works. Re-exported helpers (\`timestampToDate\`, \`durationToHuman\`, \`denomToHuman\`, \`amountToHuman\`) are still accessible from the top-level export.

Three direct importers also updated:
- \`src/builder/tools/builders/explainCollection.ts\`
- \`src/cli/commands/builder.ts\`
- \`src/cli/commands/sdk.ts\`

## Verification

- [x] \`bun run build\` — passes (tsc, tsc-alias, fixup, dep-check all green).
- [x] \`madge --circular\` — reports "No circular dependency found!"
- [x] Manual CJS load test: \`typeof BitBadgesCollection === 'function'\` and \`new BitBadgesCollection(...)\` no longer throws the "Super expression" error.
- [ ] After merge + publish: re-run bitbadges-indexer \`test.yml\` — the 37 identical failures should all go away.

## Related

- Tracked in autopilot backlog #0260.
- Depends on indexer PR #102 (exit-code fix) landing first so that \`test.yml\` actually surfaces pass/fail accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)