### PR TITLE
fix(verify-standards): break second circular import by moving to api-indexer/

### DIFF
--- a/packages/bitbadgesjs-sdk/src/api-indexer/index.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/index.ts
@@ -8,5 +8,6 @@ export * from './BitBadgesCollection.js';
 export * from './BitBadgesUserInfo.js';
 // Moved here from core/ to break a runtime circular import (see comment in core/index.ts).
 export * from './interpret.js';
+export * from './verify-standards.js';
 export * from './requests/index.js';
 export * from './responses/index.js';

--- a/packages/bitbadgesjs-sdk/src/api-indexer/verify-standards.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/verify-standards.ts
@@ -11,9 +11,9 @@
  * These validators ensure the structural skeleton is correct.
  */
 
-import { CollectionDoc } from '../api-indexer/docs-types/docs.js';
-import { doesCollectionFollowSubscriptionProtocol } from './subscriptions.js';
-import { normalizeForReview } from './review-normalize.js';
+import { CollectionDoc } from './docs-types/docs.js';
+import { doesCollectionFollowSubscriptionProtocol } from '../core/subscriptions.js';
+import { normalizeForReview } from '../core/review-normalize.js';
 
 const MAX_UINT64 = 18446744073709551615n;
 const FOREVER = [{ start: 1n, end: MAX_UINT64 }];

--- a/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
@@ -4,7 +4,7 @@
  * Verifies that all builders produce valid { typeUrl, value } JSON
  * that passes the SDK's verifyStandardsCompliance checks.
  */
-import { verifyStandardsCompliance } from '../verify-standards.js';
+import { verifyStandardsCompliance } from '../../api-indexer/verify-standards.js';
 
 import { buildVault } from './vault.js';
 import { buildSubscription } from './subscription.js';

--- a/packages/bitbadgesjs-sdk/src/core/index.ts
+++ b/packages/bitbadgesjs-sdk/src/core/index.ts
@@ -62,7 +62,9 @@ export {
 export * from './validate.js';
 export * from './blankCriteria.js';
 export * from './audit.js';
-export * from './verify-standards.js';
+// NOTE: verify-standards.js moved to ../api-indexer/verify-standards.js — same reason as interpret.js.
+// It creates a runtime `new CollectionDoc(...)`, which requires docs-types/docs.js — and that chain
+// used to reach back into core/ mid-load, producing a "Super expression" error.
 export * from './review.js';
 
 export * from './builders/index.js';

--- a/packages/bitbadgesjs-sdk/src/core/review.ts
+++ b/packages/bitbadgesjs-sdk/src/core/review.ts
@@ -18,7 +18,7 @@
  */
 
 import { auditCollection, type AuditFinding, type AuditSeverity } from './audit.js';
-import { verifyStandardsCompliance, type StandardViolation } from './verify-standards.js';
+import { verifyStandardsCompliance, type StandardViolation } from '../api-indexer/verify-standards.js';
 import { runUxChecks } from './review-ux/index.js';
 import type { Finding, FindingSource, Localized, ReviewContext, ReviewResult, Severity } from './review-types.js';
 import { normalizeForReview, extractCollectionValue } from './review-normalize.js';


### PR DESCRIPTION
## Summary

Follow-up to #162. After publishing \`bitbadges@0.34.2\` and bumping the indexer dep, the exact same \`TypeError: Super expression must either be null or a function\` surfaced again — this time from a different cycle entry point:

\`\`\`
src/index.ts
  → core/index.ts
    → core/verify-standards.ts
      → api-indexer/docs-types/docs.ts (mid-evaluation: class extends fails)
\`\`\`

Root cause is identical to #162: \`verify-standards.ts\` calls \`new CollectionDoc(...)\` at runtime, creating a live dependency from \`core/\` into \`api-indexer/\` that cycles back mid-load.

## Fix

Move \`src/core/verify-standards.ts\` → \`src/api-indexer/verify-standards.ts\` (its natural home — it instantiates an api-indexer class). Relative imports, re-exports, and two direct importers updated.

I also **scanned the rest of the codebase for the same anti-pattern** before publishing anything this time:

\`\`\`bash
# core/*.ts files with non-type runtime imports from api-indexer/
$ for f in $(find src/core -name "*.ts" -not -name "*.spec.ts"); do
    grep -qE "^import \\\\{[^}]*\\\\} from '\\\\.\\\\./api-indexer" "$f" && echo "$f"
  done
\`\`\`

Only \`verify-standards.ts\` matches (and it's what this PR moves). No other files affected.

## Verification

- [x] \`bun run build\` passes (tsc, tsc-alias, fixup, dep-check all green).
- [x] \`madge --circular\` — \"No circular dependency found!\"
- [x] **Direct CJS load test:** 767 top-level exports probed (716 callables), **0 broken**. Before this PR, any import path touching \`core/index.ts\` threw \"Super expression\" at load time.
- [x] **Replicate the exact failing indexer specs' imports:** \`MAINNET_COINS_REGISTRY\`, \`TESTNET_COINS_REGISTRY\`, \`BitBadgesApiRoutes\`, \`GetSignInChallengeSuccessResponse\`, \`SiwbbChallengeParams\`, \`UintRangeArray\` — all resolve.
- [ ] After merge + publish \`0.34.3\` + bump indexer dep → \`test.yml\` run should no longer show 37 identical suite failures.

Public API unchanged: top-level \`import { verifyStandardsCompliance } from 'bitbadges'\` still works via the api-indexer/index.ts re-export.

## Related

- Autopilot backlog #0260 (updated with this follow-up).
- [indexer PR #102](https://github.com/BitBadges/bitbadges-indexer/pull/102) — already merged. CI exit-code gating is now working correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)