### PR TITLE
fix(builder/agent): review polish — stacked on #172

### DIFF
--- a/packages/bitbadgesjs-sdk/src/builder/agent/BitBadgesBuilderAgent.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/BitBadgesBuilderAgent.spec.ts
@@ -7,7 +7,7 @@
  * stub out the whole peer dep.
  */
 
-import { BitBadgesBuilderAgent, MemoryStore, ValidationFailedError } from './index.js';
+import { BitBadgesBuilderAgent, MemoryStore, QuotaExceededError, ValidationFailedError } from './index.js';
 
 describe('BitBadgesBuilderAgent', () => {
   it('throws a clear error when no Anthropic credentials are provided', () => {
@@ -97,7 +97,7 @@ describe('BitBadgesBuilderAgent', () => {
 
   it('supports opus model override', () => {
     const agent = new BitBadgesBuilderAgent({ anthropicKey: 'test-key', model: 'opus' });
-    expect(agent.modelInfo.id).toBe('claude-opus-4-6');
+    expect(agent.modelInfo.id).toBe('claude-opus-4-7');
   });
 
   it('substituteImages swaps IMAGE_N tokens inside nested structures', () => {
@@ -582,5 +582,140 @@ describe('toolAdapter — mergeDefaults undefined filter', () => {
       await registry.execute('echo_tool', { apiKey: null }, { sessionId: 's', callerAddress: 'bb1' })
     );
     expect(out2.apiKey).toBeNull();
+  });
+});
+
+describe('BitBadgesBuilderAgent — healthCheck', () => {
+  it('returns anthropic.ok=true when the probe call succeeds', async () => {
+    const probe = jest.fn(async () => ({
+      usage: { input_tokens: 1, output_tokens: 0 },
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: 'pong' }]
+    }));
+    const agent = new BitBadgesBuilderAgent({
+      anthropicClient: { messages: { create: probe } },
+      anthropicKey: 'unused'
+    });
+    const report = await agent.healthCheck();
+    expect(report.anthropic.ok).toBe(true);
+    expect(report.anthropic.model).toBe(agent.modelInfo.id);
+    expect(probe).toHaveBeenCalledTimes(1);
+    // bitbadgesApi is optional — with no key configured, it's marked not configured and not ok.
+    expect(report.bitbadgesApi.configured).toBe(false);
+    expect(report.bitbadgesApi.ok).toBe(false);
+  });
+
+  it('returns anthropic.ok=false and captures the error message when the probe throws', async () => {
+    const agent = new BitBadgesBuilderAgent({
+      anthropicClient: {
+        messages: {
+          create: async () => {
+            throw new Error('simulated auth failure');
+          }
+        }
+      },
+      anthropicKey: 'unused'
+    });
+    const report = await agent.healthCheck();
+    expect(report.anthropic.ok).toBe(false);
+    expect(report.anthropic.error).toMatch(/simulated auth failure/);
+  });
+});
+
+describe('BitBadgesBuilderAgent — validate()', () => {
+  it('runs the validation gate on a pre-built transaction and returns a structured result', async () => {
+    const agent = new BitBadgesBuilderAgent({
+      anthropicKey: 'k',
+      defaultCreatorAddress: 'bb1test'
+    });
+    const tx = { messages: [{ value: { creator: 'bb1test', collectionId: '0' } }] };
+    const result = await agent.validate(tx);
+    expect(result).toHaveProperty('valid');
+    expect(result).toHaveProperty('errors');
+    expect(Array.isArray(result.errors)).toBe(true);
+  });
+
+  it('consults the onChainSnapshotFetcher when existingCollectionId is supplied', async () => {
+    const fetcher = jest.fn(async (id: string) => ({ collectionId: id, fakeSnapshot: true }));
+    const agent = new BitBadgesBuilderAgent({
+      anthropicKey: 'k',
+      defaultCreatorAddress: 'bb1test',
+      onChainSnapshotFetcher: fetcher
+    });
+    const tx = { messages: [{ value: { creator: 'bb1test', collectionId: '42' } }] };
+    await agent.validate(tx, { existingCollectionId: '42' });
+    expect(fetcher).toHaveBeenCalledWith('42');
+  });
+
+  it('does not call the snapshot fetcher when existingCollectionId is omitted', async () => {
+    const fetcher = jest.fn(async () => null);
+    const agent = new BitBadgesBuilderAgent({
+      anthropicKey: 'k',
+      defaultCreatorAddress: 'bb1test',
+      onChainSnapshotFetcher: fetcher
+    });
+    const tx = { messages: [{ value: { creator: 'bb1test' } }] };
+    await agent.validate(tx);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});
+
+describe('BitBadgesBuilderAgent — token quota cap', () => {
+  function makeMockClient(scripted: any[]) {
+    let i = 0;
+    return {
+      messages: { create: async () => scripted[i++ % scripted.length] }
+    };
+  }
+
+  it('throws QuotaExceededError when cumulative tokens exceed maxTokensPerBuild', async () => {
+    // One round that reports 500 input + 600 output = 1100 tokens,
+    // tripping the 1000-token cap.
+    const client = makeMockClient([
+      {
+        usage: { input_tokens: 500, output_tokens: 600 },
+        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: 'done' }]
+      }
+    ]);
+    const agent = new BitBadgesBuilderAgent({
+      anthropicClient: client,
+      anthropicKey: 'unused',
+      validation: 'off',
+      maxTokensPerBuild: 1000,
+      defaultCreatorAddress: 'bb1test'
+    });
+    await expect(agent.build('any prompt')).rejects.toBeInstanceOf(QuotaExceededError);
+  });
+});
+
+describe('BitBadgesBuilderAgent — sessionTtlSeconds override', () => {
+  it('threads the configured TTL through to the session store set call', async () => {
+    // Capture the ttlSeconds that gets passed to set().
+    const setSpy = jest.fn(async (_key: string, _value: string, _opts?: { ttlSeconds?: number }) => {});
+    const agent = new BitBadgesBuilderAgent({
+      anthropicClient: {
+        messages: {
+          create: async () => ({
+            usage: { input_tokens: 1, output_tokens: 1 },
+            stop_reason: 'end_turn',
+            content: [{ type: 'text', text: 'done' }]
+          })
+        }
+      },
+      anthropicKey: 'unused',
+      validation: 'off',
+      sessionTtlSeconds: 60 * 60 * 24, // 24h
+      sessionStore: {
+        get: async () => null,
+        set: setSpy,
+        delete: async () => {}
+      },
+      defaultCreatorAddress: 'bb1test'
+    });
+    await agent.build('any');
+    expect(setSpy).toHaveBeenCalled();
+    const opts = setSpy.mock.calls[0][2];
+    expect(opts).toMatchObject({ ttlSeconds: 60 * 60 * 24 });
   });
 });

--- a/packages/bitbadgesjs-sdk/src/builder/agent/BitBadgesBuilderAgent.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/BitBadgesBuilderAgent.ts
@@ -601,7 +601,7 @@ export class BitBadgesBuilderAgent {
       await this.sessionStore.set(
         sessionId,
         JSON.stringify({ messages: loopResult.messages, transaction, tokensUsed: totalTokens }),
-        { ttlSeconds: DEFAULTS.sessionTtlSeconds }
+        { ttlSeconds: this.options.sessionTtlSeconds ?? DEFAULTS.sessionTtlSeconds }
       );
     } catch {
       // non-fatal
@@ -746,8 +746,16 @@ export class BitBadgesBuilderAgent {
   /**
    * Validate an existing transaction object without running the agent
    * loop. Useful for CI checks or re-running validation after manual edits.
+   *
+   * When `existingCollectionId` is supplied AND the agent was configured
+   * with an `onChainSnapshotFetcher`, the validation gate pulls the live
+   * on-chain snapshot for diff-based review — matching the update-mode
+   * behavior inside `build()`.
    */
-  async validate(transaction: any, creatorAddress?: string): Promise<{
+  async validate(
+    transaction: any,
+    options?: { creatorAddress?: string; existingCollectionId?: string; abortSignal?: AbortSignal }
+  ): Promise<{
     valid: boolean;
     errors: StructuredError[];
     warnings: Warning[];
@@ -755,10 +763,16 @@ export class BitBadgesBuilderAgent {
     simulation: any | null;
     audit: any | null;
   }> {
+    const onChainSnapshot =
+      options?.existingCollectionId && this.options.onChainSnapshotFetcher
+        ? await this.options.onChainSnapshotFetcher(options.existingCollectionId).catch(() => null)
+        : undefined;
     const gate = await runValidationGate({
       transaction,
-      creatorAddress: creatorAddress ?? this.options.defaultCreatorAddress ?? '',
-      simulate: this.options.simulate
+      creatorAddress: options?.creatorAddress ?? this.options.defaultCreatorAddress ?? '',
+      simulate: this.options.simulate,
+      abortSignal: options?.abortSignal,
+      onChainSnapshot
     });
     return {
       valid: gate.valid,

--- a/packages/bitbadgesjs-sdk/src/builder/agent/errors.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/errors.ts
@@ -62,7 +62,10 @@ export class QuotaExceededError extends BitBadgesBuilderAgentError {
 export class AnthropicAuthError extends BitBadgesBuilderAgentError {
   constructor(detail?: string) {
     super(
-      `Anthropic authentication failed. Check that ANTHROPIC_API_KEY is set and valid.${detail ? ` (${detail})` : ''}`,
+      `Anthropic authentication failed. Verify that your Anthropic credentials are valid — ` +
+        `either an API key (ANTHROPIC_API_KEY / anthropicKey) or an OAuth token ` +
+        `(ANTHROPIC_AUTH_TOKEN / ANTHROPIC_OAUTH_TOKEN / anthropicAuthToken).` +
+        `${detail ? ` (${detail})` : ''}`,
       'ANTHROPIC_AUTH_ERROR',
       503
     );

--- a/packages/bitbadgesjs-sdk/src/builder/agent/images.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/images.ts
@@ -11,11 +11,15 @@
 export type ImageMap = Record<string, string>;
 
 /**
- * Recursively replace `IMAGE_N` strings inside the transaction with
- * values from `images`. Only string fields named `image` are rewritten;
- * keys unrelated to image references are left alone.
+ * Recursively replace `IMAGE_N` strings anywhere in the transaction with
+ * values from `images`. Every string value is checked — the key name is
+ * not inspected, so an `IMAGE_2` reference under `description`, `uri`,
+ * or any other field is substituted just like one under `image`. This
+ * matches the frontend's `replaceImagePlaceholders` behavior.
  *
- * Returns a new transaction object — the original is not mutated.
+ * Non-string values, non-matching strings, and strings whose token has
+ * no matching entry in `images` are left alone. Returns a new
+ * transaction object — the original is not mutated.
  */
 export function substituteImages<T>(transaction: T, images: ImageMap): T {
   if (!images || Object.keys(images).length === 0) return transaction;

--- a/packages/bitbadgesjs-sdk/src/builder/agent/loop.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/loop.ts
@@ -65,7 +65,11 @@ const COMPRESSIBLE_TOOLS = new Set([
   'set_standards', 'set_valid_token_ids', 'set_default_balances',
   'set_collection_metadata', 'set_token_metadata', 'set_approval_metadata',
   'set_mint_escrow_coins', 'get_transaction',
-  'search_knowledge_base', 'fetch_docs', 'lookup_claim_plugins', 'query_collection'
+  'search_knowledge_base', 'fetch_docs', 'lookup_claim_plugins', 'query_collection',
+  // Validation + simulation tool results are often chunky (issue arrays,
+  // stack traces, gas dumps) and the summarizer already knows how to
+  // condense them — only the most recent two results need to stay raw.
+  'simulate_transaction', 'validate_transaction'
 ]);
 
 function summarizeToolResult(toolName: string, content: string): string {
@@ -344,8 +348,15 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<AgentLoopRe
     }
   } catch (err: any) {
     if (err instanceof BitBadgesBuilderAgentError) throw err;
-    // Preserve original error shape but attach token usage so caller can track partial cost.
-    err.partialTokens = totalTokens;
+    // Preserve original error shape but attach token usage so caller
+    // can track partial cost. Guard the assignment — some errors (frozen
+    // objects, primitives thrown as "errors") can't take new props and
+    // would turn a real error into a cryptic TypeError.
+    try {
+      err.partialTokens = totalTokens;
+    } catch {
+      // best-effort — caller still gets the original error
+    }
     throw err;
   }
 

--- a/packages/bitbadgesjs-sdk/src/builder/agent/models.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/models.spec.ts
@@ -34,7 +34,7 @@ describe('resolveModel', () => {
 
   it('resolves friendly name "opus"', () => {
     const info = resolveModel('opus');
-    expect(info.id).toBe('claude-opus-4-6');
+    expect(info.id).toBe('claude-opus-4-7');
   });
 
   it('unknown string is treated as a raw Anthropic model ID with opus pricing fallback', () => {

--- a/packages/bitbadgesjs-sdk/src/builder/agent/models.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/models.ts
@@ -21,7 +21,7 @@ export const MODELS: Record<ModelName, ModelInfo> = {
     outputPerMTok: 15.0
   },
   opus: {
-    id: 'claude-opus-4-6',
+    id: 'claude-opus-4-7',
     inputPerMTok: 5.0,
     outputPerMTok: 25.0
   }

--- a/packages/bitbadgesjs-sdk/src/builder/agent/toolAdapter.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/toolAdapter.spec.ts
@@ -149,13 +149,20 @@ describe('createAgentToolRegistry — execute behavior', () => {
     expect(parsed.error).toBe('kaboom');
   });
 
-  it('result > 100KB is truncated with the trailing marker', async () => {
+  it('result > 100KB is wrapped in a valid-JSON truncation envelope', async () => {
     const huge = 'a'.repeat(150_000);
     const custom = makeCustom('huge', async () => huge);
     const reg = createAgentToolRegistry({ add: [custom] });
     const result = await reg.execute('huge', {}, { sessionId: 's', callerAddress: '' });
-    expect(result.length).toBeLessThanOrEqual(100_000 + 200);
-    expect(result).toMatch(/truncated — result too large/);
+    // The LLM has to parse this — it MUST be valid JSON, not a slice
+    // with a text-suffix marker.
+    const parsed = JSON.parse(result);
+    expect(parsed._truncated).toBe(true);
+    expect(parsed.originalBytes).toBe(150_000);
+    expect(typeof parsed.preview).toBe('string');
+    expect(parsed.preview.length).toBeGreaterThan(1000);
+    // Whole envelope still fits under the cap with room to spare.
+    expect(result.length).toBeLessThan(100_000);
   });
 
   it('result just under 100KB is NOT truncated', async () => {

--- a/packages/bitbadgesjs-sdk/src/builder/agent/toolAdapter.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/toolAdapter.ts
@@ -145,7 +145,16 @@ export function createAgentToolRegistry(options?: CreateRegistryOptions): AgentT
       try {
         const result = await fn(args, ctx);
         const s = typeof result === 'string' ? result : JSON.stringify(result);
-        if (s.length > 100_000) return s.slice(0, 100_000) + '\n[...truncated — result too large]';
+        if (s.length > 100_000) {
+          // Return valid JSON so the LLM doesn't choke trying to parse a
+          // slice + text-suffix combo. Preview is sized to comfortably
+          // fit the whole wrapper under 100KB even after JSON escaping.
+          return JSON.stringify({
+            _truncated: true,
+            originalBytes: s.length,
+            preview: s.slice(0, 90_000)
+          });
+        }
         return s;
       } catch (err: any) {
         return JSON.stringify({ error: err?.message || 'Tool execution failed' });

--- a/packages/bitbadgesjs-sdk/src/builder/agent/types.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/types.ts
@@ -18,7 +18,7 @@ export type ModelName = 'haiku' | 'sonnet' | 'opus';
 
 /** Cost/quality metadata for each supported model. */
 export interface ModelInfo {
-  /** Anthropic model ID (e.g. "claude-opus-4-6"). */
+  /** Anthropic model ID (e.g. "claude-opus-4-7"). */
   id: string;
   /** USD per 1M input tokens. */
   inputPerMTok: number;
@@ -347,6 +347,13 @@ export interface BitBadgesBuilderAgentOptions {
 
   /** Pluggable session store. Default: new MemoryStore(). */
   sessionStore?: KVStore;
+  /**
+   * TTL in seconds for persisted session snapshots (refinement replay).
+   * Default: 7200 (2h). Raise for multi-day refinement flows; stores
+   * that ignore TTL (e.g. a consumer Redis adapter with its own
+   * eviction) may safely disregard this value.
+   */
+  sessionTtlSeconds?: number;
 
   /** Pluggable community-skills fetcher (indexer plugs in Mongo; default no-op). */
   communitySkillsFetcher?: CommunitySkillsFetcher;


### PR DESCRIPTION
## Summary
Stacked on top of #172 so diff reviews cleanly without main-branch churn. Pure polish — no new feature surface.

- **opus model ID** bumped `claude-opus-4-6` → `claude-opus-4-7` (plus pinned test expectations).
- Greptile-flagged items fixed: `substituteImages` JSDoc now matches behavior; `AnthropicAuthError` covers OAuth too.
- Correctness nits: dead `summarizeToolResult` branches now actually fire; `toolAdapter` truncation emits **valid JSON** (parseable by the LLM) instead of a slice + text marker; `loop.ts` partial-tokens write is guarded.
- Small ergonomics: `sessionTtlSeconds` is now configurable; `agent.validate()` takes an options bag with `existingCollectionId` and threads through `onChainSnapshotFetcher` like `build()` does.
- New tests for `healthCheck`, `validate` (with + without snapshot fetcher), quota cap, session TTL wiring, and the truncation envelope.

162/162 agent tests pass locally (serial).

## Notes on #172
One of Greptile's P1 comments on #172 ("version errors swallowed in `loadAnthropicSdk`") is a false positive against the current code — the retry loop's `catch` only covers strategy execution, and `assertSupportedVersion` runs outside any try/catch at `anthropicClient.ts:126`. The inline comment at lines 58–68 explicitly calls this out. Not changed here.

## Test plan
- [x] `npx jest src/builder/agent --runInBand` → 162 passed
- [x] `npx tsc --noEmit` clean
- [ ] Once #172 lands, rebase this onto `main` (should be trivial — no conflicts inside this stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)