### PR TITLE
docs(openapi): fix Miscellanous tag typo + declare Maps and Protocols tag

### DIFF
--- a/packages/bitbadgesjs-sdk/openapitypes-helpers/routes.yaml
+++ b/packages/bitbadgesjs-sdk/openapitypes-helpers/routes.yaml
@@ -219,6 +219,9 @@ tags:
   - name: Utility Pages
     description: Endpoints for managing utility pages
   - name: Miscellaneous
+    description: Endpoints that don't fit other categories
+  - name: Maps and Protocols
+    description: Endpoints for maps and protocols (on-chain key-value stores and standardized metadata schemes)
   - name: Assets
     description: Endpoints for asset pair operations, liquidity pools, and swap analytics
 paths:
@@ -1405,7 +1408,7 @@ paths:
         - **[Response Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iGetStatusSuccessResponse)**
         - **[SDK API Function](https://bitbadges.github.io/bitbadgesjs/classes/BitBadgesAPI.html#getstatus)**
       tags:
-        - Miscellanous
+        - Miscellaneous
       responses:
         '200':
           content:


### PR DESCRIPTION
## Summary

- Fix `Miscellanous` typo (missing "e") on `getStatus` operation. The alias in `scripts/generate-api-routes.ts` was quietly papering over it; fix at the source.
- Declare the `Maps and Protocols` tag properly — it was referenced by 4 `/maps` and `/mapValues` operations but never declared in the top-level `tags:` block, leaving them grouped under an undocumented tag.
- Add a short description to the already-declared-but-bare `Miscellaneous` tag.

No operation bodies change. No visibility change.

Detected by docs-watch agent, 2026-04-24.

## Test plan

- [ ] CI: `genapi.yml` regenerates the hosted spec cleanly
- [ ] Stoplight shows `Maps and Protocols` as its own group in the navigation with the 4 map operations underneath
- [ ] `Miscellaneous` group still shows `getStatus`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>