### PR TITLE
ci(genapi): skip tag pushes so Create PR step stops failing

### DIFF
--- a/.github/workflows/genapi.yml
+++ b/.github/workflows/genapi.yml
@@ -2,6 +2,8 @@ name: Generate API Documentation
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "packages/bitbadgesjs-sdk/**"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Restrict the Generate API Documentation workflow to `push` events on the `main` branch (in addition to `workflow_dispatch`).
- Tag pushes (e.g. `v0.34.3`) checkout a detached commit, which causes `peter-evans/create-pull-request@v5` to fail with "When the repository is checked out on a commit instead of a branch, the 'base' input must be supplied."
- Purpose of this workflow is to publish hosted OpenAPI after SDK changes land on `main`, so tag pushes don't need to trigger it.

Reference failing run: https://github.com/BitBadges/bitbadgesjs/actions/runs/24632433653

## Test plan
- [ ] Next push to `main` still triggers the workflow and succeeds as before
- [ ] Next release tag push does NOT trigger this workflow