### PR TITLE
fix(openapi): export EvmTx and MultiChainMsg so SkipGoMessage $refs resolve

### DIFF
--- a/packages/bitbadgesjs-sdk/src/gamm/indexer.ts
+++ b/packages/bitbadgesjs-sdk/src/gamm/indexer.ts
@@ -193,14 +193,14 @@ export interface iGetPoolInfoByIdSuccessResponse {
 // SWAP TYPES
 // ============================================================================
 
-interface MultiChainMsg {
+export interface MultiChainMsg {
   chain_id: string;
   path: string[];
   msg: string;
   msg_type_url: string;
 }
 
-interface EvmTx {
+export interface EvmTx {
   chain_id: string;
   to: string;
   value: string;


### PR DESCRIPTION
## Summary

Narrows PR #171 after the 8-route payload-deletion portion was rolled back. The zero-prop `payload` blocks in `routes.yaml` are harmless in practice — `spread_explodes.ts` drops them before the hosted spec ships, so 3p API consumers never see them. Keeping them in `routes.yaml` as dead weight is preferable to risking an accidental drop of a route param someone actually wanted.

## What stays in this PR

**Add `export` to `EvmTx` and `MultiChainMsg` in `src/gamm/indexer.ts`.** Both types are referenced transitively by `SkipGoMessage` but were defined without `export`, so `typeconv` skipped them and the hosted spec shipped broken `#/components/schemas/EvmTx` / `MultiChainMsg` refs. One-word-each fix. Implements #0292 (partial — the 5 dynamic-store + swap-activities types deferred until PR #168 merges).

## What was rolled back

The 8 zero-prop `payload` param deletions from `routes.yaml` (ticket #0293). Audit confirmed:

| Route | Verdict | Action |
|---|---|---|
| GET /developerApp/{clientId} | genuinely-empty | kept as-is |
| GET /plugin/{pluginId} | genuinely-empty | kept as-is |
| GET /utilityPage/{utilityPageId} | genuinely-empty | kept as-is |
| GET /application/{applicationId} | genuinely-empty | kept as-is |
| GET /claims/status/{claimAttemptId} | genuinely-empty | kept as-is |
| GET /maps/{mapId} | genuinely-empty | kept as-is |
| GET /claims/gatedContent/{claimId} | genuinely-empty | kept as-is |
| GET /plugins/creator | **real-props** — `iGetCreatorPluginsPayload` has `creatorAddress`, `bookmark`, `returnSensitiveData`; `spread_explodes.ts` expands into per-field query params | kept as-is — prior deletion would have stripped these from hosted spec |

Seven routes are genuinely empty (handler reads only `req.params.{id}`); one had real props the first pass missed, reinforcing the call to leave `routes.yaml` alone.

## Test plan

- [x] Typecheck (SDK build) clean
- [x] No unresolved `$ref`s in the hosted spec after the pipeline regenerates (CI will verify)