### PR TITLE
SDK daily bundle 2026-04-21 — address tools, master prompt, docs, time-check bounds

### DIFF
--- a/packages/bitbadgesjs-sdk/AI_AGENT_GUIDE.md
+++ b/packages/bitbadgesjs-sdk/AI_AGENT_GUIDE.md
@@ -5,20 +5,21 @@ This guide provides comprehensive information for AI agents working with the Bit
 ## Table of Contents
 
 1. [Overview](#overview)
-2. [Installation & Setup](#installation--setup)
-3. [Core Concepts](#core-concepts)
-4. [API Client Usage](#api-client-usage)
-5. [Transaction Building](#transaction-building)
-6. [Address Conversion](#address-conversion)
-7. [Module Structure](#module-structure)
-8. [Common Patterns](#common-patterns)
-9. [Best Practices](#best-practices)
+2. [MCP Builder — Recommended Path](#mcp-builder--recommended-path)
+3. [Installation & Setup](#installation--setup)
+4. [Core Concepts](#core-concepts)
+5. [API Client Usage](#api-client-usage)
+6. [Transaction Building](#transaction-building)
+7. [Address Conversion](#address-conversion)
+8. [Module Structure](#module-structure)
+9. [Common Patterns](#common-patterns)
+10. [Best Practices](#best-practices)
 
 ---
 
 ## Overview
 
-The BitBadges SDK (`bitbadgesjs-sdk`) is a TypeScript library that provides tools for interacting with the BitBadges blockchain, API, and indexer. It's designed to work with multiple BitBadges chain versions and provides type-safe interfaces for all operations.
+The BitBadges SDK (published on npm as `bitbadges`, formerly `bitbadgesjs-sdk`) is a TypeScript library that provides tools for interacting with the BitBadges blockchain, API, and indexer. It's designed to work with multiple BitBadges chain versions and provides type-safe interfaces for all operations.
 
 ### Key Features
 
@@ -46,8 +47,45 @@ The SDK is versioned to match BitBadges chain versions:
 | v21                     | 0.26.x            |
 | v22                     | 0.27.x            |
 | v23                     | 0.28.x            |
+| v27+                    | 0.34.x            |
 
-**Current SDK Version**: 0.28.0 (compatible with BitBadges v23)
+**Current SDK Version**: 0.34.3 (compatible with BitBadges v27+). The package is published as `bitbadges` on npm — the old `bitbadgesjs-sdk` name is deprecated.
+
+---
+
+## MCP Builder — Recommended Path
+
+If you are an AI agent building a BitBadges transaction, the MCP builder server is the default entry point. It is bundled with this package as the `bitbadges-builder` bin (source: `src/builder/`) and exposes per-field tools, built-in validation, a review pass, and a recipe library for common token shapes.
+
+### Why use it
+
+- One tool per field (e.g. `set_valid_token_ids`, `add_approval`, `set_permissions`) keeps prompts small and errors localized.
+- `review_collection` and `validate_transaction` run a static audit before you ship a transaction.
+- Skill instructions, example transactions, and the master prompt are all loaded as MCP resources — no need to scrape docs.
+- The builder emits `MsgUniversalUpdateCollection` throughout, which is what every in-repo example and the chain's `tokenization` module expect.
+
+### Register with your MCP client
+
+```bash
+# Claude Code
+claude mcp add bitbadges-builder bitbadges-builder
+```
+
+For other MCP clients, point at the `bitbadges-builder` executable installed alongside this package and speak stdio.
+
+### Full docs
+
+<https://docs.bitbadges.io/for-developers/ai-agents/builder-tools>
+
+### When to fall back to the classes below
+
+Use direct class-based transaction construction when:
+
+- You need a message type the builder does not yet expose.
+- You are writing server-side code that cannot run an MCP client.
+- You are building non-transaction flows (API-only usage, read paths, balance math).
+
+For every new-collection / update-collection / subscription flow, prefer the MCP builder.
 
 ---
 
@@ -57,11 +95,13 @@ The SDK is versioned to match BitBadges chain versions:
 
 ```bash
 # Using npm
-npm install bitbadgesjs-sdk@^0.28.0
+npm install bitbadges
 
 # Using bun (recommended for this repository)
-bun add bitbadgesjs-sdk@^0.28.0
+bun add bitbadges
 ```
+
+> The package was previously published as `bitbadgesjs-sdk`. If you have install commands or imports referencing that name, update them to `bitbadges`.
 
 ### Basic Import
 

--- a/packages/bitbadgesjs-sdk/README.md
+++ b/packages/bitbadgesjs-sdk/README.md
@@ -14,6 +14,27 @@ npm install bitbadges
 bun add bitbadges
 ```
 
+## AI agents / MCP builder
+
+If you are building with an AI agent (Claude, Cursor, etc.), the recommended path is the bundled MCP builder server — it exposes per-field tools for constructing BitBadges transactions end-to-end with built-in validation, review, and examples.
+
+The package ships three bins:
+
+- `bitbadges` / `bitbadges-cli` — interactive CLI helpers
+- `bitbadges-builder` — the stdio MCP server (entry point: `src/builder/index.ts`)
+
+Point your MCP client at it:
+
+```bash
+# Claude Code
+claude mcp add bitbadges-builder bitbadges-builder
+```
+
+Full walkthrough, tool reference, and skill instructions:
+<https://docs.bitbadges.io/for-developers/ai-agents/builder-tools>
+
+Hand-rolled transaction construction via the classes below is still supported as a low-level alternative, but the MCP builder is the expected entry point for agent-driven workflows.
+
 ## Quick Start
 
 ### 1. Initialize the API Client

--- a/packages/bitbadgesjs-sdk/src/builder/resources/conceptsDocs.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/resources/conceptsDocs.ts
@@ -90,7 +90,7 @@ Collection approvals can override user-level approvals:
 
 ### v29 Approval Criteria Additions
 
-- **altTimeChecks**: Now supports \`offlineMonths\` (1-12), \`offlineDaysOfMonth\` (1-31), \`offlineWeeksOfYear\` (ISO 1-52), \`timezoneOffsetMinutes\`, and \`timezoneOffsetNegative\` in addition to the existing offlineHours/offlineDays.
+- **altTimeChecks**: Now supports \`offlineMonths\` (1-12), \`offlineDaysOfMonth\` (1-31), \`offlineWeeksOfYear\` (ISO 1-53 — ISO 8601 weeks reach 53 in long years such as 2026), \`timezoneOffsetMinutes\` (0-840; 840 = UTC+14), and \`timezoneOffsetNegative\` in addition to the existing offlineHours/offlineDays.
 - **votingChallenges**: New \`resetAfterExecution\` (bool) resets votes after a successful transfer. New \`delayAfterQuorum\` (Uint, ms) adds a timelock between quorum and execution.
 - **userApprovalSettings**: New field on approvalCriteria with \`allowedDenoms\` (string[]) and \`disableUserCoinTransfers\` (bool) to control user-level approval behavior.`,
 

--- a/packages/bitbadgesjs-sdk/src/builder/resources/learnings.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/resources/learnings.ts
@@ -218,7 +218,7 @@ const LEARNINGS: LearningEntry[] = [
   {
     topic: 'approvals',
     title: 'altTimeChecks for business-hours restrictions',
-    content: 'The altTimeChecks field on approval criteria allows denying transfers during specific UTC hours (offlineHours: 0-23), days of week (offlineDays: 0=Sunday to 6=Saturday), months (offlineMonths: 1-12), days of month (offlineDaysOfMonth: 1-31), or ISO weeks (offlineWeeksOfYear: 1-52). Use timezoneOffsetMinutes (Uint) and timezoneOffsetNegative (bool) to adjust from UTC. Works in addition to transferTimes. Useful for compliance/RWA tokens that should only trade during business hours.',
+    content: 'The altTimeChecks field on approval criteria allows denying transfers during specific UTC hours (offlineHours: 0-23), days of week (offlineDays: 0=Sunday to 6=Saturday), months (offlineMonths: 1-12), days of month (offlineDaysOfMonth: 1-31), or ISO weeks (offlineWeeksOfYear: 1-53 — ISO 8601 long years like 2026 reach week 53). Use timezoneOffsetMinutes (0-840; 840 = UTC+14 Kiribati) and timezoneOffsetNegative (bool) to adjust from UTC. Works in addition to transferTimes. Useful for compliance/RWA tokens that should only trade during business hours.',
     severity: 'tip'
   },
   {

--- a/packages/bitbadgesjs-sdk/src/builder/resources/masterPrompt.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/resources/masterPrompt.ts
@@ -136,7 +136,7 @@ The complete transaction is a JSON object with this EXACT structure:
 
 {
   "messages": [
-    { "typeUrl": "/tokenization.MsgCreateCollection", "value": {...} }
+    { "typeUrl": "/tokenization.MsgUniversalUpdateCollection", "value": {...} }
   ],
   "memo": "Optional memo text",
   "fee": {
@@ -149,7 +149,7 @@ The complete transaction is a JSON object with this EXACT structure:
 1. All numbers as strings: "1" not 1, "0" not 0
 2. UintRange format: { "start": "1", "end": "18446744073709551615" }
 3. Max uint64: "18446744073709551615" (use for "forever" time ranges)
-4. New vs edit: use MsgCreateCollection to create a new collection, MsgUpdateCollection (with real collectionId) to edit one.`,
+4. New vs edit: use MsgUniversalUpdateCollection with collectionId: "0" to create a new collection, or with a real collectionId to edit an existing one.`,
 
   messageTypes: `## Message Types
 
@@ -157,15 +157,16 @@ The complete transaction is a JSON object with this EXACT structure:
 
 | typeUrl | Purpose |
 |---------|---------|
-| /tokenization.MsgCreateCollection | Create a new collection. Keeps \`defaultBalances\` and \`invariants\`; no \`collectionId\` and no \`updateXxxTimeline\` flags. |
-| /tokenization.MsgUpdateCollection | Edit an existing collection. Requires non-zero \`collectionId\` + \`updateXxxTimeline\` flags. Never set \`defaultBalances\` or \`invariants\` here. |
+| /tokenization.MsgUniversalUpdateCollection | Create a new collection (\`collectionId: "0"\`) or edit an existing one (real \`collectionId\` + \`updateXxxTimeline\` flags). This is the message the builder session tools emit. |
 | /tokenization.MsgCreateAddressLists | Create reusable address lists |
 | /tokenization.MsgUpdateUserApprovals | Update user-level approvals |
-| /tokenization.MsgTransferTokens | Mint or transfer tokens (commonly paired after Create for initial distribution) |
+| /tokenization.MsgTransferTokens | Mint or transfer tokens (commonly paired after the Universal Update for initial distribution) |
 
 ### Message Selection
-- **New collection**: MsgCreateCollection (optionally followed by MsgTransferTokens for initial mint)
-- **Edit existing**: MsgUpdateCollection with the real \`collectionId\` and the \`updateXxxTimeline\` flags for the fields you intend to change.`,
+- **New collection**: MsgUniversalUpdateCollection with \`collectionId: "0"\` (optionally followed by MsgTransferTokens for initial mint)
+- **Edit existing**: MsgUniversalUpdateCollection with the real \`collectionId\` and the \`updateXxxTimeline\` flags for the fields you intend to change.
+
+> MsgCreateCollection and MsgUpdateCollection are lower-level alternatives that the chain also accepts, but the builder session tools and every example in this guide emit MsgUniversalUpdateCollection. Stick to that.`,
 
   msgUniversalUpdateCollection: `## MsgUniversalUpdateCollection - Complete Structure
 
@@ -524,9 +525,9 @@ For senderChecks/recipientChecks/initiatorChecks, ONLY these fields are valid:
       { "start": "1", "end": "1" }  // Block transfers on the 1st of each month (1-31)
     ],
     "offlineWeeksOfYear": [
-      { "start": "52", "end": "52" }  // Block transfers during ISO week 52 (1-52)
+      { "start": "53", "end": "53" }  // Block transfers during ISO week 53 (valid range 1-53; long ISO years like 2026 reach 53)
     ],
-    "timezoneOffsetMinutes": "300",  // Timezone offset in minutes (e.g., 300 = UTC-5 or UTC+5)
+    "timezoneOffsetMinutes": "300",  // Timezone offset in minutes. Valid range 0-840 (840 = UTC+14, Kiribati).
     "timezoneOffsetNegative": true   // If true, offset is negative (UTC-5). If false, positive (UTC+5).
   }
 }

--- a/packages/bitbadgesjs-sdk/src/builder/tools/session/addApproval.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/session/addApproval.ts
@@ -211,7 +211,7 @@ export const addApprovalSchema = z.object({
     evmQueryChallenges: z.array(z.any()).optional().describe('EVM contract query requirements. Advanced — use search_knowledge_base for details.'),
     votingChallenges: z.array(z.any()).optional().describe('Multi-sig voting requirements. Supports resetAfterExecution (bool, resets votes after quorum met) and delayAfterQuorum (Uint ms, delay before execution). Advanced — use search_knowledge_base for details.'),
     ethSignatureChallenges: z.array(z.any()).optional().describe('ETH signature requirements. Advanced — use search_knowledge_base for details.'),
-    altTimeChecks: z.any().optional().describe('Offline time blocking. Supports offlineHours (0-23), offlineDays (0=Sun-6=Sat), offlineMonths (1-12), offlineDaysOfMonth (1-31), offlineWeeksOfYear (ISO 1-52), timezoneOffsetMinutes (Uint), timezoneOffsetNegative (bool). Advanced — use search_knowledge_base for details.'),
+    altTimeChecks: z.any().optional().describe('Offline time blocking. Supports offlineHours (0-23), offlineDays (0=Sun-6=Sat), offlineMonths (1-12), offlineDaysOfMonth (1-31), offlineWeeksOfYear (ISO 1-53 — long years like 2026 reach 53), timezoneOffsetMinutes (0-840; 840 = UTC+14 Kiribati), timezoneOffsetNegative (bool). Advanced — use search_knowledge_base for details.'),
     userApprovalSettings: z.object({
       allowedDenoms: z.array(z.string()).optional().describe('Restrict which coin denominations can be used in user-level coinTransfers.'),
       disableUserCoinTransfers: z.boolean().optional().describe('If true, disable user-level coin transfers entirely for this approval.'),
@@ -402,7 +402,7 @@ export const addApprovalTool = {
           evmQueryChallenges: { type: 'array', description: 'EVM contract query requirements. Advanced — use search_knowledge_base for details.' },
           votingChallenges: { type: 'array', description: 'Multi-sig voting requirements. Supports resetAfterExecution and delayAfterQuorum. Advanced — use search_knowledge_base for details.' },
           ethSignatureChallenges: { type: 'array', description: 'ETH signature requirements. Advanced — use search_knowledge_base for details.' },
-          altTimeChecks: { type: 'object', description: 'Offline time blocking. Supports offlineHours, offlineDays, offlineMonths, offlineDaysOfMonth, offlineWeeksOfYear, timezoneOffsetMinutes, timezoneOffsetNegative. Advanced — use search_knowledge_base for details.' },
+          altTimeChecks: { type: 'object', description: 'Offline time blocking. Supports offlineHours (0-23), offlineDays (0-6), offlineMonths (1-12), offlineDaysOfMonth (1-31), offlineWeeksOfYear (ISO 1-53), timezoneOffsetMinutes (0-840), timezoneOffsetNegative. Advanced — use search_knowledge_base for details.' },
           userApprovalSettings: {
             type: 'object',
             description: 'User-level approval settings (v29). Controls allowed denoms and user coin transfer behavior.',

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/convertAddress.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/convertAddress.spec.ts
@@ -1,19 +1,18 @@
 /**
  * Tests for `convert_address` builder tool.
  *
- * convertAddress wraps bech32 encoding/decoding to move between the two
- * canonical BitBadges address formats:
- *   - 0x... (Ethereum-style, 20-byte hex)
- *   - bb1... (Cosmos bech32 with "bb" prefix)
+ * convertAddress is a thin wrapper over the SDK's canonical address helpers
+ * in `src/address-converter/converter.ts` (`convertToBitBadgesAddress`,
+ * `convertToEthAddress`, `getChainForAddress`). The MCP tool should agree
+ * with the rest of the SDK on format detection, bech32 decoding, and
+ * EIP-55 checksum rules.
  *
- * This is called by the LLM builder both for user convenience (paste either
- * format) and to normalize addresses before stuffing them into txs. The
- * round-trip property is critical — eth → bb1 → eth must give back the same
- * lowercased address, and bb1 → eth → bb1 must give back the same lowercased
- * bech32 form.
+ * The round-trip property is critical — eth → bb1 → eth must give back the
+ * same address (in the SDK's canonical ETH form, i.e. EIP-55 checksummed),
+ * and bb1 → eth → bb1 must give back the same lowercased bech32 form.
  *
  * Every code path in `handleConvertAddress` is exercised:
- *   - source detection (eth / cosmos / unknown)
+ *   - source detection via `getChainForAddress` (eth / cosmos / unknown)
  *   - auto-target selection when `targetFormat` is omitted
  *   - identity short-circuit (eth→eth, bb1→bb1)
  *   - actual conversion (both directions)
@@ -27,8 +26,12 @@ describe('handleConvertAddress', () => {
   const ETH_ZERO = '0x' + '0'.repeat(40);
   const BB1_ZERO = 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv';
 
-  // A non-zero fixture to make sure we're not just passing `00...00` through
-  const ETH_NONZERO = '0x742d35cc6634c0532925a3b844bc9e7595f0beb1';
+  // A non-zero fixture to make sure we're not just passing `00...00` through.
+  // All-lowercase hex bypasses EIP-55 checksum enforcement; the SDK's
+  // `convertToEthAddress` returns the EIP-55 checksummed form, so the
+  // round-trip lands on the mixed-case canonical string below.
+  const ETH_NONZERO_LOWER = '0x742d35cc6634c0532925a3b844bc9e7595f0beb1';
+  const ETH_NONZERO_CHECKSUM = '0x742d35cC6634c0532925A3b844bc9E7595F0beB1';
 
   describe('auto-detected target format', () => {
     it('converts 0x → bb1 when target is omitted', () => {
@@ -40,32 +43,30 @@ describe('handleConvertAddress', () => {
       expect(res.originalAddress).toBe(ETH_ZERO);
     });
 
-    it('converts bb1 → 0x when target is omitted', () => {
+    it('converts bb1 → 0x when target is omitted (returns EIP-55 checksummed form)', () => {
       const res = handleConvertAddress({ address: BB1_ZERO });
       expect(res.success).toBe(true);
       expect(res.originalFormat).toBe('bitbadges');
       expect(res.targetFormat).toBe('eth');
+      // Zero bytes have no case to check, so the checksummed form equals lowercase.
       expect(res.convertedAddress).toBe(ETH_ZERO);
     });
 
-    it('round-trips a non-zero ETH address: 0x → bb1 → 0x', () => {
-      const toBb1 = handleConvertAddress({ address: ETH_NONZERO });
+    it('round-trips a non-zero ETH address: 0x → bb1 → 0x (landing on the checksummed form)', () => {
+      const toBb1 = handleConvertAddress({ address: ETH_NONZERO_LOWER });
       expect(toBb1.success).toBe(true);
       expect(toBb1.convertedAddress).toMatch(/^bb1/);
 
       const backToEth = handleConvertAddress({ address: toBb1.convertedAddress! });
       expect(backToEth.success).toBe(true);
-      expect(backToEth.convertedAddress).toBe(ETH_NONZERO);
+      // SDK canonical form is EIP-55 checksummed, not lowercase.
+      expect(backToEth.convertedAddress).toBe(ETH_NONZERO_CHECKSUM);
     });
 
-    it('normalizes mixed-case ETH input to lowercase during conversion', () => {
-      const mixed = '0x742D35CC6634C0532925A3B844BC9E7595F0BEB1';
-      const res = handleConvertAddress({ address: mixed });
+    it('accepts already-checksummed ETH input and normalizes it through the conversion', () => {
+      const res = handleConvertAddress({ address: ETH_NONZERO_CHECKSUM });
       expect(res.success).toBe(true);
-      // The converted bb1 must be the same as the one derived from the
-      // lowercased form — confirming eth→cosmos normalizes case.
-      const expected = handleConvertAddress({ address: mixed.toLowerCase() });
-      expect(res.convertedAddress).toBe(expected.convertedAddress);
+      expect(res.convertedAddress).toMatch(/^bb1/);
     });
   });
 
@@ -88,36 +89,39 @@ describe('handleConvertAddress', () => {
     });
 
     it('explicit 0x → bitbadges produces the same result as auto-detect', () => {
-      const auto = handleConvertAddress({ address: ETH_NONZERO });
-      const explicit = handleConvertAddress({ address: ETH_NONZERO, targetFormat: 'bitbadges' });
+      const auto = handleConvertAddress({ address: ETH_NONZERO_LOWER });
+      const explicit = handleConvertAddress({ address: ETH_NONZERO_LOWER, targetFormat: 'bitbadges' });
       expect(explicit.convertedAddress).toBe(auto.convertedAddress);
     });
 
-    it('explicit bb1 → eth produces the same result as auto-detect', () => {
-      const toBb1 = handleConvertAddress({ address: ETH_NONZERO });
+    it('explicit bb1 → eth produces the same result as auto-detect (checksummed)', () => {
+      const toBb1 = handleConvertAddress({ address: ETH_NONZERO_LOWER });
       const explicit = handleConvertAddress({ address: toBb1.convertedAddress!, targetFormat: 'eth' });
       expect(explicit.success).toBe(true);
-      expect(explicit.convertedAddress).toBe(ETH_NONZERO);
+      expect(explicit.convertedAddress).toBe(ETH_NONZERO_CHECKSUM);
     });
   });
 
-  describe('rejects unknown formats', () => {
+  describe('rejects unknown / invalid formats', () => {
     it('returns success=false for an empty string', () => {
       const res = handleConvertAddress({ address: '' });
       expect(res.success).toBe(false);
       expect(res.error).toMatch(/unknown/i);
     });
 
-    it('returns success=false for a bare "0x"', () => {
+    it('returns success=false for a bare "0x" (fails conversion — no hex body)', () => {
+      // getChainForAddress('0x') still reports ETH (prefix-based), so we fall
+      // through to the converter which fails and returns the "Failed to convert"
+      // path rather than the upstream "unknown format" path.
       const res = handleConvertAddress({ address: '0x' });
       expect(res.success).toBe(false);
-      expect(res.error).toMatch(/unknown/i);
+      expect(res.error).toMatch(/failed to convert|check format/i);
     });
 
-    it('returns success=false for a 41-char 0x string (wrong length)', () => {
+    it('returns success=false for a 41-char 0x string (invalid length / checksum)', () => {
       const res = handleConvertAddress({ address: '0x' + '0'.repeat(39) });
       expect(res.success).toBe(false);
-      expect(res.error).toMatch(/unknown/i);
+      expect(res.error).toMatch(/failed to convert|check format/i);
     });
 
     it('returns success=false for a non-prefixed random string', () => {
@@ -126,14 +130,12 @@ describe('handleConvertAddress', () => {
       expect(res.error).toMatch(/unknown/i);
     });
 
-    it('surfaces bech32 decode failure as an error when bb1 checksum is corrupt', () => {
+    it('surfaces bech32 decode failure as a conversion error when bb1 checksum is corrupt', () => {
       const broken = BB1_ZERO.slice(0, -1) + 'x';
       const res = handleConvertAddress({ address: broken });
-      // The detectFormat() function only checks the prefix, so this is
-      // routed through cosmosToEth() and bech32.decode() throws.
-      // handleConvertAddress wraps that in its catch block → success: false.
       expect(res.success).toBe(false);
-      expect(res.error).toMatch(/failed to convert/i);
+      // A corrupted bb1 is detected as COSMOS by prefix, then fails in the converter.
+      expect(res.error).toMatch(/failed to convert|check format/i);
     });
   });
 });

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/convertAddress.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/convertAddress.ts
@@ -1,10 +1,17 @@
 /**
  * Tool: convert_address
- * Convert between ETH (0x) and BitBadges (bb1) address formats
+ * Convert between ETH (0x) and BitBadges (bb1) address formats.
+ *
+ * Thin wrapper over the SDK's canonical address helpers in
+ * `src/address-converter/converter.ts`. Do not reimplement bech32 here —
+ * keeping one source of truth guarantees the MCP tool agrees with the rest
+ * of the SDK (and therefore with the indexer and chain) on checksum rules,
+ * aliases (`Mint`), and `bbvaloper` handling.
  */
 
 import { z } from 'zod';
-import { bech32 } from 'bech32';
+import { convertToBitBadgesAddress, convertToEthAddress, getChainForAddress } from '../../../address-converter/converter.js';
+import { SupportedChain } from '../../../common/types.js';
 
 export const convertAddressSchema = z.object({
   address: z.string().describe('The address to convert (0x... or bb1...)'),
@@ -42,55 +49,18 @@ export const convertAddressTool = {
   }
 };
 
-/**
- * Convert Ethereum address to Cosmos (bb1) address
- */
-function ethToCosmos(ethAddress: string): string {
-  // Remove 0x prefix if present
-  const cleanAddress = ethAddress.toLowerCase().replace('0x', '');
-
-  // Convert hex string to bytes
-  const addressBytes = Buffer.from(cleanAddress, 'hex');
-
-  // Encode to bech32 with bb prefix
-  const words = bech32.toWords(addressBytes);
-  return bech32.encode('bb', words);
-}
-
-/**
- * Convert Cosmos (bb1) address to Ethereum address
- */
-function cosmosToEth(cosmosAddress: string): string {
-  // Decode bech32
-  const decoded = bech32.decode(cosmosAddress);
-
-  // Convert words back to bytes
-  const addressBytes = Buffer.from(bech32.fromWords(decoded.words));
-
-  // Convert to hex with 0x prefix
-  return '0x' + addressBytes.toString('hex');
-}
-
-/**
- * Detect address format
- */
-function detectFormat(address: string): 'eth' | 'cosmos' | 'unknown' {
-  if (address.startsWith('0x') && address.length === 42) {
-    return 'eth';
-  }
-  if (address.startsWith('bb1')) {
-    return 'cosmos';
-  }
+function chainToFormat(chain: SupportedChain): 'eth' | 'bitbadges' | 'unknown' {
+  if (chain === SupportedChain.ETH) return 'eth';
+  if (chain === SupportedChain.COSMOS) return 'bitbadges';
   return 'unknown';
 }
 
 export function handleConvertAddress(input: ConvertAddressInput): ConvertAddressResult {
   try {
     const { address } = input;
-    const sourceFormat = detectFormat(address);
 
-    // Auto-detect target format if not specified
-    const targetFormat = input.targetFormat || (sourceFormat === 'eth' ? 'bitbadges' : 'eth');
+    const chain = getChainForAddress(address);
+    const sourceFormat = chainToFormat(chain);
 
     if (sourceFormat === 'unknown') {
       return {
@@ -99,36 +69,22 @@ export function handleConvertAddress(input: ConvertAddressInput): ConvertAddress
       };
     }
 
-    // Check if already in target format
-    if ((sourceFormat === 'eth' && targetFormat === 'eth') ||
-        (sourceFormat === 'cosmos' && targetFormat === 'bitbadges')) {
-      return {
-        success: true,
-        originalAddress: address,
-        convertedAddress: address,
-        originalFormat: sourceFormat === 'eth' ? 'eth' : 'bitbadges',
-        targetFormat: targetFormat
-      };
-    }
+    const targetFormat = input.targetFormat ?? (sourceFormat === 'eth' ? 'bitbadges' : 'eth');
 
-    // Convert
-    let convertedAddress: string;
-    if (sourceFormat === 'eth' && targetFormat === 'bitbadges') {
-      convertedAddress = ethToCosmos(address);
-    } else if (sourceFormat === 'cosmos' && targetFormat === 'eth') {
-      convertedAddress = cosmosToEth(address);
-    } else {
+    const converted = targetFormat === 'eth' ? convertToEthAddress(address) : convertToBitBadgesAddress(address);
+
+    if (!converted) {
       return {
         success: false,
-        error: `Cannot convert from ${sourceFormat} to ${targetFormat}`
+        error: `Failed to convert address "${address}" to ${targetFormat}. Check format and checksum.`
       };
     }
 
     return {
       success: true,
       originalAddress: address,
-      convertedAddress,
-      originalFormat: sourceFormat === 'eth' ? 'eth' : 'bitbadges',
+      convertedAddress: converted,
+      originalFormat: sourceFormat,
       targetFormat
     };
   } catch (error) {

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateAddress.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateAddress.spec.ts
@@ -1,19 +1,17 @@
 /**
  * Tests for `validate_address` builder tool.
  *
- * validateAddress is called by the LLM builder to confirm user-supplied addresses
- * before putting them into on-chain transactions. Misclassifying a valid address
- * or accepting an invalid one would cause downstream tx failures, so the
- * function must be airtight across every input shape we actually encounter:
+ * validateAddress is a thin wrapper over the SDK's canonical address helpers
+ * (`getChainForAddress`, `isAddressValid`, `convertToBitBadgesAddress`). The
+ * MCP tool should return the same answer the rest of the SDK (and therefore
+ * the indexer and chain) would return for the same address.
  *
- *   - empty / whitespace strings
- *   - 0x prefix with invalid length / invalid hex
- *   - valid 20-byte ETH addresses (mixed case)
- *   - bb1 / cosmos1 bech32 addresses with valid + invalid checksums
- *   - generic bech32 addresses from other chains (osmo1, ibc channel ids, etc.)
- *   - strings that look like addresses but aren't
- *
- * Each branch in `handleValidateAddress` is exercised at least once.
+ * Scope: only `0x` (ETH) and `bb`-prefixed (BitBadges bech32, including
+ * `bbvaloper`) addresses count as "known". Other bech32 prefixes
+ * (`cosmos1`, `osmo1`, `juno1`, etc.) are not BitBadges-supported chains and
+ * report as `chain: 'unknown'`. This matches `getChainForAddress` and avoids
+ * the prior footgun where `validate_address` would accept a foreign bech32
+ * that subsequently broke any BitBadges tool downstream.
  */
 
 import { handleValidateAddress } from './validateAddress.js';
@@ -55,11 +53,23 @@ describe('handleValidateAddress', () => {
       expect(res.details?.length).toBe(42);
     });
 
-    it('accepts a well-formed 0x address with mixed case and normalizes to lowercase', () => {
+    it('rejects a mixed-case 0x address that fails the EIP-55 checksum', () => {
+      // Mixed-case addresses must satisfy the EIP-55 checksum. This one does
+      // not, so the canonical SDK helper rejects it — a correctness tighten
+      // over the old hand-rolled `/^[0-9a-fA-F]+$/` check that accepted it.
       const addr = '0xAbCdEf0123456789aBcDeF0123456789AbCdEf01';
       const res = handleValidateAddress({ address: addr });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('eth');
+    });
+
+    it('accepts a valid EIP-55 checksummed 0x address', () => {
+      // Derived by round-tripping an all-lowercase form through the SDK's
+      // checksum encoder.
+      const addr = '0x742d35cC6634c0532925A3b844bc9E7595F0beB1';
+      const res = handleValidateAddress({ address: addr });
       expect(res.valid).toBe(true);
-      expect(res.normalized).toBe(addr.toLowerCase());
+      expect(res.chain).toBe('eth');
     });
 
     it('rejects a 0x address that is too short (41 chars)', () => {
@@ -102,7 +112,6 @@ describe('handleValidateAddress', () => {
       expect(res.chain).toBe('cosmos');
       expect(res.details?.prefix).toBe('bb');
       expect(res.details?.format).toBe('bech32');
-      expect(res.normalized).toBe(validBb1.toLowerCase());
     });
 
     it('rejects a bb1 address with a corrupted checksum', () => {
@@ -115,37 +124,25 @@ describe('handleValidateAddress', () => {
     });
   });
 
-  describe('Cosmos-prefixed (cosmos1) addresses', () => {
-    // Valid cosmos1 encoding of 20 zero bytes
+  describe('non-BitBadges bech32 prefixes are not recognized', () => {
+    // Valid cosmos1 encoding of 20 zero bytes — still not a BitBadges chain.
     const validCosmos1 = 'cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a';
-
-    it('accepts a valid cosmos1 address', () => {
-      const res = handleValidateAddress({ address: validCosmos1 });
-      expect(res.valid).toBe(true);
-      expect(res.chain).toBe('cosmos');
-      expect(res.details?.prefix).toBe('cosmos');
-    });
-
-    it('rejects a cosmos1 address with invalid checksum', () => {
-      const broken = validCosmos1.slice(0, -1) + 'z';
-      const res = handleValidateAddress({ address: broken });
-      expect(res.valid).toBe(false);
-      expect(res.chain).toBe('cosmos');
-    });
-  });
-
-  describe('generic bech32 (other-chain prefixes)', () => {
-    // osmo1 of 20 zero bytes
+    // osmo1 of 20 zero bytes — same deal.
     const validOsmo = 'osmo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqmcn030';
 
-    it('accepts a valid osmo1 bech32 address via generic fallback', () => {
-      const res = handleValidateAddress({ address: validOsmo });
-      expect(res.valid).toBe(true);
-      expect(res.chain).toBe('cosmos');
-      expect(res.details?.prefix).toBe('osmo');
+    it('reports cosmos1 addresses as chain=unknown (not a BitBadges-supported chain)', () => {
+      const res = handleValidateAddress({ address: validCosmos1 });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('unknown');
     });
 
-    it('rejects an arbitrary non-bech32 string that has no 0x/bb1/cosmos1 prefix', () => {
+    it('reports osmo1 addresses as chain=unknown (not a BitBadges-supported chain)', () => {
+      const res = handleValidateAddress({ address: validOsmo });
+      expect(res.valid).toBe(false);
+      expect(res.chain).toBe('unknown');
+    });
+
+    it('rejects an arbitrary non-bech32 string with no supported prefix', () => {
       const res = handleValidateAddress({ address: 'foo1bar' });
       expect(res.valid).toBe(false);
       expect(res.chain).toBe('unknown');
@@ -154,8 +151,8 @@ describe('handleValidateAddress', () => {
 
   describe('output shape is consistent', () => {
     it('always returns success=true for non-throw paths (even when address is invalid)', () => {
-      // This is important for MCP tool contracts — `success` means "the tool ran",
-      // not "the address is valid". Downstream agents check `valid` separately.
+      // `success` means "the tool ran", not "the address is valid". Downstream
+      // agents check `valid` separately.
       const cases = ['', '0x', '0xdead', 'bb1broken', 'random', '   '];
       for (const addr of cases) {
         const res = handleValidateAddress({ address: addr });

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateAddress.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateAddress.ts
@@ -1,10 +1,20 @@
 /**
  * Tool: validate_address
- * Check if an address is valid and detect its chain type
+ * Check if an address is valid and detect its chain type.
+ *
+ * Thin wrapper over the SDK's canonical address helpers in
+ * `src/address-converter/converter.ts`. This guarantees the MCP tool applies
+ * the same checksum and prefix rules as the rest of the SDK (and therefore
+ * as the indexer and chain).
  */
 
 import { z } from 'zod';
-import { bech32 } from 'bech32';
+import {
+  convertToBitBadgesAddress,
+  getChainForAddress,
+  isAddressValid
+} from '../../../address-converter/converter.js';
+import { SupportedChain } from '../../../common/types.js';
 
 export const validateAddressSchema = z.object({
   address: z.string().describe('The address to validate')
@@ -40,44 +50,10 @@ export const validateAddressTool = {
   }
 };
 
-/**
- * Validate an Ethereum address
- */
-function isValidEthAddress(address: string): boolean {
-  if (!address.startsWith('0x')) {
-    return false;
-  }
-  if (address.length !== 42) {
-    return false;
-  }
-  // Check if it's valid hex
-  const hexPart = address.slice(2);
-  return /^[0-9a-fA-F]+$/.test(hexPart);
-}
-
-/**
- * Validate a Cosmos/BitBadges address
- */
-function isValidCosmosAddress(address: string): { valid: boolean; prefix?: string } {
-  try {
-    const decoded = bech32.decode(address);
-    return {
-      valid: true,
-      prefix: decoded.prefix
-    };
-  } catch {
-    return { valid: false };
-  }
-}
-
-/**
- * Normalize an address to lowercase
- */
-function normalizeAddress(address: string, chain: 'eth' | 'cosmos'): string {
-  if (chain === 'eth') {
-    return address.toLowerCase();
-  }
-  return address.toLowerCase();
+function chainLabel(chain: SupportedChain): 'eth' | 'cosmos' | 'unknown' {
+  if (chain === SupportedChain.ETH) return 'eth';
+  if (chain === SupportedChain.COSMOS) return 'cosmos';
+  return 'unknown';
 }
 
 export function handleValidateAddress(input: ValidateAddressInput): ValidateAddressResult {
@@ -93,14 +69,30 @@ export function handleValidateAddress(input: ValidateAddressInput): ValidateAddr
       };
     }
 
-    // Check for ETH address
-    if (address.startsWith('0x')) {
-      const isValid = isValidEthAddress(address);
+    const chain = getChainForAddress(address);
+    const chainName = chainLabel(chain);
+
+    if (chain === SupportedChain.UNKNOWN) {
       return {
         success: true,
-        valid: isValid,
-        chain: 'eth',
-        normalized: isValid ? normalizeAddress(address, 'eth') : undefined,
+        valid: false,
+        chain: 'unknown',
+        details: {
+          length: address.length,
+          format: 'unknown'
+        },
+        error: 'Address format not recognized. Expected 0x... (ETH) or bb1... (BitBadges)'
+      };
+    }
+
+    const valid = isAddressValid(address, chain);
+
+    if (chain === SupportedChain.ETH) {
+      return {
+        success: true,
+        valid,
+        chain: chainName,
+        normalized: valid ? address.toLowerCase() : undefined,
         details: {
           prefix: '0x',
           length: address.length,
@@ -109,48 +101,20 @@ export function handleValidateAddress(input: ValidateAddressInput): ValidateAddr
       };
     }
 
-    // Check for Cosmos/BitBadges address
-    if (address.startsWith('bb1') || address.startsWith('cosmos1')) {
-      const cosmosResult = isValidCosmosAddress(address);
-      return {
-        success: true,
-        valid: cosmosResult.valid,
-        chain: 'cosmos',
-        normalized: cosmosResult.valid ? normalizeAddress(address, 'cosmos') : undefined,
-        details: {
-          prefix: cosmosResult.prefix,
-          length: address.length,
-          format: 'bech32'
-        }
-      };
-    }
-
-    // Try to decode as generic bech32
-    const cosmosResult = isValidCosmosAddress(address);
-    if (cosmosResult.valid) {
-      return {
-        success: true,
-        valid: true,
-        chain: 'cosmos',
-        normalized: normalizeAddress(address, 'cosmos'),
-        details: {
-          prefix: cosmosResult.prefix,
-          length: address.length,
-          format: 'bech32'
-        }
-      };
-    }
-
-    // Unknown format
+    // COSMOS: derive canonical bb1 form via the SDK helper so `bbvaloper` and
+    // other bb-prefixed addresses are normalized consistently.
+    const canonical = valid ? convertToBitBadgesAddress(address) : '';
+    const prefix = address.startsWith('bbvaloper') ? 'bbvaloper' : address.startsWith('bb') ? 'bb' : undefined;
     return {
       success: true,
-      valid: false,
-      chain: 'unknown',
+      valid,
+      chain: chainName,
+      normalized: valid ? (canonical || address.toLowerCase()) : undefined,
       details: {
+        prefix,
         length: address.length,
-        format: 'unknown'
-      },
-      error: 'Address format not recognized. Expected 0x... (ETH) or bb1... (BitBadges)'
+        format: 'bech32'
+      }
     };
   } catch (error) {
     return {


### PR DESCRIPTION
Daily bundle for 2026-04-21. Four small, independent tickets that all land in `packages/bitbadgesjs-sdk/` — grouped into one PR per the dev-coordinator playbook.

## Tickets covered

### #0265 — MCP address tools now call SDK canonical helpers
`convert_address` and `validate_address` in `src/builder/tools/utilities/` were reimplementing bech32 encoding, hex validation, and prefix detection on top of the raw `bech32` package. The SDK already exports `convertToBitBadgesAddress`, `convertToEthAddress`, `isAddressValid`, and `getChainForAddress` from `src/address-converter/converter.ts` — built on `web3-validator` and `crypto-addr-codec`, with EIP-55 checksum enforcement and `bbvaloper` support. Replaced the private helpers with calls to those exports. ~200 lines deleted.

Three user-visible behaviour tightenings (correctness fixes, not regressions — the rest of the SDK already behaved this way):

- Mixed-case `0x` addresses that fail the EIP-55 checksum are now rejected.
- `bb1 → 0x` now returns the canonical EIP-55 checksummed form.
- `cosmos1` / `osmo1` and other non-bb bech32 prefixes report as `chain=unknown` rather than `chain=cosmos`.

Specs updated to match. 30/30 address tests pass; full SDK suite 1933/1933 passing.

Implements backlog #0265.

### #0267 — master prompt no longer contradicts itself on the create-collection message
The Build → Review → Deploy master prompt in `src/builder/resources/masterPrompt.ts` told agents three different things on the same page: workflow said `MsgUniversalUpdateCollection` (which is what the session tools actually emit), Transaction Structure example said `MsgCreateCollection`, and the Message Types table listed `MsgCreateCollection` / `MsgUpdateCollection` as primary. Agents reading top-to-bottom usually trusted the concrete example, which was the wrong one.

Flipped the Transaction Structure example to `MsgUniversalUpdateCollection`, rewrote the "New vs edit" rule around `collectionId: "0"` vs real id, and reworked the Message Types table to list `MsgUniversalUpdateCollection` as primary with `MsgCreateCollection` / `MsgUpdateCollection` noted as lower-level alternatives.

Implements backlog #0267.

### #0269 — README + AI_AGENT_GUIDE now mention the MCP builder
The `bitbadges` npm package ships three bins — `bitbadges`, `bitbadges-cli`, and `bitbadges-builder` — and the third is the stdio MCP server, the recommended entry point for AI agents. But neither `README.md` nor `AI_AGENT_GUIDE.md` mentioned it. An agent landing on either file saw only the manual class-based path.

- `README.md`: added an "AI agents / MCP builder" section between Install and Quick Start, with the `claude mcp add bitbadges-builder bitbadges-builder` one-liner and a link to the docs.
- `AI_AGENT_GUIDE.md`: added a new top-level "MCP Builder — Recommended Path" section (indexed in the table of contents), extended the chain-to-SDK version table to v27+ / 0.34.x, refreshed the "Current SDK Version" line from the stale `0.28.0 (v23)` to `0.34.3 (v27+)`, and switched install examples from the deprecated `bitbadgesjs-sdk` package name to `bitbadges`.

Inline `import { ... } from 'bitbadgesjs-sdk'` code examples further down in the guide were left as-is — renaming them sweeps a lot more surface and is out of scope for this ticket.

Implements backlog #0269.

### #0270 — altTimeChecks bounds match chain v29
Chain PR #73 pinned the authoritative bounds for `AltTimeChecks` fields: `offlineWeeksOfYear [1, 53]` (ISO 8601 long years like 2026 reach 53) and `timezoneOffsetMinutes [0, 840]` (UTC+14, Kiribati). Four SDK builder-resource surfaces still advertised weeks 1-52 and gave no upper bound at all for the timezone offset. An agent following those resources could construct a transaction that `ValidateBasic` rejects.

Fixed all four references:

- `src/builder/resources/conceptsDocs.ts` (v29 approval-criteria bullet)
- `src/builder/resources/learnings.ts` (altTimeChecks tip)
- `src/builder/tools/session/addApproval.ts:214` (Zod describe)
- `src/builder/tools/session/addApproval.ts:405` (JSON-schema describe)

Also bumped the `offlineWeeksOfYear` example in `masterPrompt.ts` from 52 to 53 so the example no longer hides the real max. The docs-side companion is in bitbadges-docs PR #45 — that PR opens and merges independently.

Implements backlog #0270.

## Testing
- `bun run test` — 56 suites / 1933 tests pass.
- `bun run build` — clean, no circular deps.

## Rollout
Each ticket is an independent, backwards-compatible SDK tightening. No chain change, no new dependencies.

Generated by the BitBadges dev-coordinator daily run.