### PR TITLE
docs(openapi): fix Miscellanous typo, declare Maps and Protocols tag

### DIFF
--- a/packages/bitbadgesjs-sdk/openapitypes-helpers/routes.yaml
+++ b/packages/bitbadgesjs-sdk/openapitypes-helpers/routes.yaml
@@ -219,6 +219,8 @@ tags:
   - name: Utility Pages
     description: Endpoints for managing utility pages
   - name: Miscellaneous
+  - name: Maps and Protocols
+    description: Endpoints for on-chain maps and registered protocol definitions
   - name: Assets
     description: Endpoints for asset pair operations, liquidity pools, and swap analytics
 paths:
@@ -1405,7 +1407,7 @@ paths:
         - **[Response Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iGetStatusSuccessResponse)**
         - **[SDK API Function](https://bitbadges.github.io/bitbadgesjs/classes/BitBadgesAPI.html#getstatus)**
       tags:
-        - Miscellanous
+        - Miscellaneous
       responses:
         '200':
           content:


### PR DESCRIPTION
## Summary

Two small tag-consistency issues that surface in the Stoplight-rendered public reference:

1. **Typo'd tag on `/status`** — it's tagged `Miscellanous` (missing the `e`), while the top-level `tags:` list declares `Miscellaneous`. Stoplight treats these as distinct groups, so `/status` ends up under a typo'd section instead of the intended Miscellaneous bucket.

2. **Undeclared `Maps and Protocols` tag** — four routes (`/maps`, `/maps/{mapId}`, `/mapValues`, `/mapValue/{mapId}/{key}`) are grouped under `Maps and Protocols` but the tag is never declared at the top level, so Stoplight renders them as an untitled/undescribed group.

Fix:
- Change `Miscellanous` -> `Miscellaneous` on `/status`
- Add `Maps and Protocols` to the top-level `tags:` list with a one-line description

## Test plan
- [ ] After merge, verify on Stoplight that `/status` renders under Miscellaneous and the Maps and Protocols group has its description.

Generated by the docs-watch agent (daily OpenAPI quality sweep).