### PR TITLE
test(mcp-builder): cover 4 session setter handlers (48 tests)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/builder/tools/session/setInvariants.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/session/setInvariants.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for `set_invariants` builder tool.
+ *
+ * handleSetInvariants is a thin wrapper around setInvariantsInSession. It's
+ * trivial in code but important to pin down because invariants cannot be
+ * removed after collection creation — a wrong value set here is
+ * un-reversible on-chain. These tests verify:
+ *
+ *   - happy paths for each invariant shape (none / subscription / smart token)
+ *   - explicit `null` to clear invariants is passed through verbatim
+ *   - `updateInvariants` flag is flipped so downstream tx uses the value
+ *   - session isolation by sessionId
+ *   - re-calling replaces (set semantics), does not merge
+ */
+import { handleSetInvariants } from './setInvariants.js';
+import { getOrCreateSession, resetAllSessions } from '../../session/sessionState.js';
+
+describe('handleSetInvariants', () => {
+  beforeEach(() => resetAllSessions());
+
+  it('writes a simple noCustomOwnershipTimes=true invariant', () => {
+    const res = handleSetInvariants({ invariants: { noCustomOwnershipTimes: true } });
+    expect(res.success).toBe(true);
+    expect(getOrCreateSession().messages[0].value.invariants).toEqual({ noCustomOwnershipTimes: true });
+    expect(getOrCreateSession().messages[0].value.updateInvariants).toBe(true);
+  });
+
+  it('writes a subscription-style invariant (noCustomOwnershipTimes=false, maxSupplyPerId=1)', () => {
+    const res = handleSetInvariants({
+      invariants: { noCustomOwnershipTimes: false, maxSupplyPerId: '1' }
+    });
+    expect(res.success).toBe(true);
+    const inv = getOrCreateSession().messages[0].value.invariants;
+    expect(inv.noCustomOwnershipTimes).toBe(false);
+    expect(inv.maxSupplyPerId).toBe('1');
+  });
+
+  it('writes a full smart-token invariant with cosmosCoinBackedPath', () => {
+    const path = {
+      conversion: {
+        sideA: { amount: '1', denom: 'ibc/ABC123' },
+        sideB: [{
+          amount: '1',
+          tokenIds: [{ start: '1', end: '1' }],
+          ownershipTimes: [{ start: '1', end: '18446744073709551615' }]
+        }]
+      }
+    };
+    const res = handleSetInvariants({ invariants: { cosmosCoinBackedPath: path } });
+    expect(res.success).toBe(true);
+    expect(getOrCreateSession().messages[0].value.invariants.cosmosCoinBackedPath).toEqual(path);
+  });
+
+  it('passes through null to clear invariants', () => {
+    handleSetInvariants({ invariants: { noCustomOwnershipTimes: true } });
+    const res = handleSetInvariants({ invariants: null });
+    expect(res.success).toBe(true);
+    expect(getOrCreateSession().messages[0].value.invariants).toBeNull();
+  });
+
+  it('replaces invariants on re-call (does not merge)', () => {
+    handleSetInvariants({ invariants: { noCustomOwnershipTimes: true, maxSupplyPerId: '0' } });
+    handleSetInvariants({ invariants: { disablePoolCreation: true } });
+    const inv = getOrCreateSession().messages[0].value.invariants;
+    expect(inv).toEqual({ disablePoolCreation: true });
+    expect(inv.noCustomOwnershipTimes).toBeUndefined();
+  });
+
+  it('isolates invariants per sessionId', () => {
+    handleSetInvariants({ sessionId: 'a', invariants: { noCustomOwnershipTimes: true } });
+    handleSetInvariants({ sessionId: 'b', invariants: { noCustomOwnershipTimes: false } });
+    expect(getOrCreateSession('a').messages[0].value.invariants.noCustomOwnershipTimes).toBe(true);
+    expect(getOrCreateSession('b').messages[0].value.invariants.noCustomOwnershipTimes).toBe(false);
+  });
+
+  it('auto-creates a session if none exists', () => {
+    handleSetInvariants({ invariants: { noCustomOwnershipTimes: true } });
+    // The call should have created the default session even though we never
+    // explicitly initialised it elsewhere.
+    expect(getOrCreateSession().messages).toHaveLength(1);
+    expect(getOrCreateSession().messages[0].typeUrl).toBe('/tokenization.MsgUniversalUpdateCollection');
+  });
+
+  it('uses creatorAddress when initialising a fresh session', () => {
+    handleSetInvariants({ creatorAddress: 'bb1abc', invariants: { noCustomOwnershipTimes: true } });
+    // creator is bech32-normalised by ensureBb1; we only assert it is non-empty.
+    const value = getOrCreateSession().messages[0].value;
+    expect(typeof value.creator).toBe('string');
+    expect(value.creator.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/session/setInvariants.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/session/setInvariants.spec.ts
@@ -19,10 +19,14 @@ describe('handleSetInvariants', () => {
   beforeEach(() => resetAllSessions());
 
   it('writes a simple noCustomOwnershipTimes=true invariant', () => {
+    const session = getOrCreateSession();
+    // updateInvariants defaults to true, so the assertion below would be
+    // vacuous without first resetting to false.
+    session.messages[0].value.updateInvariants = false;
     const res = handleSetInvariants({ invariants: { noCustomOwnershipTimes: true } });
     expect(res.success).toBe(true);
-    expect(getOrCreateSession().messages[0].value.invariants).toEqual({ noCustomOwnershipTimes: true });
-    expect(getOrCreateSession().messages[0].value.updateInvariants).toBe(true);
+    expect(session.messages[0].value.invariants).toEqual({ noCustomOwnershipTimes: true });
+    expect(session.messages[0].value.updateInvariants).toBe(true);
   });
 
   it('writes a subscription-style invariant (noCustomOwnershipTimes=false, maxSupplyPerId=1)', () => {

--- a/packages/bitbadgesjs-sdk/src/builder/tools/session/setMintEscrowCoins.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/session/setMintEscrowCoins.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for `set_mint_escrow_coins` builder tool.
+ *
+ * handleSetMintEscrowCoins funds the mint escrow on collection creation and
+ * is load-bearing for quest-reward and auto-payout flows. The handler has
+ * two non-trivial branches beyond the basic pass-through:
+ *
+ *   1. AI frequently passes `coins` as a JSON-encoded string instead of a
+ *      real array. The handler attempts JSON.parse, falls back to a helpful
+ *      error on parse failure.
+ *   2. The chain only supports one coin entry in mintEscrowCoinsToTransfer.
+ *      The handler rejects arrays of length >1 with a clear error message.
+ *
+ * These tests cover both branches plus the happy path, session mutation, and
+ * sessionId isolation.
+ */
+import { handleSetMintEscrowCoins } from './setMintEscrowCoins.js';
+import { getOrCreateSession, resetAllSessions } from '../../session/sessionState.js';
+
+describe('handleSetMintEscrowCoins', () => {
+  beforeEach(() => resetAllSessions());
+
+  describe('happy path', () => {
+    it('accepts a single coin entry and writes it to the session', () => {
+      const res = handleSetMintEscrowCoins({ coins: [{ denom: 'ubadge', amount: '1000' }] });
+      expect(res.success).toBe(true);
+      expect(res.coins).toEqual([{ denom: 'ubadge', amount: '1000' }]);
+      expect(getOrCreateSession().messages[0].value.mintEscrowCoinsToTransfer).toEqual([{ denom: 'ubadge', amount: '1000' }]);
+    });
+
+    it('accepts an empty coin array (no funding)', () => {
+      const res = handleSetMintEscrowCoins({ coins: [] });
+      expect(res.success).toBe(true);
+      expect(res.coins).toEqual([]);
+    });
+
+    it('accepts an IBC denom', () => {
+      const res = handleSetMintEscrowCoins({
+        coins: [{ denom: 'ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349', amount: '42' }]
+      });
+      expect(res.success).toBe(true);
+    });
+  });
+
+  describe('chain constraint: at most one coin entry', () => {
+    it('rejects an array with two entries', () => {
+      const res = handleSetMintEscrowCoins({
+        coins: [
+          { denom: 'ubadge', amount: '100' },
+          { denom: 'ustake', amount: '200' }
+        ]
+      } as any);
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/at most 1/i);
+    });
+
+    it('rejects an array with three entries', () => {
+      const res = handleSetMintEscrowCoins({
+        coins: [
+          { denom: 'a', amount: '1' },
+          { denom: 'b', amount: '2' },
+          { denom: 'c', amount: '3' }
+        ]
+      } as any);
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/at most 1/i);
+    });
+  });
+
+  describe('JSON-string coercion (AI quirk)', () => {
+    it('parses a JSON array string into an array', () => {
+      const res = handleSetMintEscrowCoins({ coins: '[{"denom":"ubadge","amount":"1000"}]' } as any);
+      expect(res.success).toBe(true);
+      expect(res.coins).toEqual([{ denom: 'ubadge', amount: '1000' }]);
+    });
+
+    it('rejects an unparseable JSON string with a helpful error', () => {
+      const res = handleSetMintEscrowCoins({ coins: 'not-valid-json' } as any);
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/array of \{denom, amount\}/i);
+    });
+
+    it('still applies the 1-entry cap after JSON parsing', () => {
+      const res = handleSetMintEscrowCoins({
+        coins: '[{"denom":"a","amount":"1"},{"denom":"b","amount":"2"}]'
+      } as any);
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/at most 1/i);
+    });
+  });
+
+  describe('session mutation', () => {
+    it('replaces coins on re-call (set semantics)', () => {
+      handleSetMintEscrowCoins({ coins: [{ denom: 'ubadge', amount: '100' }] });
+      handleSetMintEscrowCoins({ coins: [{ denom: 'ustake', amount: '200' }] });
+      expect(getOrCreateSession().messages[0].value.mintEscrowCoinsToTransfer).toEqual([{ denom: 'ustake', amount: '200' }]);
+    });
+
+    it('isolates coins per sessionId', () => {
+      handleSetMintEscrowCoins({ sessionId: 'a', coins: [{ denom: 'ubadge', amount: '10' }] });
+      handleSetMintEscrowCoins({ sessionId: 'b', coins: [{ denom: 'ustake', amount: '20' }] });
+      expect(getOrCreateSession('a').messages[0].value.mintEscrowCoinsToTransfer).toEqual([{ denom: 'ubadge', amount: '10' }]);
+      expect(getOrCreateSession('b').messages[0].value.mintEscrowCoinsToTransfer).toEqual([{ denom: 'ustake', amount: '20' }]);
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/session/setStandards.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/session/setStandards.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for `set_standards` builder tool.
+ *
+ * handleSetStandards sets the collection's `standards` array. Beyond pushing
+ * the value into the session, it does one piece of soft validation: if a
+ * standard is not in the KNOWN_STANDARDS whitelist AND it doesn't look like
+ * a dynamic qualifier (contains ":", e.g. `NFTPricingDenom:ubadge`), the
+ * handler attaches a `warnings` array so the model can fix typos without
+ * blocking the call (custom standards are still allowed).
+ *
+ * These tests verify:
+ *   - known standards pass silently (no warnings key)
+ *   - unknown standards produce a warning each
+ *   - dynamic standards (ListView:*, NFTPricingDenom:*, DefaultDisplayCurrency:*)
+ *     are never warned about
+ *   - the session state is mutated correctly on every branch
+ */
+import { handleSetStandards } from './setStandards.js';
+import { getOrCreateSession, resetAllSessions } from '../../session/sessionState.js';
+
+describe('handleSetStandards', () => {
+  beforeEach(() => resetAllSessions());
+
+  describe('whitelist pass-through', () => {
+    it('accepts a known single standard with no warnings', () => {
+      const res = handleSetStandards({ standards: ['NFTs'] });
+      expect(res.success).toBe(true);
+      expect(res.standards).toEqual(['NFTs']);
+      expect(res).not.toHaveProperty('warnings');
+    });
+
+    it('accepts multiple known standards', () => {
+      const res = handleSetStandards({
+        standards: ['NFTs', 'NFTMarketplace', 'Tradable']
+      });
+      expect(res.success).toBe(true);
+      expect(res).not.toHaveProperty('warnings');
+    });
+
+    it('accepts known smart-token combo', () => {
+      const res = handleSetStandards({ standards: ['Smart Token', 'AI Agent Vault'] });
+      expect(res.success).toBe(true);
+      expect(res).not.toHaveProperty('warnings');
+    });
+
+    it('accepts an empty standards array', () => {
+      const res = handleSetStandards({ standards: [] });
+      expect(res.success).toBe(true);
+      expect(res.standards).toEqual([]);
+    });
+  });
+
+  describe('dynamic qualifiers (contain ":")', () => {
+    it('does not warn about NFTPricingDenom:ubadge', () => {
+      const res = handleSetStandards({
+        standards: ['NFTs', 'NFTPricingDenom:ubadge']
+      });
+      expect(res).not.toHaveProperty('warnings');
+    });
+
+    it('does not warn about ListView:something', () => {
+      const res = handleSetStandards({
+        standards: ['ListView:mycustomview']
+      });
+      expect(res).not.toHaveProperty('warnings');
+    });
+
+    it('does not warn about DefaultDisplayCurrency:usd', () => {
+      const res = handleSetStandards({ standards: ['DefaultDisplayCurrency:usd'] });
+      expect(res).not.toHaveProperty('warnings');
+    });
+  });
+
+  describe('unknown standards produce warnings', () => {
+    it('warns for a single typo standard', () => {
+      const res: any = handleSetStandards({ standards: ['NFT'] }); // missing trailing 's'
+      expect(res.success).toBe(true);
+      expect(res.warnings).toBeDefined();
+      expect(res.warnings).toHaveLength(1);
+      expect(res.warnings[0]).toMatch(/"NFT".*not a recognized standard/i);
+    });
+
+    it('warns once per unknown entry in a mixed array', () => {
+      const res: any = handleSetStandards({
+        standards: ['NFTs', 'Bogus', 'Smart Token', 'AlsoBogus']
+      });
+      expect(res.warnings).toHaveLength(2);
+      expect(res.warnings[0]).toMatch(/Bogus/);
+      expect(res.warnings[1]).toMatch(/AlsoBogus/);
+    });
+
+    it('still writes unknown standards into the session (custom allowed)', () => {
+      handleSetStandards({ standards: ['CustomStandard'] });
+      expect(getOrCreateSession().messages[0].value.standards).toEqual(['CustomStandard']);
+    });
+  });
+
+  describe('session mutation', () => {
+    it('flips updateStandards=true', () => {
+      handleSetStandards({ standards: ['NFTs'] });
+      expect(getOrCreateSession().messages[0].value.updateStandards).toBe(true);
+    });
+
+    it('replaces standards on re-call', () => {
+      handleSetStandards({ standards: ['NFTs'] });
+      handleSetStandards({ standards: ['Fungible Tokens'] });
+      expect(getOrCreateSession().messages[0].value.standards).toEqual(['Fungible Tokens']);
+    });
+
+    it('isolates by sessionId', () => {
+      handleSetStandards({ sessionId: 'a', standards: ['NFTs'] });
+      handleSetStandards({ sessionId: 'b', standards: ['Subscriptions'] });
+      expect(getOrCreateSession('a').messages[0].value.standards).toEqual(['NFTs']);
+      expect(getOrCreateSession('b').messages[0].value.standards).toEqual(['Subscriptions']);
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/session/setStandards.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/session/setStandards.spec.ts
@@ -97,8 +97,12 @@ describe('handleSetStandards', () => {
 
   describe('session mutation', () => {
     it('flips updateStandards=true', () => {
+      const session = getOrCreateSession();
+      // updateStandards defaults to true, so the assertion below would be
+      // vacuous without first resetting to false.
+      session.messages[0].value.updateStandards = false;
       handleSetStandards({ standards: ['NFTs'] });
-      expect(getOrCreateSession().messages[0].value.updateStandards).toBe(true);
+      expect(session.messages[0].value.updateStandards).toBe(true);
     });
 
     it('replaces standards on re-call', () => {

--- a/packages/bitbadgesjs-sdk/src/builder/tools/session/setValidTokenIds.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/session/setValidTokenIds.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for `set_valid_token_ids` builder tool.
+ *
+ * handleSetValidTokenIds validates a list of token-id ranges (uint64 strings)
+ * and writes them into the in-memory session. The file previously had zero
+ * tests even though the validation logic is the last line of defense before a
+ * malformed tokenIds array reaches the chain — negative values, reversed
+ * ranges, or out-of-uint64 bounds would all abort the transaction at tx-check
+ * time. Every branch in the validator (negative start/end, >MAX_UINT64
+ * start/end, start>end, non-numeric) is exercised below.
+ *
+ * On success we also verify the session state is mutated the way downstream
+ * per-field tools assume: `validTokenIds` set to the provided array and
+ * `updateValidTokenIds` flagged true.
+ */
+import { handleSetValidTokenIds } from './setValidTokenIds.js';
+import { getOrCreateSession, resetAllSessions } from '../../session/sessionState.js';
+
+const MAX_UINT64 = '18446744073709551615';
+
+describe('handleSetValidTokenIds', () => {
+  beforeEach(() => resetAllSessions());
+
+  describe('happy path', () => {
+    it('accepts a single 1..1 range (fungible token / subscription)', () => {
+      const res = handleSetValidTokenIds({ tokenIds: [{ start: '1', end: '1' }] });
+      expect(res.success).toBe(true);
+      expect(res.tokenIds).toEqual([{ start: '1', end: '1' }]);
+    });
+
+    it('accepts a large NFT range 1..100', () => {
+      const res = handleSetValidTokenIds({ tokenIds: [{ start: '1', end: '100' }] });
+      expect(res.success).toBe(true);
+      expect(res.tokenIds).toEqual([{ start: '1', end: '100' }]);
+    });
+
+    it('accepts multiple ranges', () => {
+      const res = handleSetValidTokenIds({
+        tokenIds: [
+          { start: '1', end: '10' },
+          { start: '100', end: '200' }
+        ]
+      });
+      expect(res.success).toBe(true);
+      expect(res.tokenIds).toHaveLength(2);
+    });
+
+    it('accepts a range at exactly MAX_UINT64 on both sides', () => {
+      const res = handleSetValidTokenIds({ tokenIds: [{ start: MAX_UINT64, end: MAX_UINT64 }] });
+      expect(res.success).toBe(true);
+    });
+
+    it('accepts start === end === "0" (zero is a valid uint64)', () => {
+      const res = handleSetValidTokenIds({ tokenIds: [{ start: '0', end: '0' }] });
+      expect(res.success).toBe(true);
+    });
+
+    it('accepts an empty tokenIds array without complaining (edge case — no iteration)', () => {
+      const res = handleSetValidTokenIds({ tokenIds: [] });
+      expect(res.success).toBe(true);
+      expect(res.tokenIds).toEqual([]);
+    });
+  });
+
+  describe('validation errors', () => {
+    it('rejects a negative start', () => {
+      const res = handleSetValidTokenIds({ tokenIds: [{ start: '-1', end: '5' }] });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/start.*negative/i);
+    });
+
+    it('rejects a negative end', () => {
+      const res = handleSetValidTokenIds({ tokenIds: [{ start: '1', end: '-5' }] });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/end.*negative/i);
+    });
+
+    it('rejects a start > MAX_UINT64', () => {
+      const overflow = (BigInt(MAX_UINT64) + 1n).toString();
+      const res = handleSetValidTokenIds({ tokenIds: [{ start: overflow, end: overflow }] });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/start.*max uint64/i);
+    });
+
+    it('rejects an end > MAX_UINT64', () => {
+      const overflow = (BigInt(MAX_UINT64) + 1n).toString();
+      const res = handleSetValidTokenIds({ tokenIds: [{ start: '1', end: overflow }] });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/end.*max uint64/i);
+    });
+
+    it('rejects reversed range (start > end)', () => {
+      const res = handleSetValidTokenIds({ tokenIds: [{ start: '10', end: '5' }] });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/start.*> end/i);
+    });
+
+    it('rejects non-numeric strings', () => {
+      const res = handleSetValidTokenIds({ tokenIds: [{ start: 'abc', end: '5' }] });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/numeric/i);
+    });
+
+    it('rejects decimals (BigInt parser throws on "1.5")', () => {
+      const res = handleSetValidTokenIds({ tokenIds: [{ start: '1.5', end: '5' }] });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/numeric/i);
+    });
+
+    it('fails on the first bad range and does not mutate the session', () => {
+      const res = handleSetValidTokenIds({
+        tokenIds: [
+          { start: '1', end: '10' }, // valid
+          { start: '5', end: '1' }   // invalid — triggers bail
+        ]
+      });
+      expect(res.success).toBe(false);
+      // Session should not exist since validation failed before getOrCreateSession is called
+      const session = getOrCreateSession();
+      expect(session.messages[0].value.validTokenIds).toEqual([]);
+    });
+  });
+
+  describe('session mutation', () => {
+    it('writes tokenIds into the session and flips updateValidTokenIds', () => {
+      handleSetValidTokenIds({ tokenIds: [{ start: '1', end: '5' }] });
+      const session = getOrCreateSession();
+      expect(session.messages[0].value.validTokenIds).toEqual([{ start: '1', end: '5' }]);
+      expect(session.messages[0].value.updateValidTokenIds).toBe(true);
+    });
+
+    it('replaces prior ranges on a second call (set semantics, not append)', () => {
+      handleSetValidTokenIds({ tokenIds: [{ start: '1', end: '5' }] });
+      handleSetValidTokenIds({ tokenIds: [{ start: '10', end: '20' }] });
+      const session = getOrCreateSession();
+      expect(session.messages[0].value.validTokenIds).toEqual([{ start: '10', end: '20' }]);
+    });
+
+    it('isolates sessions by sessionId', () => {
+      handleSetValidTokenIds({ sessionId: 'alpha', tokenIds: [{ start: '1', end: '5' }] });
+      handleSetValidTokenIds({ sessionId: 'bravo', tokenIds: [{ start: '100', end: '200' }] });
+      expect(getOrCreateSession('alpha').messages[0].value.validTokenIds).toEqual([{ start: '1', end: '5' }]);
+      expect(getOrCreateSession('bravo').messages[0].value.validTokenIds).toEqual([{ start: '100', end: '200' }]);
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/session/setValidTokenIds.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/session/setValidTokenIds.spec.ts
@@ -115,7 +115,9 @@ describe('handleSetValidTokenIds', () => {
         ]
       });
       expect(res.success).toBe(false);
-      // Session should not exist since validation failed before getOrCreateSession is called
+      // Validation aborted before any session was written to. Calling
+      // getOrCreateSession() here creates a fresh blank session whose
+      // validTokenIds default is [].
       const session = getOrCreateSession();
       expect(session.messages[0].value.validTokenIds).toEqual([]);
     });
@@ -123,8 +125,11 @@ describe('handleSetValidTokenIds', () => {
 
   describe('session mutation', () => {
     it('writes tokenIds into the session and flips updateValidTokenIds', () => {
-      handleSetValidTokenIds({ tokenIds: [{ start: '1', end: '5' }] });
       const session = getOrCreateSession();
+      // updateValidTokenIds defaults to true, so the assertion below would be
+      // vacuous without first resetting to false.
+      session.messages[0].value.updateValidTokenIds = false;
+      handleSetValidTokenIds({ tokenIds: [{ start: '1', end: '5' }] });
       expect(session.messages[0].value.validTokenIds).toEqual([{ start: '1', end: '5' }]);
       expect(session.messages[0].value.updateValidTokenIds).toBe(true);
     });


### PR DESCRIPTION
## Summary

- Adds unit tests for 4 MCP builder session setters under `src/builder/tools/session/` that had zero test coverage
- 48 new tests (1933 to 1981 total), all passing
- No bugs discovered; existing behavior pinned down

## Handlers covered

- `handleSetValidTokenIds` — uint64 range validation (negative, MAX_UINT64 overflow, start>end, non-numeric), session mutation, sessionId isolation
- `handleSetInvariants` — each invariant shape (simple, subscription-style, smart-token with cosmosCoinBackedPath), null-clear, re-call replacement, session isolation
- `handleSetMintEscrowCoins` — 1-entry chain cap, JSON-string coercion fallback (AI quirk), unparseable-JSON error path
- `handleSetStandards` — KNOWN_STANDARDS whitelist, dynamic qualifier skip (`ListView:*`, `NFTPricingDenom:*`, `DefaultDisplayCurrency:*`), typo warnings, custom standards still allowed

## Test plan

- [x] `npx jest src/builder/tools/session/` passes (48/48)
- [x] `npm test` full SDK suite passes (1981/1981)
- [ ] Human review of test cases before merge
- [ ] Ensure no flaky behavior (session state reset between specs)

Tracked in autopilot backlog 0288.

Generated with Claude Code