### PR TITLE
fix(builder-agent): strip cache_control from resumed messages (fixes 5-block 400)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/builder/agent/loop.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/loop.ts
@@ -173,6 +173,27 @@ const STATUS_MAP: Record<string, string> = {
   lookup_claim_plugins: 'Researching...', lookup_token_info: 'Researching...'
 };
 
+/**
+ * Return a copy of the messages array with cache_control stripped from
+ * every content block. Used when resuming from session state so prior
+ * builds' cache markers don't accumulate past Anthropic's 4-block cap.
+ * We only need cache_control on the NEWEST user message each request;
+ * the prompt cache hits anyway via longest-shared-prefix matching.
+ */
+function stripCacheControl(messages: any[]): any[] {
+  return messages.map((msg) => {
+    if (!msg || !Array.isArray(msg.content)) return msg;
+    const cleanedContent = msg.content.map((block: any) => {
+      if (block && typeof block === 'object' && 'cache_control' in block) {
+        const { cache_control: _drop, ...rest } = block;
+        return rest;
+      }
+      return block;
+    });
+    return { ...msg, content: cleanedContent };
+  });
+}
+
 function fireHook(fn: ((...args: any[]) => any) | undefined, ...args: any[]) {
   if (!fn) return;
   try {
@@ -197,8 +218,20 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<AgentLoopRe
     ? userContent
     : [{ type: 'text' as const, text: userMessage }];
 
-  const messages: any[] = existingMessages
-    ? [...existingMessages, { role: 'user', content: initialUserBlocks }]
+  // When resuming from session state, strip cache_control from all
+  // historical message blocks. Anthropic limits a request to 4
+  // cache_control blocks; each build adds one on the new user message's
+  // stableSkills chunk (plus 1 on system + 1 on tools = 3 baseline),
+  // so after two refinements a resumed session would carry 5 → 400
+  // "A maximum of 4 blocks with cache_control may be provided."
+  //
+  // Only the NEWEST user message needs a cache boundary — Anthropic's
+  // prompt cache works by longest shared prefix, so marking the tail
+  // is sufficient; historical blocks are cached implicitly.
+  const priorMessages = existingMessages ? stripCacheControl(existingMessages) : undefined;
+
+  const messages: any[] = priorMessages
+    ? [...priorMessages, { role: 'user', content: initialUserBlocks }]
     : [{ role: 'user', content: initialUserBlocks }];
   const toolCalls: ToolCallEvent[] = [];
   let finalText = '';


### PR DESCRIPTION
## Summary

Fixes a bug where the second refinement on any session would 400 with `A maximum of 4 blocks with cache_control may be provided. Found 5.`

Each agent request carries 3 cache_control blocks baseline:
- `system` prompt (1)
- Last tool in `tools` (1)
- The new user message's `stableSkills` chunk (1)

Each refinement appends another user message whose `stableSkills` was marked `cache_control: ephemeral` when it was first sent. Those markers persist when the session is reloaded from the session store. So after two refinements a resumed session carries 5 → 400.

## Fix

When resuming from session state, walk all prior messages and strip `cache_control` from every content block. Only the newest user message keeps its cache boundary. Anthropic's prompt cache works by longest shared prefix, so marking the tail is enough — earlier blocks are cached implicitly.

## Repro

Real prod session (`ses_ztl1zgb0e6ql`):
1. Initial build: "Create a smart token vault with 1000 USDC/day withdrawal limit" → success
2. Refine #1: "Withdrawal rate is 1 vUSDC currently. It should be 1000 vUSDC / day." → success (first refinement stays at 4 cache blocks)
3. Refine #2: same prompt retried → 400 (5 cache blocks)

## Cache performance

No change to hit rate. We still cache the longest prefix per request. What changes is that historical per-refinement caches aren't individually re-marked on every subsequent turn. They're still cached — just via the single boundary on the newest user message.

## Test plan

- [x] TypeScript clean.
- [ ] Local: reproduce the 3+ refinement case and confirm it no longer 400s.
- [ ] Smoke: a fresh first-build still caches correctly (cache_creation_input_tokens > 0 on round 1, cache_read_input_tokens > 0 on round 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
