### PR TITLE
docs(openapi): hide websiteOnlyCors routes from public docs

### DIFF
--- a/packages/bitbadgesjs-sdk/openapitypes-helpers/routes.yaml
+++ b/packages/bitbadgesjs-sdk/openapitypes-helpers/routes.yaml
@@ -1250,7 +1250,7 @@ paths:
               $ref: '#/components/schemas/iCreateDynamicDataStorePayload'
       security:
         - apiKey: []
-      x-internal: false
+      x-internal: true
     put:
       operationId: updateDynamicDataStore
       summary: Update Dynamic Data Store
@@ -1296,7 +1296,7 @@ paths:
               $ref: '#/components/schemas/iUpdateDynamicDataStorePayload'
       security:
         - apiKey: []
-      x-internal: false
+      x-internal: true
     delete:
       operationId: deleteDynamicDataStore
       summary: Delete Dynamic Data Store
@@ -1343,7 +1343,7 @@ paths:
               $ref: '#/components/schemas/iDeleteDynamicDataStorePayload'
       security:
         - apiKey: []
-      x-internal: false
+      x-internal: true
   /application/{applicationId}:
     get:
       operationId: getApplication
@@ -5350,7 +5350,7 @@ paths:
           $ref: '#/components/responses/InternalServerErrorResponse'
       security:
         - apiKey: []
-      x-internal: false
+      x-internal: true
 
   /onChainDynamicStore/{storeId}:
     get:


### PR DESCRIPTION
## Summary

Flip `x-internal: false` to `x-internal: true` on four routes whose indexer handlers are wrapped in the `websiteOnlyCors` middleware (origin-locked to bitbadges.io).

Public docs were advertising these as callable, which would cause 3rd-party devs to hit CORS errors when calling them. The invariant per the docs-watch spec is: every `websiteOnlyCors` route MUST be absent from `routes.yaml` or have `x-internal: true`.

## Routes affected

| Method | Path | Handler |
|--------|------|---------|
| POST | `/dynamicStores` | `createDynamicDataStore` |
| PUT | `/dynamicStores` | `updateDynamicDataStore` |
| DELETE | `/dynamicStores` | `deleteDynamicDataStore` |
| GET | `/swapActivities` | `getSwapActivities` |

## Why hide instead of expose

These are mutations that require the `Manage Dynamic Stores` scope or return user-activity feeds; not core 3p-dev integration surface. Dynamic data stores are managed via the frontend UI today — exposing public docs for routes that then CORS-reject third-party origins is worse than hiding them.

If any of these should actually be publicly callable, the indexer middleware needs to change (remove `websiteOnlyCors`) — that's a separate security-shaped call and a human should make it.

## Test plan

- [ ] CI: `genapi.yml` runs cleanly on merge and opens the usual `update-openapi-hosted` PR
- [ ] Stoplight re-renders and these four operations no longer appear in the public navigation
- [ ] Frontend (which calls these via same-origin) is unaffected — no indexer change

Detected by docs-watch agent, 2026-04-24.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>