### PR TITLE
feat(builder): smart token-type inference

### DIFF
--- a/packages/bitbadgesjs-sdk/src/builder/agent/BitBadgesBuilderAgent.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/BitBadgesBuilderAgent.spec.ts
@@ -184,6 +184,7 @@ describe('BitBadgesBuilderAgent — end-to-end with mocked Anthropic', () => {
 
     const agent = new BitBadgesBuilderAgent({
       anthropicClient: client,
+      autoInferTokenType: false,
       anthropicKey: 'unused-with-client',
       validation: 'off', // skip validation in this smoke test — tx is empty
       hooks: { onToolCall, onTokenUsage, onCompletion },
@@ -218,6 +219,7 @@ describe('BitBadgesBuilderAgent — end-to-end with mocked Anthropic', () => {
 
     const agent = new BitBadgesBuilderAgent({
       anthropicClient: client,
+      autoInferTokenType: false,
       anthropicKey: 'unused',
       validation: 'strict',
       fixLoopMaxRounds: 0, // no fixes
@@ -239,6 +241,7 @@ describe('BitBadgesBuilderAgent — end-to-end with mocked Anthropic', () => {
 
     const agent = new BitBadgesBuilderAgent({
       anthropicClient: client,
+      autoInferTokenType: false,
       anthropicKey: 'unused',
       validation: 'lenient',
       fixLoopMaxRounds: 0,
@@ -355,6 +358,7 @@ describe('BitBadgesBuilderAgent — concurrency + abort', () => {
     const client = makeMockClient(script);
     const agent = new BitBadgesBuilderAgent({
       anthropicClient: client,
+      autoInferTokenType: false,
       anthropicKey: 'unused',
       validation: 'off',
       defaultCreatorAddress: 'bb1test'
@@ -396,6 +400,7 @@ describe('BitBadgesBuilderAgent — concurrency + abort', () => {
 
     const agent = new BitBadgesBuilderAgent({
       anthropicClient: hangingClient,
+      autoInferTokenType: false,
       anthropicKey: 'unused',
       validation: 'off',
       defaultCreatorAddress: 'bb1test'
@@ -484,6 +489,7 @@ describe('BitBadgesBuilderAgent — onCompletion always fires', () => {
     ]);
     const agent = new BitBadgesBuilderAgent({
       anthropicClient: client,
+      autoInferTokenType: false,
       anthropicKey: 'unused',
       validation: 'strict', // will throw via forced simulation failure
       fixLoopMaxRounds: 0,
@@ -511,6 +517,7 @@ describe('BitBadgesBuilderAgent — onCompletion always fires', () => {
     ]);
     const agent = new BitBadgesBuilderAgent({
       anthropicClient: client,
+      autoInferTokenType: false,
       anthropicKey: 'unused',
       validation: 'off',
       hooks: { onCompletion },
@@ -680,6 +687,7 @@ describe('BitBadgesBuilderAgent — token quota cap', () => {
     ]);
     const agent = new BitBadgesBuilderAgent({
       anthropicClient: client,
+      autoInferTokenType: false,
       anthropicKey: 'unused',
       validation: 'off',
       maxTokensPerBuild: 1000,
@@ -704,6 +712,7 @@ describe('BitBadgesBuilderAgent — sessionTtlSeconds override', () => {
         }
       },
       anthropicKey: 'unused',
+      autoInferTokenType: false,
       validation: 'off',
       sessionTtlSeconds: 60 * 60 * 24, // 24h
       sessionStore: {
@@ -717,5 +726,123 @@ describe('BitBadgesBuilderAgent — sessionTtlSeconds override', () => {
     expect(setSpy).toHaveBeenCalled();
     const opts = setSpy.mock.calls[0][2];
     expect(opts).toMatchObject({ ttlSeconds: 60 * 60 * 24 });
+  });
+});
+
+describe('BitBadgesBuilderAgent — autoInferTokenType wiring', () => {
+  // Inference prepends one messages.create call before the main build,
+  // so any test here must feed at least two scripted responses.
+  function makeScriptedClient(scripted: any[]) {
+    let i = 0;
+    return {
+      messages: {
+        create: jest.fn(async () => scripted[i++])
+      }
+    };
+  }
+
+  function mainBuildResponse(text = 'done') {
+    return {
+      usage: { input_tokens: 50, output_tokens: 20 },
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text }]
+    };
+  }
+
+  function inferenceResponse(id: string | null, confidence: 'high' | 'low' = 'high') {
+    return {
+      usage: { input_tokens: 120, output_tokens: 40 },
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ id, confidence, reasoning: 'test' })
+        }
+      ]
+    };
+  }
+
+  it('runs inference when no token-type skill is in selectedSkills and populates result.inferredTokenType', async () => {
+    const client = makeScriptedClient([inferenceResponse('subscription'), mainBuildResponse()]);
+    const agent = new BitBadgesBuilderAgent({
+      anthropicClient: client,
+      anthropicKey: 'unused',
+      validation: 'off',
+      defaultCreatorAddress: 'bb1test'
+    });
+    const result = await agent.build('monthly subscription for $10');
+    expect(result.inferredTokenType).toBe('subscription');
+    expect(result.inferredTokenTypeSource).toBe('llm');
+    expect(client.messages.create).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips inference entirely when selectedSkills already contains a token-type', async () => {
+    const client = makeScriptedClient([mainBuildResponse()]);
+    const agent = new BitBadgesBuilderAgent({
+      anthropicClient: client,
+      anthropicKey: 'unused',
+      validation: 'off',
+      defaultCreatorAddress: 'bb1test'
+    });
+    const result = await agent.build('anything', { selectedSkills: ['nft-collection'] });
+    expect(result.inferredTokenType).toBeUndefined();
+    expect(client.messages.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('per-build autoInferTokenType=false overrides the constructor default', async () => {
+    const client = makeScriptedClient([mainBuildResponse()]);
+    const agent = new BitBadgesBuilderAgent({
+      anthropicClient: client,
+      anthropicKey: 'unused',
+      validation: 'off',
+      defaultCreatorAddress: 'bb1test'
+    });
+    const result = await agent.build('vague request', { autoInferTokenType: false });
+    expect(result.inferredTokenType).toBeUndefined();
+    expect(client.messages.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('records inferredTokenType=null (freestyle) when inference returns low confidence', async () => {
+    const client = makeScriptedClient([inferenceResponse(null, 'low'), mainBuildResponse()]);
+    const agent = new BitBadgesBuilderAgent({
+      anthropicClient: client,
+      anthropicKey: 'unused',
+      validation: 'off',
+      defaultCreatorAddress: 'bb1test'
+    });
+    const result = await agent.build('some vague description');
+    expect(result.inferredTokenType).toBeNull();
+    expect(result.inferredTokenTypeSource).toBeUndefined();
+  });
+
+  it('constructor skills whitelist narrows the inference candidate set', async () => {
+    const client = makeScriptedClient([
+      // Claude picks a whitelisted id; this should survive the filter.
+      inferenceResponse('subscription'),
+      mainBuildResponse()
+    ]);
+    const agent = new BitBadgesBuilderAgent({
+      anthropicClient: client,
+      anthropicKey: 'unused',
+      validation: 'off',
+      skills: ['subscription', 'fungible-token'],
+      defaultCreatorAddress: 'bb1test'
+    });
+    const result = await agent.build('monthly sub for $10');
+    expect(result.inferredTokenType).toBe('subscription');
+  });
+
+  it('fires onTokenUsage for the inference round with round=0', async () => {
+    const client = makeScriptedClient([inferenceResponse('smart-token'), mainBuildResponse()]);
+    const onTokenUsage = jest.fn();
+    const agent = new BitBadgesBuilderAgent({
+      anthropicClient: client,
+      anthropicKey: 'unused',
+      validation: 'off',
+      hooks: { onTokenUsage },
+      defaultCreatorAddress: 'bb1test'
+    });
+    await agent.build('wrap USDC 1:1');
+    const rounds = onTokenUsage.mock.calls.map((c: any[]) => c[0].round);
+    expect(rounds).toContain(0);
   });
 });

--- a/packages/bitbadgesjs-sdk/src/builder/agent/BitBadgesBuilderAgent.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/BitBadgesBuilderAgent.ts
@@ -18,7 +18,7 @@ import { handleGetTransaction } from '../tools/index.js';
 import { getOrCreateSession } from '../session/sessionState.js';
 import { getAllSkillInstructions, type SkillInstruction } from '../resources/skillInstructions.js';
 import { getAnthropicClient } from './anthropicClient.js';
-import { AbortedError, BitBadgesBuilderAgentError, QuotaExceededError, ValidationFailedError } from './errors.js';
+import { AbortedError, BitBadgesBuilderAgentError, ValidationFailedError } from './errors.js';
 import { containsInjection } from './sanitize.js';
 import { substituteImages, collectImageReferences, type ImageMap } from './images.js';
 import { resolveModel, type ModelInfo } from './models.js';
@@ -452,30 +452,22 @@ export class BitBadgesBuilderAgent {
       // Fold the inference LLM call into the caller's token budget via
       // onTokenUsage. Round 0 signals "pre-build inference"; the
       // indexer's ledger sums inputTokens + outputTokens uniformly so
-      // this keeps billing consistent with a normal round.
+      // this keeps billing consistent with a normal round. Errors
+      // propagate unchanged — the indexer's TokenLedger throws its
+      // own error class and callers `instanceof`-check against it.
       if (inferenceResult.tokenUsage && hooks?.onTokenUsage) {
-        try {
-          await hooks.onTokenUsage({
-            inputTokens: inferenceResult.tokenUsage.inputTokens,
-            outputTokens: inferenceResult.tokenUsage.outputTokens,
-            cacheCreationTokens: inferenceResult.tokenUsage.cacheCreationTokens,
-            cacheReadTokens: inferenceResult.tokenUsage.cacheReadTokens,
-            round: 0,
-            cumulativeTokens: inferenceResult.tokenUsage.inputTokens + inferenceResult.tokenUsage.outputTokens,
-            cumulativeCacheCreationTokens: inferenceResult.tokenUsage.cacheCreationTokens,
-            cumulativeCacheReadTokens: inferenceResult.tokenUsage.cacheReadTokens,
-            cumulativeCostUsd: inferenceResult.tokenUsage.costUsd,
-            model: inferenceResult.tokenUsage.model
-          });
-        } catch {
-          // If a quota-enforcing hook throws here, propagate so the
-          // caller sees the budget overrun before we burn more tokens
-          // on the main build.
-          throw new QuotaExceededError(
-            inferenceResult.tokenUsage.inputTokens + inferenceResult.tokenUsage.outputTokens,
-            this.options.maxTokensPerBuild ?? DEFAULTS.maxTokensPerBuild
-          );
-        }
+        await hooks.onTokenUsage({
+          inputTokens: inferenceResult.tokenUsage.inputTokens,
+          outputTokens: inferenceResult.tokenUsage.outputTokens,
+          cacheCreationTokens: inferenceResult.tokenUsage.cacheCreationTokens,
+          cacheReadTokens: inferenceResult.tokenUsage.cacheReadTokens,
+          round: 0,
+          cumulativeTokens: inferenceResult.tokenUsage.inputTokens + inferenceResult.tokenUsage.outputTokens,
+          cumulativeCacheCreationTokens: inferenceResult.tokenUsage.cacheCreationTokens,
+          cumulativeCacheReadTokens: inferenceResult.tokenUsage.cacheReadTokens,
+          cumulativeCostUsd: inferenceResult.tokenUsage.costUsd,
+          model: inferenceResult.tokenUsage.model
+        });
       }
 
       if (hooks?.onLog) {

--- a/packages/bitbadgesjs-sdk/src/builder/agent/BitBadgesBuilderAgent.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/BitBadgesBuilderAgent.ts
@@ -27,6 +27,7 @@ import { MemoryStore, type KVStore } from './sessionStore.js';
 import { createAgentToolRegistry, type AgentToolRegistry } from './toolAdapter.js';
 import { runAgentLoop } from './loop.js';
 import { runValidationGate, type ValidationGateResult } from './validation.js';
+import { inferTokenTypeFromPrompt, getTokenTypeSkills } from './tokenTypeInference.js';
 import type {
   AgentHooks,
   BitBadgesBuilderAgentOptions,
@@ -385,14 +386,114 @@ export class BitBadgesBuilderAgent {
 
     // Load any prior conversation from the session store (for refinement across HTTP boundaries)
     let existingMessages: any[] | undefined;
+    let existingSessionTransaction: any = null;
     try {
       const raw = await this.sessionStore.get(sessionId);
       if (raw) {
         const parsed = JSON.parse(raw);
         if (Array.isArray(parsed?.messages)) existingMessages = parsed.messages;
+        if (parsed && typeof parsed.transaction === 'object') existingSessionTransaction = parsed.transaction;
       }
     } catch {
       // ignore — store read errors are non-fatal
+    }
+
+    // --- Smart token-type inference ----------------------------------
+    // Runs only when the caller didn't supply a token-type skill. Non
+    // token-type skills (community / additional-context) don't block
+    // inference — they coexist with an inferred token type. For
+    // refine/update flows we fold prior intent + existing standards
+    // into the inference context, so a short "fix this" doesn't strip
+    // the classifier of the signal it needs.
+    const tokenTypeSkillIds = new Set(getTokenTypeSkills().map((s) => s.id));
+    const effectiveSkillsHasTokenType = effectiveSkills.some((s) => tokenTypeSkillIds.has(s));
+    const inferFlag =
+      options?.autoInferTokenType ?? this.options.autoInferTokenType ?? true;
+    const shouldInferTokenType =
+      inferFlag &&
+      !effectiveSkillsHasTokenType &&
+      !!prompt &&
+      !!this.client;
+
+    let inferredTokenType: string | null | undefined = undefined;
+    let inferredTokenTypeSource: 'standards' | 'llm' | undefined = undefined;
+    let inferredTokenTypeReasoning: string | undefined = undefined;
+    let finalSkills = effectiveSkills;
+
+    if (shouldInferTokenType) {
+      let existingSnapshot: any = null;
+      if (options?.existingCollectionId && this.options.onChainSnapshotFetcher) {
+        existingSnapshot = await this.options.onChainSnapshotFetcher(options.existingCollectionId).catch(() => null);
+      }
+      const inferenceCtx = {
+        prompt,
+        mode,
+        originalPrompt: options?.originalPrompt,
+        priorRefinePrompts: options?.priorRefinePrompts,
+        existingTransaction: existingSessionTransaction ?? existingSnapshot,
+        allowedTokenTypeIds: this.options.skills
+          ? this.options.skills.filter((s) => tokenTypeSkillIds.has(s))
+          : undefined,
+        anthropicClient: this.client,
+        abortSignal: signal,
+        debug
+      };
+      const inferenceResult = await inferTokenTypeFromPrompt(inferenceCtx);
+      inferredTokenType = inferenceResult.tokenType;
+      if (inferenceResult.tokenType && inferenceResult.source) {
+        inferredTokenTypeSource = inferenceResult.source;
+        inferredTokenTypeReasoning = inferenceResult.reasoning;
+        // Prepend (don't append) — token types are most load-bearing,
+        // and buildSelectedSkillsSection sorts for cache stability so
+        // order is purely a readability choice.
+        finalSkills = [inferenceResult.tokenType, ...effectiveSkills];
+      }
+
+      // Fold the inference LLM call into the caller's token budget via
+      // onTokenUsage. Round 0 signals "pre-build inference"; the
+      // indexer's ledger sums inputTokens + outputTokens uniformly so
+      // this keeps billing consistent with a normal round.
+      if (inferenceResult.tokenUsage && hooks?.onTokenUsage) {
+        try {
+          await hooks.onTokenUsage({
+            inputTokens: inferenceResult.tokenUsage.inputTokens,
+            outputTokens: inferenceResult.tokenUsage.outputTokens,
+            cacheCreationTokens: inferenceResult.tokenUsage.cacheCreationTokens,
+            cacheReadTokens: inferenceResult.tokenUsage.cacheReadTokens,
+            round: 0,
+            cumulativeTokens: inferenceResult.tokenUsage.inputTokens + inferenceResult.tokenUsage.outputTokens,
+            cumulativeCacheCreationTokens: inferenceResult.tokenUsage.cacheCreationTokens,
+            cumulativeCacheReadTokens: inferenceResult.tokenUsage.cacheReadTokens,
+            cumulativeCostUsd: inferenceResult.tokenUsage.costUsd,
+            model: inferenceResult.tokenUsage.model
+          });
+        } catch {
+          // If a quota-enforcing hook throws here, propagate so the
+          // caller sees the budget overrun before we burn more tokens
+          // on the main build.
+          throw new QuotaExceededError(
+            inferenceResult.tokenUsage.inputTokens + inferenceResult.tokenUsage.outputTokens,
+            this.options.maxTokensPerBuild ?? DEFAULTS.maxTokensPerBuild
+          );
+        }
+      }
+
+      if (hooks?.onLog) {
+        try {
+          hooks.onLog({
+            type: 'info',
+            label: 'token-type inferred',
+            data: {
+              inferred: inferenceResult.tokenType,
+              source: inferenceResult.source,
+              confidence: inferenceResult.confidence,
+              reasoning: inferenceResult.reasoning
+            }
+          });
+        } catch {
+          // Observability hook — never let it break the build.
+        }
+      }
     }
 
     // Assemble prompt — honor `systemPrompt` full replace and `systemPromptAppend`
@@ -400,7 +501,7 @@ export class BitBadgesBuilderAgent {
       {
         prompt,
         creatorAddress,
-        selectedSkills: effectiveSkills,
+        selectedSkills: finalSkills,
         promptSkillIds: options?.promptSkillIds ?? [],
         contextHelpers: options?.contextHelpers,
         metadata: options?.metadata,
@@ -656,6 +757,9 @@ export class BitBadgesBuilderAgent {
       rounds,
       fixRounds,
       trace,
+      inferredTokenType,
+      inferredTokenTypeSource,
+      inferredTokenTypeReasoning,
       toString() {
         const msgCount = Array.isArray(this.transaction?.messages) ? this.transaction.messages.length : 0;
         const validityStr = this.valid ? 'valid' : `${this.errors.length} error${this.errors.length === 1 ? '' : 's'}`;

--- a/packages/bitbadgesjs-sdk/src/builder/agent/index.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/index.ts
@@ -26,6 +26,19 @@ export {
 } from './communitySkills.js';
 export { getAllSkillInstructions, type SkillInstruction } from '../resources/skillInstructions.js';
 export {
+  inferTokenTypeFromPrompt,
+  getTokenTypeSkillIds,
+  getTokenTypeSkills,
+  extractStandards,
+  inferFromStandards,
+  buildInferenceSystemPrompt,
+  buildInferenceUserPrompt,
+  parseInferenceResponse,
+  STANDARD_TO_TOKEN_TYPE,
+  type TokenTypeInferenceInput,
+  type TokenTypeInferenceResult
+} from './tokenTypeInference.js';
+export {
   BitBadgesBuilderAgentError,
   ValidationFailedError,
   QuotaExceededError,

--- a/packages/bitbadgesjs-sdk/src/builder/agent/tokenTypeInference.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/tokenTypeInference.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * Unit tests for the smart token-type inference module.
+ *
+ * The LLM branch is exercised via a fake `anthropicClient` that
+ * returns a canned response shape — no peer-dep required.
+ */
+
+import {
+  buildInferenceSystemPrompt,
+  buildInferenceUserPrompt,
+  extractStandards,
+  getTokenTypeSkillIds,
+  getTokenTypeSkills,
+  inferFromStandards,
+  inferTokenTypeFromPrompt,
+  parseInferenceResponse,
+  STANDARD_TO_TOKEN_TYPE
+} from './tokenTypeInference.js';
+
+function makeFakeClient(response: any, opts: { captureArgs?: { value: any } } = {}) {
+  return {
+    messages: {
+      create: jest.fn(async (args: any) => {
+        if (opts.captureArgs) opts.captureArgs.value = args;
+        return response;
+      })
+    }
+  };
+}
+
+function mkMessagesResponse(bodyText: string) {
+  return {
+    content: [{ type: 'text', text: bodyText }],
+    usage: {
+      input_tokens: 120,
+      output_tokens: 40,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0
+    }
+  };
+}
+
+describe('tokenTypeInference catalog helpers', () => {
+  it('getTokenTypeSkillIds includes every user-facing core token type', () => {
+    const ids = getTokenTypeSkillIds();
+    // The 15 frontend marketplace entries — all should be present.
+    for (const expected of [
+      'smart-token',
+      'fungible-token',
+      'nft-collection',
+      'subscription',
+      'custom-2fa',
+      'credit-token',
+      'address-list',
+      'payment-protocol',
+      'liquidity-pools',
+      'quest',
+      'bounty',
+      'crowdfund',
+      'auction',
+      'product-catalog',
+      'prediction-market'
+    ]) {
+      expect(ids).toContain(expected);
+    }
+  });
+
+  it('every mapped standard resolves to a real token-type skill id', () => {
+    const ids = new Set(getTokenTypeSkillIds());
+    for (const { skillId } of STANDARD_TO_TOKEN_TYPE) {
+      expect(ids.has(skillId)).toBe(true);
+    }
+  });
+
+  it('getTokenTypeSkills returns full SkillInstruction records', () => {
+    const skills = getTokenTypeSkills();
+    expect(skills.length).toBeGreaterThanOrEqual(15);
+    expect(skills.every((s) => s.category === 'token-type')).toBe(true);
+  });
+});
+
+describe('extractStandards', () => {
+  it('returns [] for undefined / null / non-object', () => {
+    expect(extractStandards(undefined)).toEqual([]);
+    expect(extractStandards(null)).toEqual([]);
+    expect(extractStandards('nope')).toEqual([]);
+  });
+
+  it('pulls standards from the top-level field', () => {
+    expect(extractStandards({ standards: ['Smart Token'] })).toEqual(['Smart Token']);
+  });
+
+  it('tolerates nested collection shapes', () => {
+    expect(extractStandards({ collection: { standards: ['Subscription'] } })).toEqual(['Subscription']);
+    expect(extractStandards({ collections: [{ standards: ['NFT Collection'] }] })).toEqual(['NFT Collection']);
+  });
+
+  it('tolerates object-form standards with a name field', () => {
+    expect(extractStandards({ standards: [{ name: 'Payment Protocol' }, 'Something Else'] })).toEqual([
+      'Payment Protocol',
+      'Something Else'
+    ]);
+  });
+});
+
+describe('inferFromStandards (deterministic fast-path)', () => {
+  const allowedAll = new Set(getTokenTypeSkillIds());
+
+  it('maps Smart Token → smart-token', () => {
+    expect(inferFromStandards(['Smart Token'], allowedAll)).toBe('smart-token');
+  });
+
+  it('maps Liquidity Pools → liquidity-pools (tradable asset)', () => {
+    expect(inferFromStandards(['Liquidity Pools'], allowedAll)).toBe('liquidity-pools');
+  });
+
+  it('is case-insensitive', () => {
+    expect(inferFromStandards(['smart token'], allowedAll)).toBe('smart-token');
+    expect(inferFromStandards(['SUBSCRIPTION'], allowedAll)).toBe('subscription');
+  });
+
+  it('returns null when no standard matches', () => {
+    expect(inferFromStandards(['Unknown Standard'], allowedAll)).toBeNull();
+    expect(inferFromStandards([], allowedAll)).toBeNull();
+  });
+
+  it('respects the allowedIds filter', () => {
+    const allowed = new Set(['subscription']);
+    expect(inferFromStandards(['Smart Token'], allowed)).toBeNull();
+    expect(inferFromStandards(['Subscription'], allowed)).toBe('subscription');
+  });
+});
+
+describe('parseInferenceResponse', () => {
+  const allowed = new Set(['subscription', 'smart-token']);
+
+  it('accepts a valid high-confidence pick', () => {
+    const r = parseInferenceResponse(
+      '{"id":"subscription","confidence":"high","reasoning":"recurring $10/mo"}',
+      allowed
+    );
+    expect(r.tokenType).toBe('subscription');
+    expect(r.confidence).toBe('high');
+    expect(r.reasoning).toBe('recurring $10/mo');
+  });
+
+  it('strips ```json fences that Claude occasionally adds', () => {
+    const r = parseInferenceResponse(
+      '```json\n{"id":"smart-token","confidence":"high","reasoning":"wraps USDC"}\n```',
+      allowed
+    );
+    expect(r.tokenType).toBe('smart-token');
+  });
+
+  it('returns null when confidence is not high', () => {
+    const r = parseInferenceResponse(
+      '{"id":"subscription","confidence":"low","reasoning":"ambiguous"}',
+      allowed
+    );
+    expect(r.tokenType).toBeNull();
+    expect(r.confidence).toBe('low');
+  });
+
+  it('returns null when id is not allowed', () => {
+    const r = parseInferenceResponse(
+      '{"id":"fungible-token","confidence":"high","reasoning":"x"}',
+      allowed
+    );
+    expect(r.tokenType).toBeNull();
+  });
+
+  it('handles null id as explicit freestyle', () => {
+    const r = parseInferenceResponse('{"id":null,"confidence":"high","reasoning":"too vague"}', allowed);
+    expect(r.tokenType).toBeNull();
+    expect(r.confidence).toBe('high');
+  });
+
+  it('returns null on malformed JSON', () => {
+    const r = parseInferenceResponse('not json', allowed);
+    expect(r.tokenType).toBeNull();
+    expect(r.confidence).toBeNull();
+  });
+});
+
+describe('buildInferenceUserPrompt', () => {
+  it('just the prompt for create mode', () => {
+    const out = buildInferenceUserPrompt({ prompt: 'monthly sub for $10', mode: 'create' });
+    expect(out).toContain('User build request');
+    expect(out).toContain('monthly sub for $10');
+    expect(out).not.toContain('Original build intent');
+  });
+
+  it('refine mode prepends original intent + prior turns', () => {
+    const out = buildInferenceUserPrompt({
+      prompt: 'raise the supply to 2000',
+      mode: 'refine',
+      originalPrompt: 'mint a fungible governance token',
+      priorRefinePrompts: ['change the name to Gov', 'also make it transferable']
+    });
+    expect(out).toContain('Original build intent');
+    expect(out).toContain('mint a fungible governance token');
+    expect(out).toContain('change the name to Gov');
+    expect(out).toContain('Current refinement turn');
+    expect(out).toContain('raise the supply to 2000');
+  });
+
+  it('includes existing standards when provided', () => {
+    const out = buildInferenceUserPrompt({
+      prompt: 'fix the validation error',
+      mode: 'refine',
+      existingStandards: ['Smart Token']
+    });
+    expect(out).toContain('Existing collection standards');
+    expect(out).toContain('Smart Token');
+  });
+
+  it('caps priorRefinePrompts to the last three turns', () => {
+    const out = buildInferenceUserPrompt({
+      prompt: 'latest',
+      mode: 'refine',
+      originalPrompt: 'orig',
+      priorRefinePrompts: ['t1', 't2', 't3', 't4', 't5']
+    });
+    expect(out).not.toContain('t1');
+    expect(out).not.toContain('t2');
+    expect(out).toContain('t3');
+    expect(out).toContain('t4');
+    expect(out).toContain('t5');
+  });
+});
+
+describe('buildInferenceSystemPrompt', () => {
+  it('enumerates every supplied skill + states the JSON contract', () => {
+    const catalog = getTokenTypeSkills();
+    const sys = buildInferenceSystemPrompt(catalog);
+    expect(sys).toContain('"id"');
+    expect(sys).toContain('"confidence"');
+    expect(sys).toContain('"high"');
+    expect(sys).toContain('Freestyle is a valid outcome');
+    for (const s of catalog) {
+      expect(sys).toContain(s.id);
+    }
+  });
+});
+
+describe('inferTokenTypeFromPrompt (end-to-end with fake client)', () => {
+  it('fast-paths existing standards without calling Claude', async () => {
+    const client = makeFakeClient(mkMessagesResponse(''));
+    const r = await inferTokenTypeFromPrompt({
+      prompt: 'fix the supply cap',
+      mode: 'refine',
+      existingTransaction: { standards: ['Smart Token'] },
+      anthropicClient: client
+    });
+    expect(r.tokenType).toBe('smart-token');
+    expect(r.source).toBe('standards');
+    expect(r.confidence).toBe('high');
+    expect(client.messages.create).not.toHaveBeenCalled();
+    expect(r.tokenUsage).toBeUndefined();
+  });
+
+  it('calls Claude when no standards signal is available', async () => {
+    const client = makeFakeClient(
+      mkMessagesResponse(
+        '{"id":"subscription","confidence":"high","reasoning":"recurring monthly payment pattern"}'
+      )
+    );
+    const r = await inferTokenTypeFromPrompt({
+      prompt: 'monthly subscription for $10, max 500 subscribers',
+      mode: 'create',
+      anthropicClient: client
+    });
+    expect(r.tokenType).toBe('subscription');
+    expect(r.source).toBe('llm');
+    expect(r.tokenUsage?.model).toMatch(/haiku/);
+    expect(client.messages.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when Claude reports low confidence', async () => {
+    const client = makeFakeClient(
+      mkMessagesResponse('{"id":"fungible-token","confidence":"low","reasoning":"too vague"}')
+    );
+    const r = await inferTokenTypeFromPrompt({
+      prompt: 'I want to make some kind of token thing for my community',
+      anthropicClient: client
+    });
+    expect(r.tokenType).toBeNull();
+    expect(r.confidence).toBe('low');
+    expect(r.source).toBeNull();
+  });
+
+  it('returns null on network errors (freestyle is valid)', async () => {
+    const client = {
+      messages: {
+        create: jest.fn(async () => {
+          throw new Error('network down');
+        })
+      }
+    };
+    const r = await inferTokenTypeFromPrompt({
+      prompt: 'any prompt',
+      anthropicClient: client
+    });
+    expect(r.tokenType).toBeNull();
+    expect(r.source).toBeNull();
+    expect(client.messages.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when anthropicClient is absent and no standards hint', async () => {
+    const r = await inferTokenTypeFromPrompt({
+      prompt: 'anything',
+      anthropicClient: null
+    });
+    expect(r.tokenType).toBeNull();
+  });
+
+  it('restricts candidates via allowedTokenTypeIds', async () => {
+    const captured = { value: null as any };
+    const client = makeFakeClient(
+      mkMessagesResponse('{"id":"fungible-token","confidence":"high","reasoning":"..."}'),
+      { captureArgs: captured }
+    );
+    const r = await inferTokenTypeFromPrompt({
+      prompt: 'simple fungible token',
+      allowedTokenTypeIds: ['subscription'],
+      anthropicClient: client
+    });
+    // fungible-token is not in the allowlist → must be rejected.
+    expect(r.tokenType).toBeNull();
+    const sysText: string = captured.value.system[0].text;
+    expect(sysText).toContain('subscription');
+    expect(sysText).not.toContain('`fungible-token`');
+  });
+
+  it('sends a cache_control hint on the system prompt', async () => {
+    const captured = { value: null as any };
+    const client = makeFakeClient(
+      mkMessagesResponse('{"id":null,"confidence":"low","reasoning":"..."}'),
+      { captureArgs: captured }
+    );
+    await inferTokenTypeFromPrompt({ prompt: 'x', anthropicClient: client });
+    expect(captured.value.system[0].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('folds refine context into the user message', async () => {
+    const captured = { value: null as any };
+    const client = makeFakeClient(
+      mkMessagesResponse('{"id":"fungible-token","confidence":"high","reasoning":"gov token"}'),
+      { captureArgs: captured }
+    );
+    await inferTokenTypeFromPrompt({
+      prompt: 'fix this',
+      mode: 'refine',
+      originalPrompt: 'make a governance token called GOV, supply 1000',
+      priorRefinePrompts: ['add a logo'],
+      anthropicClient: client
+    });
+    const userMsg: string = captured.value.messages[0].content;
+    expect(userMsg).toContain('Original build intent');
+    expect(userMsg).toContain('governance token');
+    expect(userMsg).toContain('Current refinement turn');
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/agent/tokenTypeInference.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/tokenTypeInference.ts
@@ -223,8 +223,15 @@ export function parseInferenceResponse(
   allowedIds: Set<string>
 ): { tokenType: string | null; confidence: 'high' | 'low' | null; reasoning?: string } {
   const trimmed = raw.trim();
-  // Claude may wrap the JSON in ```json fences despite instructions; strip once.
-  const unfenced = trimmed.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
+  // Claude may wrap the JSON in ```json fences despite instructions;
+  // strip once. Split into two anchored replaces + trim rather than
+  // one alternation with `\s*` — avoids the polynomial-regex-on-
+  // uncontrolled-input footgun CodeQL flagged.
+  let unfenced = trimmed;
+  if (unfenced.startsWith('```')) {
+    unfenced = unfenced.replace(/^```(?:json)?/, '').trimStart();
+    unfenced = unfenced.replace(/```$/, '').trimEnd();
+  }
   let obj: any;
   try {
     obj = JSON.parse(unfenced);

--- a/packages/bitbadgesjs-sdk/src/builder/agent/tokenTypeInference.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/tokenTypeInference.ts
@@ -1,0 +1,373 @@
+/**
+ * Smart token-type inference.
+ *
+ * Given a natural-language build prompt plus whatever prior context is
+ * available (existing transaction in update mode, original intent +
+ * recent refinement turns in refine mode), picks at most one
+ * token-type skill id. Returns `null` whenever the answer isn't a
+ * high-confidence match — a freestyle build with no token-type skill
+ * is an explicitly valid outcome.
+ *
+ * Two signals, in order:
+ *   1. Deterministic standards → skill mapping. If the existing
+ *      transaction (session or on-chain snapshot) already declares a
+ *      `standards` array that matches a known token type, we accept
+ *      that immediately — no LLM call needed. This is the dominant
+ *      signal for update/refine flows where the user prompt is often
+ *      just "fix this" or "raise the supply".
+ *   2. A haiku classification call against the enriched prompt
+ *      (original intent + recent refinement turns + current prompt +
+ *      standards hint when available). Strict JSON output contract;
+ *      only `confidence: "high"` results are accepted.
+ */
+
+import { MODELS, computeCostUsd, type ModelInfo } from './models.js';
+import { getAllSkillInstructions, type SkillInstruction } from '../resources/skillInstructions.js';
+import type { AgentHooks, BuildMode } from './types.js';
+
+export interface TokenTypeInferenceInput {
+  /** Current user prompt (create) or refinement turn (refine) or update instruction (update). */
+  prompt: string;
+  /** Build mode — affects how prior context is folded into the inference prompt. */
+  mode?: BuildMode;
+  /** Restrict inference to this subset of token-type skill ids (useful when the agent has a `skills` whitelist). */
+  allowedTokenTypeIds?: string[];
+  /** The first-turn prompt for a refinement chain. Surfaces the real intent when the current turn is vague. */
+  originalPrompt?: string;
+  /** Prior refinement turns (most recent last). Capped to the last 3 before being included in the inference prompt. */
+  priorRefinePrompts?: string[];
+  /** The existing collection transaction (session snapshot for refine, on-chain snapshot for update). */
+  existingTransaction?: any;
+  /** Explicit standards list override — if set, takes precedence over `existingTransaction.standards`. */
+  existingStandards?: string[];
+
+  anthropicClient: any;
+  model?: ModelInfo;
+  /** Per-inference timeout (ms). Default: 30_000. */
+  timeoutMs?: number;
+  abortSignal?: AbortSignal;
+  debug?: boolean;
+  hooks?: AgentHooks;
+}
+
+export interface TokenTypeInferenceResult {
+  /** Picked skill id, or null when confidence was not `high` / no clear match / inference failed. */
+  tokenType: string | null;
+  /** `'high'` → accepted. `'low'` / `null` → we force `tokenType` to null. */
+  confidence: 'high' | 'low' | null;
+  /** Which signal produced the pick (useful for UI and debug). */
+  source: 'standards' | 'llm' | null;
+  /** Short reasoning string, useful for UI surfacing. Empty when null. */
+  reasoning?: string;
+  /** Token usage from the LLM call — absent when inference came from the standards fast-path or failed. */
+  tokenUsage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    costUsd: number;
+    model: string;
+  };
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_PRIOR_REFINE_PROMPTS = 3;
+
+/**
+ * Standard-name → token-type skill id. Derived from each skill's
+ * "Required standards" stanza — kept as a typed constant so callers
+ * (and tests) can audit the full mapping without parsing summaries at
+ * runtime.
+ */
+export const STANDARD_TO_TOKEN_TYPE: ReadonlyArray<{ standard: string; skillId: string }> = [
+  { standard: 'Smart Token', skillId: 'smart-token' },
+  { standard: 'Fungible Token', skillId: 'fungible-token' },
+  { standard: 'NFT Collection', skillId: 'nft-collection' },
+  { standard: 'Subscription', skillId: 'subscription' },
+  { standard: 'Custom 2FA', skillId: 'custom-2fa' },
+  { standard: 'Payment Protocol', skillId: 'payment-protocol' },
+  { standard: 'Credit Token', skillId: 'credit-token' },
+  { standard: 'Address List', skillId: 'address-list' },
+  { standard: 'Quest', skillId: 'quest' },
+  { standard: 'Bounty', skillId: 'bounty' },
+  { standard: 'Crowdfund', skillId: 'crowdfund' },
+  { standard: 'Auction', skillId: 'auction' },
+  { standard: 'Products', skillId: 'product-catalog' },
+  { standard: 'Prediction Market', skillId: 'prediction-market' },
+  { standard: 'Liquidity Pools', skillId: 'liquidity-pools' }
+];
+
+/**
+ * Returns every token-type skill id currently known to the SDK.
+ * Drives the frontend's marketplace and the inference prompt catalog.
+ */
+export function getTokenTypeSkillIds(): string[] {
+  return getAllSkillInstructions()
+    .filter((s) => s.category === 'token-type')
+    .map((s) => s.id);
+}
+
+/** Returns the full `SkillInstruction` records for every token-type skill. */
+export function getTokenTypeSkills(): SkillInstruction[] {
+  return getAllSkillInstructions().filter((s) => s.category === 'token-type');
+}
+
+/**
+ * Normalize the `standards` field off any existing-transaction shape
+ * we might be handed. Tolerates undefined, arrays of strings, and
+ * arrays of objects with a `name` — all shapes that have appeared in
+ * the wild.
+ */
+export function extractStandards(transaction: any): string[] {
+  if (!transaction) return [];
+  const raw = transaction.standards ?? transaction.collection?.standards ?? transaction?.collections?.[0]?.standards;
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry === 'string' && entry.trim()) out.push(entry.trim());
+    else if (entry && typeof entry.name === 'string' && entry.name.trim()) out.push(entry.name.trim());
+  }
+  return out;
+}
+
+/**
+ * Deterministic fast-path: map declared `standards` to a token-type
+ * skill id. Returns null when nothing matches — we'd rather fall
+ * through to the LLM than guess.
+ */
+export function inferFromStandards(standards: string[], allowedIds: Set<string>): string | null {
+  for (const s of standards) {
+    const match = STANDARD_TO_TOKEN_TYPE.find((m) => m.standard.toLowerCase() === s.toLowerCase());
+    if (match && allowedIds.has(match.skillId)) return match.skillId;
+  }
+  return null;
+}
+
+/**
+ * Build the system prompt that lists every token-type skill with a
+ * one-line description and the strict JSON output contract.
+ */
+export function buildInferenceSystemPrompt(catalog: SkillInstruction[]): string {
+  const lines = catalog.map((s) => `- \`${s.id}\` — ${s.name}: ${s.description}`).join('\n');
+  return `You classify BitBadges token build requests into exactly one token-type skill — or none at all.
+
+Available token types (pick ZERO or ONE):
+
+${lines}
+
+Output contract — respond with a single JSON object, no surrounding prose, no markdown fences:
+
+{
+  "id": "<one of the ids above, or null>",
+  "confidence": "high" | "low",
+  "reasoning": "<one short sentence>"
+}
+
+Rules:
+- Only return a non-null \`id\` when the request maps unambiguously to that skill.
+- If the request is vague, generic, covers multiple token types, or describes something unusual, return \`id: null\`. Freestyle is a valid outcome.
+- \`confidence\` must be \`"high"\` to be acted on — anything else is treated as no match.
+- When the context mentions existing \`standards: [...]\`, that is authoritative — match it directly.
+- When the user prompt is a refinement like "fix this" or "raise the supply", rely on the original intent and prior turns rather than the short current turn.
+- Never invent skill ids. Never return more than one.
+- Keep \`reasoning\` under 20 words.`;
+}
+
+/**
+ * Assemble the user-message body. For `refine` mode we prepend the
+ * original intent + up to the last three refinement turns so a short
+ * "fix this" doesn't strip the inference of its context. For `update`
+ * mode we surface declared standards — the single strongest signal.
+ */
+export function buildInferenceUserPrompt(input: {
+  prompt: string;
+  mode?: BuildMode;
+  originalPrompt?: string;
+  priorRefinePrompts?: string[];
+  existingStandards?: string[];
+}): string {
+  const parts: string[] = [];
+  const mode = input.mode ?? 'create';
+
+  if (input.existingStandards && input.existingStandards.length > 0) {
+    parts.push(`Existing collection standards: ${JSON.stringify(input.existingStandards)}`);
+  }
+
+  if (mode === 'refine' || mode === 'update') {
+    if (input.originalPrompt && input.originalPrompt.trim() && input.originalPrompt.trim() !== input.prompt.trim()) {
+      parts.push(`Original build intent:\n${input.originalPrompt.trim()}`);
+    }
+    if (input.priorRefinePrompts && input.priorRefinePrompts.length > 0) {
+      const tail = input.priorRefinePrompts
+        .filter((p): p is string => typeof p === 'string' && !!p.trim())
+        .slice(-MAX_PRIOR_REFINE_PROMPTS);
+      if (tail.length > 0) {
+        parts.push(`Prior ${mode === 'refine' ? 'refinement' : 'update'} turns (oldest → newest):\n${tail.map((p) => `- ${p.trim()}`).join('\n')}`);
+      }
+    }
+    const currentLabel = mode === 'refine' ? 'Current refinement turn' : 'Current update instruction';
+    parts.push(`${currentLabel}:\n${input.prompt.trim()}`);
+  } else {
+    parts.push(`User build request:\n${input.prompt.trim()}`);
+  }
+
+  return parts.join('\n\n');
+}
+
+/**
+ * Normalize a Claude response into a validated `TokenTypeInferenceResult`.
+ * Extracted so tests can exercise parsing without mocking the full client.
+ */
+export function parseInferenceResponse(
+  raw: string,
+  allowedIds: Set<string>
+): { tokenType: string | null; confidence: 'high' | 'low' | null; reasoning?: string } {
+  const trimmed = raw.trim();
+  // Claude may wrap the JSON in ```json fences despite instructions; strip once.
+  const unfenced = trimmed.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
+  let obj: any;
+  try {
+    obj = JSON.parse(unfenced);
+  } catch {
+    return { tokenType: null, confidence: null };
+  }
+  if (!obj || typeof obj !== 'object') return { tokenType: null, confidence: null };
+  const id = typeof obj.id === 'string' ? obj.id : null;
+  const confidence =
+    obj.confidence === 'high' || obj.confidence === 'low' ? (obj.confidence as 'high' | 'low') : null;
+  const reasoning = typeof obj.reasoning === 'string' ? obj.reasoning.slice(0, 240) : undefined;
+  if (!id || !allowedIds.has(id) || confidence !== 'high') {
+    return { tokenType: null, confidence, reasoning };
+  }
+  return { tokenType: id, confidence, reasoning };
+}
+
+/**
+ * Run token-type inference. Never throws — returns a null pick on any
+ * failure so the caller can proceed with a freestyle build.
+ */
+export async function inferTokenTypeFromPrompt(
+  input: TokenTypeInferenceInput
+): Promise<TokenTypeInferenceResult> {
+  const { prompt, anthropicClient, abortSignal, debug } = input;
+  if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+    return { tokenType: null, confidence: null, source: null };
+  }
+
+  const allSkills = getTokenTypeSkills();
+  const catalog = input.allowedTokenTypeIds?.length
+    ? allSkills.filter((s) => input.allowedTokenTypeIds!.includes(s.id))
+    : allSkills;
+  if (catalog.length === 0) {
+    return { tokenType: null, confidence: null, source: null };
+  }
+  const allowedIds = new Set(catalog.map((s) => s.id));
+
+  // --- Signal 1: deterministic standards → skill ---------------------
+  const standards =
+    input.existingStandards && input.existingStandards.length > 0
+      ? input.existingStandards
+      : extractStandards(input.existingTransaction);
+
+  const fromStandards = inferFromStandards(standards, allowedIds);
+  if (fromStandards) {
+    if (debug) {
+      console.error(
+        `[bitbadges-builder-agent] tokenTypeInference (standards fast-path) pick=${fromStandards} standards=${JSON.stringify(standards)}`
+      );
+    }
+    return {
+      tokenType: fromStandards,
+      confidence: 'high',
+      source: 'standards',
+      reasoning: `Existing collection declares standards ${JSON.stringify(standards)}.`
+    };
+  }
+
+  // --- Signal 2: haiku LLM classification ----------------------------
+  if (!anthropicClient) {
+    return { tokenType: null, confidence: null, source: null };
+  }
+
+  const model: ModelInfo = input.model ?? MODELS.haiku;
+  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const systemPrompt = buildInferenceSystemPrompt(catalog);
+  const userPrompt = buildInferenceUserPrompt({
+    prompt,
+    mode: input.mode,
+    originalPrompt: input.originalPrompt,
+    priorRefinePrompts: input.priorRefinePrompts,
+    existingStandards: standards
+  });
+
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+  if (abortSignal) {
+    if (abortSignal.aborted) controller.abort();
+    else abortSignal.addEventListener('abort', () => controller.abort(), { once: true });
+  }
+
+  try {
+    const response: any = await anthropicClient.messages.create(
+      {
+        model: model.id,
+        max_tokens: 200,
+        temperature: 0,
+        system: [
+          {
+            type: 'text',
+            text: systemPrompt,
+            cache_control: { type: 'ephemeral' }
+          }
+        ],
+        messages: [{ role: 'user', content: userPrompt }]
+      },
+      { signal: controller.signal }
+    );
+
+    const textBlock = Array.isArray(response?.content)
+      ? response.content.find((b: any) => b?.type === 'text')
+      : null;
+    const rawText = typeof textBlock?.text === 'string' ? textBlock.text : '';
+    const parsed = parseInferenceResponse(rawText, allowedIds);
+
+    const usage = response?.usage ?? {};
+    const inputTokens = Number(usage.input_tokens ?? 0) || 0;
+    const outputTokens = Number(usage.output_tokens ?? 0) || 0;
+    const cacheCreationTokens = Number(usage.cache_creation_input_tokens ?? 0) || 0;
+    const cacheReadTokens = Number(usage.cache_read_input_tokens ?? 0) || 0;
+    const costUsd = computeCostUsd(inputTokens, outputTokens, model, cacheCreationTokens, cacheReadTokens);
+
+    const result: TokenTypeInferenceResult = {
+      tokenType: parsed.tokenType,
+      confidence: parsed.confidence,
+      source: parsed.tokenType ? 'llm' : null,
+      reasoning: parsed.reasoning,
+      tokenUsage: {
+        inputTokens,
+        outputTokens,
+        cacheCreationTokens,
+        cacheReadTokens,
+        costUsd,
+        model: model.id
+      }
+    };
+
+    if (debug) {
+      console.error(
+        `[bitbadges-builder-agent] tokenTypeInference model=${model.id} ` +
+          `pick=${result.tokenType ?? 'null'} confidence=${result.confidence ?? 'null'} ` +
+          `tokens_in=${inputTokens} out=${outputTokens}`
+      );
+    }
+
+    return result;
+  } catch (err) {
+    if (debug) {
+      console.warn('[bitbadges-builder-agent] tokenTypeInference failed:', err);
+    }
+    return { tokenType: null, confidence: null, source: null };
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}

--- a/packages/bitbadgesjs-sdk/src/builder/agent/types.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/types.ts
@@ -292,6 +292,18 @@ export interface BuildResult {
   fixRounds: number;
   /** Full trace — messages, tool calls, etc. */
   trace: BuildTrace;
+  /**
+   * Token-type skill id picked by the smart auto-inference step, or
+   * `null` when inference ran but didn't find a high-confidence match
+   * (freestyle build). `undefined` when inference was skipped
+   * entirely — e.g. the caller already supplied a token-type skill,
+   * or `autoInferTokenType` was turned off.
+   */
+  inferredTokenType?: string | null;
+  /** Provenance of `inferredTokenType` — `'standards'` (existing-collection fast-path) or `'llm'` (haiku classifier). */
+  inferredTokenTypeSource?: 'standards' | 'llm';
+  /** One-sentence explanation of the inference pick, surfaced for UI display. */
+  inferredTokenTypeReasoning?: string;
   /** Human-readable one-paragraph summary of what the build did. */
   toString(): string;
 }
@@ -372,6 +384,15 @@ export interface BitBadgesBuilderAgentOptions {
 
   /** Default creator address (can be overridden per build). */
   defaultCreatorAddress?: string;
+
+  /**
+   * Auto-infer a single token-type skill when `selectedSkills` has no
+   * token-type entry. High-confidence matches are prepended to the
+   * build's skill list; non-matches are left alone (freestyle build is
+   * a valid outcome). Default: `true`. Non-token-type skills
+   * (community / additional-context) do not block inference.
+   */
+  autoInferTokenType?: boolean;
 }
 
 /** Options passed to `agent.build()`. Narrower than the constructor. */
@@ -391,4 +412,6 @@ export interface BuildOptions {
   abortSignal?: AbortSignal;
   /** Per-build hook overrides (merge on top of constructor hooks). */
   hooks?: AgentHooks;
+  /** Per-build override of `autoInferTokenType`. Undefined → fall back to the constructor option (default `true`). */
+  autoInferTokenType?: boolean;
 }

--- a/packages/bitbadgesjs-sdk/src/builder/resources/skillInstructions.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/resources/skillInstructions.ts
@@ -541,8 +541,8 @@ Key escrow rules:
   {
     id: 'liquidity-pools',
     name: 'Liquidity Pools',
-    category: 'standard',
-    description: 'Liquidity pool standard with the "Liquidity Pools" protocol standard tag',
+    category: 'token-type',
+    description: 'Liquidity pool standard with the "Liquidity Pools" protocol standard tag — used for tradable assets that can be swapped on a DEX',
     summary: `Required standards: ["Liquidity Pools"]
 
 - MUST set invariants.disablePoolCreation: false


### PR DESCRIPTION
## Summary

Adds automatic **token-type skill inference** to `BitBadgesBuilderAgent.build()` so frontend/indexer callers don't have to manually classify which of the 15 marketplace token types a prompt matches. When the caller already passed a token-type skill in `selectedSkills`, inference is skipped entirely — this change is additive for existing callers.

## Design notes

- **High-confidence only.** If the classifier isn't certain, `inferredTokenType` is `null` and the build proceeds freestyle. This is explicitly a valid outcome — we prefer no pick over a wrong one.
- **Two signals, in order:**
  1. Deterministic `standards` → skill mapping. If the existing session transaction (refine mode) or on-chain snapshot (update mode) declares e.g. `standards: ["Smart Token"]`, we use `smart-token` directly with no LLM call. This is the dominant path for refine flows where the user prompt is often just "fix this" or "raise the supply".
  2. Fallback haiku call with the full token-type catalog as a cache-stable system prompt. Strict JSON contract; `confidence` must be `"high"` to be acted on.
- **Refine/update context folded in.** The user message includes the original build intent, the last 3 refinement turns, and any existing standards — so a short refinement doesn't strip the classifier of its signal.
- **Cost.** Folded into existing `onTokenUsage` as `round: 0` so the indexer's token ledger stays uniform. Cached system prompt → negligible ongoing cost.
- **Side change:** flipped `liquidity-pools` from `'standard'` to `'token-type'`. It's the backing skill for the frontend's `tradable-asset` marketplace tile, which has always been grouped as a token type.

## API

```ts
new BitBadgesBuilderAgent({
  // ...
  autoInferTokenType?: boolean,   // default: true
});

agent.build(prompt, {
  autoInferTokenType?: boolean,   // per-build override
});

// result surface
result.inferredTokenType          // string | null | undefined
result.inferredTokenTypeSource    // 'standards' | 'llm' | undefined
result.inferredTokenTypeReasoning // string | undefined
```

New public exports from `bitbadges/builder/agent`:
- `inferTokenTypeFromPrompt`, `getTokenTypeSkillIds`, `getTokenTypeSkills`
- `STANDARD_TO_TOKEN_TYPE` (standards-name → skill-id table, shared w/ frontend)
- `extractStandards`, `inferFromStandards`, parsing/prompt helpers for testing
- Types: `TokenTypeInferenceInput`, `TokenTypeInferenceResult`

## Companion PRs

- Indexer — wires `autoInferTokenType` through `/ai-build` and returns `inferredTokenType` in the response
- Frontend — adds a "Smart Detect" toggle next to "Add Plugin" in the skills marketplace; surfaces the inferred type in the result pane
- Docs — new page `for-developers/ai-agents/smart-token-type-detection.md`

## Test plan

- [x] 31 new unit tests in `tokenTypeInference.spec.ts` (catalog helpers, standards fast-path, response parser, refine-context prompt assembly, end-to-end with a faked Anthropic client)
- [x] 6 new integration tests in `BitBadgesBuilderAgent.spec.ts` (default-on path, token-type already selected → skip, per-build override, low-confidence → freestyle, constructor skills whitelist, `onTokenUsage` round=0)
- [x] 199/199 agent tests pass, 2180/2180 full SDK tests pass
- [x] `npm run build` clean, no circular deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)