### PR TITLE
test(mcp-builder): cover 3 more session setter handlers (59 tests)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/builder/tools/session/addTransfer.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/session/addTransfer.spec.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for `add_transfer` builder tool.
+ *
+ * handleAddTransfer appends a MsgTransferTokens message after the
+ * collection-create message, used for auto-mint flows. Key behaviors:
+ *
+ *   - Appends a new message at the end of session.messages.
+ *   - typeUrl is '/tokenization.MsgTransferTokens'.
+ *   - value.collectionId is auto-set to "0" (the just-created collection).
+ *   - value.creator is pulled from messages[0].value.creator (even if
+ *     that's empty — e.g. session was auto-created without creatorAddress).
+ *   - `from: "Mint"` passes through unchanged; any other address is
+ *     normalized to bb1 via ensureBb1.
+ *   - Returns {success, messageIndex, note} with the index of the new msg.
+ *   - Validation errors (zod parse failures) are caught and returned as
+ *     {success: false, error}.
+ */
+import { handleAddTransfer } from './addTransfer.js';
+import { getOrCreateSession, resetAllSessions } from '../../session/sessionState.js';
+
+const MAX = '18446744073709551615';
+const FOREVER = [{ start: '1', end: MAX }];
+
+const BASE_TRANSFER = {
+  from: 'Mint',
+  toAddresses: ['bb1alice'],
+  balances: [{ amount: '1', tokenIds: [{ start: '1', end: '1' }], ownershipTimes: FOREVER }],
+  prioritizedApprovals: [{ approvalId: 'mint-approval', approverAddress: '' }],
+  merkleProofs: [],
+  memo: ''
+};
+
+describe('handleAddTransfer', () => {
+  beforeEach(() => resetAllSessions());
+
+  describe('happy path', () => {
+    it('appends a MsgTransferTokens at index 1 (after the collection create)', () => {
+      const res = handleAddTransfer({ transfers: [BASE_TRANSFER] });
+      expect(res.success).toBe(true);
+      expect(res.messageIndex).toBe(1);
+      expect(res.note).toMatch(/messages\[1\]/);
+
+      const s = getOrCreateSession();
+      expect(s.messages).toHaveLength(2);
+      expect(s.messages[1].typeUrl).toBe('/tokenization.MsgTransferTokens');
+    });
+
+    it('auto-sets collectionId="0" on the appended message', () => {
+      handleAddTransfer({ transfers: [BASE_TRANSFER] });
+      const s = getOrCreateSession();
+      expect(s.messages[1].value.collectionId).toBe('0');
+    });
+
+    it('pulls creator from messages[0].value.creator', () => {
+      handleAddTransfer({
+        // Seed the session with a creator via creatorAddress-on-first-call
+        // by pre-creating the session.
+      });
+      // Pre-seed via getOrCreateSession
+      resetAllSessions();
+      getOrCreateSession(undefined, 'bb1creator');
+      handleAddTransfer({ transfers: [BASE_TRANSFER] });
+      const s = getOrCreateSession();
+      expect(s.messages[1].value.creator).toBe('bb1creator');
+    });
+
+    it('creator is empty string when session was auto-created without address', () => {
+      handleAddTransfer({ transfers: [BASE_TRANSFER] });
+      expect(getOrCreateSession().messages[1].value.creator).toBe('');
+    });
+
+    it('pass-through "Mint" as sender (does not attempt bb1 conversion)', () => {
+      handleAddTransfer({ transfers: [BASE_TRANSFER] });
+      const s = getOrCreateSession();
+      expect(s.messages[1].value.transfers[0].from).toBe('Mint');
+    });
+
+    it('normalizes a bb1... sender (already bb1 — pass-through)', () => {
+      handleAddTransfer({
+        transfers: [{ ...BASE_TRANSFER, from: 'bb1someone' }]
+      });
+      const s = getOrCreateSession();
+      expect(s.messages[1].value.transfers[0].from).toBe('bb1someone');
+    });
+
+    it('pass-through bb1... recipient unchanged', () => {
+      handleAddTransfer({ transfers: [BASE_TRANSFER] });
+      const s = getOrCreateSession();
+      expect(s.messages[1].value.transfers[0].toAddresses).toEqual(['bb1alice']);
+    });
+
+    it('supports multiple recipients in one transfer', () => {
+      handleAddTransfer({
+        transfers: [{ ...BASE_TRANSFER, toAddresses: ['bb1alice', 'bb1bob', 'bb1carol'] }]
+      });
+      const s = getOrCreateSession();
+      expect(s.messages[1].value.transfers[0].toAddresses).toEqual(['bb1alice', 'bb1bob', 'bb1carol']);
+    });
+
+    it('supports multiple transfers in one call', () => {
+      const res = handleAddTransfer({
+        transfers: [
+          BASE_TRANSFER,
+          { ...BASE_TRANSFER, toAddresses: ['bb1bob'] }
+        ]
+      });
+      expect(res.success).toBe(true);
+      const s = getOrCreateSession();
+      expect(s.messages[1].value.transfers).toHaveLength(2);
+      expect(s.messages[1].value.transfers[1].toAddresses).toEqual(['bb1bob']);
+    });
+
+    it('returned messageIndex increments on each call', () => {
+      const a = handleAddTransfer({ transfers: [BASE_TRANSFER] });
+      const b = handleAddTransfer({ transfers: [BASE_TRANSFER] });
+      const c = handleAddTransfer({ transfers: [BASE_TRANSFER] });
+      expect(a.messageIndex).toBe(1);
+      expect(b.messageIndex).toBe(2);
+      expect(c.messageIndex).toBe(3);
+      expect(getOrCreateSession().messages).toHaveLength(4);
+    });
+  });
+
+  describe('defaults and schema behavior', () => {
+    it('defaults prioritizedApprovals to [] when omitted', () => {
+      const res = handleAddTransfer({
+        transfers: [{
+          from: 'Mint',
+          toAddresses: ['bb1alice'],
+          balances: [{ amount: '1', tokenIds: [{ start: '1', end: '1' }] }]
+        }] as any
+      });
+      expect(res.success).toBe(true);
+      expect(getOrCreateSession().messages[1].value.transfers[0].prioritizedApprovals).toEqual([]);
+    });
+
+    it('defaults memo to ""', () => {
+      handleAddTransfer({
+        transfers: [{
+          from: 'Mint',
+          toAddresses: ['bb1alice'],
+          balances: [{ amount: '1', tokenIds: [{ start: '1', end: '1' }] }]
+        }] as any
+      });
+      expect(getOrCreateSession().messages[1].value.transfers[0].memo).toBe('');
+    });
+
+    it('defaults merkleProofs to []', () => {
+      handleAddTransfer({
+        transfers: [{
+          from: 'Mint',
+          toAddresses: ['bb1alice'],
+          balances: [{ amount: '1', tokenIds: [{ start: '1', end: '1' }] }]
+        }] as any
+      });
+      expect(getOrCreateSession().messages[1].value.transfers[0].merkleProofs).toEqual([]);
+    });
+
+    it('defaults balance ownershipTimes to forever when omitted', () => {
+      handleAddTransfer({
+        transfers: [{
+          from: 'Mint',
+          toAddresses: ['bb1alice'],
+          balances: [{ amount: '1', tokenIds: [{ start: '1', end: '1' }] }]
+        }] as any
+      });
+      const balances = getOrCreateSession().messages[1].value.transfers[0].balances;
+      expect(balances[0].ownershipTimes).toEqual(FOREVER);
+    });
+
+    it('defaults prioritizedApprovals[].approverAddress to ""', () => {
+      handleAddTransfer({
+        transfers: [{
+          ...BASE_TRANSFER,
+          prioritizedApprovals: [{ approvalId: 'only-id' }]
+        }] as any
+      });
+      const pa = getOrCreateSession().messages[1].value.transfers[0].prioritizedApprovals;
+      expect(pa[0]).toEqual({ approvalId: 'only-id', approverAddress: '' });
+    });
+  });
+
+  describe('validation errors', () => {
+    it('rejects a call with zero transfers', () => {
+      const res = handleAddTransfer({ transfers: [] });
+      expect(res.success).toBe(false);
+      expect(res.error).toBeDefined();
+    });
+
+    it('rejects a transfer missing from', () => {
+      const res = handleAddTransfer({
+        transfers: [{
+          toAddresses: ['bb1alice'],
+          balances: [{ amount: '1', tokenIds: [{ start: '1', end: '1' }] }]
+        }] as any
+      });
+      expect(res.success).toBe(false);
+      expect(res.error).toBeDefined();
+    });
+
+    it('rejects a transfer missing toAddresses', () => {
+      const res = handleAddTransfer({
+        transfers: [{
+          from: 'Mint',
+          balances: [{ amount: '1', tokenIds: [{ start: '1', end: '1' }] }]
+        }] as any
+      });
+      expect(res.success).toBe(false);
+    });
+
+    it('rejects a transfer missing balances', () => {
+      const res = handleAddTransfer({
+        transfers: [{
+          from: 'Mint',
+          toAddresses: ['bb1alice']
+        }] as any
+      });
+      expect(res.success).toBe(false);
+    });
+
+    it('rejects a balance missing amount', () => {
+      const res = handleAddTransfer({
+        transfers: [{
+          from: 'Mint',
+          toAddresses: ['bb1alice'],
+          balances: [{ tokenIds: [{ start: '1', end: '1' }] }]
+        }] as any
+      });
+      expect(res.success).toBe(false);
+    });
+
+    it('rejects a tokenIds range missing end', () => {
+      const res = handleAddTransfer({
+        transfers: [{
+          from: 'Mint',
+          toAddresses: ['bb1alice'],
+          balances: [{ amount: '1', tokenIds: [{ start: '1' }] }]
+        }] as any
+      });
+      expect(res.success).toBe(false);
+    });
+
+    it('rejects a missing transfers array entirely', () => {
+      const res = handleAddTransfer({});
+      expect(res.success).toBe(false);
+    });
+
+    it('does not mutate the session on validation failure', () => {
+      const lenBefore = getOrCreateSession().messages.length;
+      const res = handleAddTransfer({ transfers: [] });
+      expect(res.success).toBe(false);
+      const lenAfter = getOrCreateSession().messages.length;
+      expect(lenAfter).toBe(lenBefore);
+    });
+  });
+
+  describe('session isolation', () => {
+    it('isolates appended transfers per sessionId', () => {
+      handleAddTransfer({ sessionId: 'a', transfers: [BASE_TRANSFER] });
+      handleAddTransfer({ sessionId: 'a', transfers: [BASE_TRANSFER] });
+      handleAddTransfer({ sessionId: 'b', transfers: [BASE_TRANSFER] });
+      expect(getOrCreateSession('a').messages).toHaveLength(3); // 1 create + 2 transfer
+      expect(getOrCreateSession('b').messages).toHaveLength(2); // 1 create + 1 transfer
+    });
+
+    it('messageIndex is per-session (not global)', () => {
+      handleAddTransfer({ sessionId: 'a', transfers: [BASE_TRANSFER] });
+      handleAddTransfer({ sessionId: 'a', transfers: [BASE_TRANSFER] });
+      const resB = handleAddTransfer({ sessionId: 'b', transfers: [BASE_TRANSFER] });
+      // Session b is fresh — transfer goes to index 1, not 3
+      expect(resB.messageIndex).toBe(1);
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/session/setDefaultBalances.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/session/setDefaultBalances.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for `set_default_balances` builder tool.
+ *
+ * handleSetDefaultBalances forwards to sessionState.setDefaultBalances which:
+ *   - Writes the supplied config onto messages[0].value.defaultBalances.
+ *   - Auto-fills the 5 required userPermissions keys with [] (neutral)
+ *     merged with whatever the caller supplied.
+ *   - Flips updateDefaultBalances=true so the SDK emits the field.
+ *
+ * autoApproveAllIncomingTransfers is called out as the #1 deployment bug —
+ * the handler itself doesn't enforce it (zod default is `true`), but we
+ * lock in the invariant here so any future regression is caught.
+ */
+import { handleSetDefaultBalances, setDefaultBalancesSchema } from './setDefaultBalances.js';
+import { getOrCreateSession, resetAllSessions } from '../../session/sessionState.js';
+
+const REQUIRED_USER_PERM_KEYS = [
+  'canUpdateOutgoingApprovals',
+  'canUpdateIncomingApprovals',
+  'canUpdateAutoApproveSelfInitiatedOutgoingTransfers',
+  'canUpdateAutoApproveSelfInitiatedIncomingTransfers',
+  'canUpdateAutoApproveAllIncomingTransfers'
+];
+
+const MINIMAL: any = {
+  balances: [],
+  outgoingApprovals: [],
+  incomingApprovals: [],
+  autoApproveAllIncomingTransfers: true,
+  autoApproveSelfInitiatedOutgoingTransfers: true,
+  autoApproveSelfInitiatedIncomingTransfers: true,
+  userPermissions: {}
+};
+
+describe('handleSetDefaultBalances', () => {
+  beforeEach(() => resetAllSessions());
+
+  describe('happy path', () => {
+    it('writes defaultBalances onto the collection message', () => {
+      const res = handleSetDefaultBalances({ defaultBalances: { ...MINIMAL } });
+      expect(res.success).toBe(true);
+
+      const value = getOrCreateSession().messages[0].value;
+      expect(value.defaultBalances.balances).toEqual([]);
+      expect(value.defaultBalances.outgoingApprovals).toEqual([]);
+      expect(value.defaultBalances.incomingApprovals).toEqual([]);
+      expect(value.defaultBalances.autoApproveAllIncomingTransfers).toBe(true);
+    });
+
+    it('flips updateDefaultBalances=true', () => {
+      handleSetDefaultBalances({ defaultBalances: { ...MINIMAL } });
+      expect(getOrCreateSession().messages[0].value.updateDefaultBalances).toBe(true);
+    });
+
+    it('preserves all three auto-approve flags when false', () => {
+      handleSetDefaultBalances({
+        defaultBalances: {
+          ...MINIMAL,
+          autoApproveAllIncomingTransfers: false,
+          autoApproveSelfInitiatedOutgoingTransfers: false,
+          autoApproveSelfInitiatedIncomingTransfers: false
+        }
+      });
+      const db = getOrCreateSession().messages[0].value.defaultBalances;
+      expect(db.autoApproveAllIncomingTransfers).toBe(false);
+      expect(db.autoApproveSelfInitiatedOutgoingTransfers).toBe(false);
+      expect(db.autoApproveSelfInitiatedIncomingTransfers).toBe(false);
+    });
+
+    it('passes through a non-empty balances array', () => {
+      handleSetDefaultBalances({
+        defaultBalances: {
+          ...MINIMAL,
+          balances: [
+            { amount: '1', tokenIds: [{ start: '1', end: '10' }] }
+          ]
+        } as any
+      });
+      const db = getOrCreateSession().messages[0].value.defaultBalances;
+      expect(db.balances).toHaveLength(1);
+      expect(db.balances[0].amount).toBe('1');
+      expect(db.balances[0].tokenIds).toEqual([{ start: '1', end: '10' }]);
+    });
+  });
+
+  describe('userPermissions auto-fill', () => {
+    it('fills every required key with neutral [] when userPermissions is empty {}', () => {
+      handleSetDefaultBalances({ defaultBalances: { ...MINIMAL, userPermissions: {} } as any });
+      const db = getOrCreateSession().messages[0].value.defaultBalances;
+      for (const key of REQUIRED_USER_PERM_KEYS) {
+        expect(db.userPermissions[key]).toEqual([]);
+      }
+    });
+
+    it('preserves caller-supplied userPermissions values', () => {
+      const supplied = [{ permanentlyPermittedTimes: [], permanentlyForbiddenTimes: [{ start: '1', end: '18446744073709551615' }] }];
+      handleSetDefaultBalances({
+        defaultBalances: {
+          ...MINIMAL,
+          userPermissions: { canUpdateOutgoingApprovals: supplied }
+        } as any
+      });
+      const db = getOrCreateSession().messages[0].value.defaultBalances;
+      expect(db.userPermissions.canUpdateOutgoingApprovals).toEqual(supplied);
+      // Other keys still auto-filled
+      expect(db.userPermissions.canUpdateIncomingApprovals).toEqual([]);
+      expect(db.userPermissions.canUpdateAutoApproveAllIncomingTransfers).toEqual([]);
+    });
+
+    it('merges: caller key wins, missing keys filled', () => {
+      const suppliedA = [{ a: 1 }];
+      handleSetDefaultBalances({
+        defaultBalances: {
+          ...MINIMAL,
+          userPermissions: {
+            canUpdateAutoApproveAllIncomingTransfers: suppliedA
+          }
+        } as any
+      });
+      const db = getOrCreateSession().messages[0].value.defaultBalances;
+      expect(db.userPermissions.canUpdateAutoApproveAllIncomingTransfers).toEqual(suppliedA);
+      expect(db.userPermissions.canUpdateOutgoingApprovals).toEqual([]);
+    });
+  });
+
+  describe('zod schema defaults', () => {
+    it('defaults arrays to [] when omitted', () => {
+      const parsed = setDefaultBalancesSchema.parse({ defaultBalances: {} });
+      expect(parsed.defaultBalances.balances).toEqual([]);
+      expect(parsed.defaultBalances.outgoingApprovals).toEqual([]);
+      expect(parsed.defaultBalances.incomingApprovals).toEqual([]);
+    });
+
+    it('defaults all three auto-approve flags to true', () => {
+      const parsed = setDefaultBalancesSchema.parse({ defaultBalances: {} });
+      expect(parsed.defaultBalances.autoApproveAllIncomingTransfers).toBe(true);
+      expect(parsed.defaultBalances.autoApproveSelfInitiatedOutgoingTransfers).toBe(true);
+      expect(parsed.defaultBalances.autoApproveSelfInitiatedIncomingTransfers).toBe(true);
+    });
+
+    it('defaults userPermissions to {}', () => {
+      const parsed = setDefaultBalancesSchema.parse({ defaultBalances: {} });
+      expect(parsed.defaultBalances.userPermissions).toEqual({});
+    });
+  });
+
+  describe('session state', () => {
+    it('replaces defaultBalances on re-call', () => {
+      handleSetDefaultBalances({ defaultBalances: { ...MINIMAL, autoApproveAllIncomingTransfers: true } as any });
+      handleSetDefaultBalances({ defaultBalances: { ...MINIMAL, autoApproveAllIncomingTransfers: false } as any });
+      expect(
+        getOrCreateSession().messages[0].value.defaultBalances.autoApproveAllIncomingTransfers
+      ).toBe(false);
+    });
+
+    it('isolates defaultBalances per sessionId', () => {
+      handleSetDefaultBalances({
+        sessionId: 'a',
+        defaultBalances: { ...MINIMAL, autoApproveAllIncomingTransfers: true } as any
+      });
+      handleSetDefaultBalances({
+        sessionId: 'b',
+        defaultBalances: { ...MINIMAL, autoApproveAllIncomingTransfers: false } as any
+      });
+      expect(
+        getOrCreateSession('a').messages[0].value.defaultBalances.autoApproveAllIncomingTransfers
+      ).toBe(true);
+      expect(
+        getOrCreateSession('b').messages[0].value.defaultBalances.autoApproveAllIncomingTransfers
+      ).toBe(false);
+    });
+
+    it('auto-creates session with creatorAddress when supplied', () => {
+      handleSetDefaultBalances({
+        sessionId: 'c',
+        creatorAddress: 'bb1alice',
+        defaultBalances: { ...MINIMAL } as any
+      });
+      expect(getOrCreateSession('c').messages[0].value.creator).toBe('bb1alice');
+    });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/builder/tools/session/setPermissions.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/session/setPermissions.spec.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for `set_permissions` builder tool.
+ *
+ * handleSetPermissions is how collection permissions are frozen/unfrozen at
+ * creation. It has three meaningful branches:
+ *
+ *   1. `preset` string -> materialize one of three canned permission sets
+ *      (fully-immutable, manager-controlled, locked-approvals). Custom
+ *      `permissions` keys merged on top still win.
+ *   2. `permissions` object only -> pass-through (plus neutral fill for
+ *      any of the 11 required keys that are missing).
+ *   3. Neither supplied -> default to `locked-approvals`.
+ *
+ * The handler also runs shape validation on every entry of every key:
+ * non-array value, non-object entry, empty object, or a record missing BOTH
+ * permanentlyPermittedTimes and permanentlyForbiddenTimes are rejected with
+ * a helpful error.
+ */
+import { handleSetPermissions } from './setPermissions.js';
+import { getOrCreateSession, resetAllSessions } from '../../session/sessionState.js';
+
+const MAX_UINT64 = '18446744073709551615';
+const FOREVER = [{ start: '1', end: MAX_UINT64 }];
+const FROZEN_ACTION = [{ permanentlyPermittedTimes: [], permanentlyForbiddenTimes: FOREVER }];
+const REQUIRED_KEYS = [
+  'canDeleteCollection', 'canArchiveCollection', 'canUpdateStandards', 'canUpdateCustomData',
+  'canUpdateManager', 'canUpdateCollectionMetadata', 'canUpdateValidTokenIds',
+  'canUpdateTokenMetadata', 'canUpdateCollectionApprovals', 'canAddMoreAliasPaths',
+  'canAddMoreCosmosCoinWrapperPaths'
+];
+
+describe('handleSetPermissions', () => {
+  beforeEach(() => resetAllSessions());
+
+  describe('preset behavior', () => {
+    it('applies the fully-immutable preset — every key frozen', () => {
+      const res = handleSetPermissions({ preset: 'fully-immutable' });
+      expect(res.success).toBe(true);
+      expect(res.preset).toBe('fully-immutable');
+
+      const perms = getOrCreateSession().messages[0].value.collectionPermissions;
+      // Every required key is non-empty (frozen)
+      for (const key of REQUIRED_KEYS) {
+        expect(Array.isArray(perms[key])).toBe(true);
+        expect(perms[key].length).toBeGreaterThan(0);
+      }
+      expect(perms.canDeleteCollection).toEqual(FROZEN_ACTION);
+    });
+
+    it('applies the manager-controlled preset — only delete frozen', () => {
+      const res = handleSetPermissions({ preset: 'manager-controlled' });
+      expect(res.success).toBe(true);
+
+      const perms = getOrCreateSession().messages[0].value.collectionPermissions;
+      expect(perms.canDeleteCollection).toEqual(FROZEN_ACTION);
+      // All others neutral (empty array)
+      expect(perms.canArchiveCollection).toEqual([]);
+      expect(perms.canUpdateStandards).toEqual([]);
+      expect(perms.canUpdateCollectionApprovals).toEqual([]);
+      expect(perms.canUpdateManager).toEqual([]);
+    });
+
+    it('applies the locked-approvals preset — approvals + supply + delete frozen, metadata neutral', () => {
+      const res = handleSetPermissions({ preset: 'locked-approvals' });
+      expect(res.success).toBe(true);
+
+      const perms = getOrCreateSession().messages[0].value.collectionPermissions;
+      // Frozen fields
+      expect(perms.canDeleteCollection.length).toBeGreaterThan(0);
+      expect(perms.canUpdateStandards.length).toBeGreaterThan(0);
+      expect(perms.canUpdateManager.length).toBeGreaterThan(0);
+      expect(perms.canUpdateValidTokenIds.length).toBeGreaterThan(0);
+      expect(perms.canUpdateCollectionApprovals.length).toBeGreaterThan(0);
+      expect(perms.canAddMoreAliasPaths.length).toBeGreaterThan(0);
+      expect(perms.canAddMoreCosmosCoinWrapperPaths.length).toBeGreaterThan(0);
+      // Metadata neutral (editable)
+      expect(perms.canArchiveCollection).toEqual([]);
+      expect(perms.canUpdateCustomData).toEqual([]);
+      expect(perms.canUpdateCollectionMetadata).toEqual([]);
+      expect(perms.canUpdateTokenMetadata).toEqual([]);
+    });
+
+    it('defaults to locked-approvals when neither preset nor permissions is provided', () => {
+      const res = handleSetPermissions({});
+      expect(res.success).toBe(true);
+      expect(res.preset).toBe('custom'); // preset undefined -> reports "custom"
+
+      const perms = getOrCreateSession().messages[0].value.collectionPermissions;
+      expect(perms.canUpdateCollectionApprovals.length).toBeGreaterThan(0);
+      expect(perms.canUpdateCollectionMetadata).toEqual([]);
+    });
+
+    it('allows a custom override on top of a preset', () => {
+      // Start from fully-immutable, then force canUpdateCollectionMetadata neutral
+      const res = handleSetPermissions({
+        preset: 'fully-immutable',
+        permissions: { canUpdateCollectionMetadata: [] }
+      });
+      expect(res.success).toBe(true);
+
+      const perms = getOrCreateSession().messages[0].value.collectionPermissions;
+      expect(perms.canUpdateCollectionMetadata).toEqual([]); // overridden
+      expect(perms.canDeleteCollection).toEqual(FROZEN_ACTION); // preserved
+    });
+
+    it('reports preset name (or "custom") in the response', () => {
+      expect(handleSetPermissions({ preset: 'locked-approvals' }).preset).toBe('locked-approvals');
+      expect(handleSetPermissions({ permissions: { canDeleteCollection: [] } }).preset).toBe('custom');
+      expect(handleSetPermissions({}).preset).toBe('custom');
+    });
+  });
+
+  describe('custom permissions', () => {
+    it('pass-through when only permissions supplied', () => {
+      const custom = {
+        canDeleteCollection: FROZEN_ACTION,
+        canArchiveCollection: []
+      };
+      const res = handleSetPermissions({ permissions: custom as any });
+      expect(res.success).toBe(true);
+
+      const perms = getOrCreateSession().messages[0].value.collectionPermissions;
+      expect(perms.canDeleteCollection).toEqual(FROZEN_ACTION);
+      expect(perms.canArchiveCollection).toEqual([]);
+    });
+
+    it('auto-fills all 11 required keys with neutral [] when missing from custom permissions', () => {
+      const res = handleSetPermissions({
+        permissions: { canDeleteCollection: FROZEN_ACTION } as any
+      });
+      expect(res.success).toBe(true);
+
+      const perms = getOrCreateSession().messages[0].value.collectionPermissions;
+      for (const key of REQUIRED_KEYS) {
+        expect(key in perms).toBe(true);
+      }
+      // Supplied key preserved
+      expect(perms.canDeleteCollection).toEqual(FROZEN_ACTION);
+      // Non-supplied keys neutral
+      expect(perms.canArchiveCollection).toEqual([]);
+      expect(perms.canUpdateStandards).toEqual([]);
+    });
+
+    it('writes updateCollectionPermissions=true to the session', () => {
+      handleSetPermissions({ preset: 'locked-approvals' });
+      const value = getOrCreateSession().messages[0].value;
+      expect(value.updateCollectionPermissions).toBe(true);
+    });
+  });
+
+  describe('validation errors', () => {
+    it('rejects a permission value that is not an array', () => {
+      const res = handleSetPermissions({
+        permissions: { canDeleteCollection: 'not-an-array' as any } as any
+      });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/canDeleteCollection/);
+      expect(res.error).toMatch(/must be an array/i);
+    });
+
+    it('rejects a permission value that is an object (not an array)', () => {
+      const res = handleSetPermissions({
+        permissions: { canDeleteCollection: { foo: 'bar' } as any } as any
+      });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/must be an array/i);
+    });
+
+    it('rejects a permission array entry that is null', () => {
+      const res = handleSetPermissions({
+        permissions: { canDeleteCollection: [null] as any } as any
+      });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/\[0\]/);
+      expect(res.error).toMatch(/must be an object/i);
+    });
+
+    it('rejects a permission array entry that is a primitive', () => {
+      const res = handleSetPermissions({
+        permissions: { canDeleteCollection: ['oops'] as any } as any
+      });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/must be an object/i);
+    });
+
+    it('rejects an empty object entry with a helpful hint', () => {
+      const res = handleSetPermissions({
+        permissions: { canDeleteCollection: [{}] as any } as any
+      });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/empty object/i);
+      expect(res.error).toMatch(/permanentlyPermittedTimes|permanentlyForbiddenTimes/);
+    });
+
+    it('rejects an entry that is missing BOTH permanentlyPermittedTimes and permanentlyForbiddenTimes', () => {
+      const res = handleSetPermissions({
+        permissions: { canDeleteCollection: [{ tokenIds: FOREVER }] as any } as any
+      });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/missing permanentlyPermittedTimes and permanentlyForbiddenTimes/i);
+    });
+
+    it('accepts an entry with only permanentlyPermittedTimes (one of the two is enough)', () => {
+      const res = handleSetPermissions({
+        permissions: {
+          canDeleteCollection: [{ permanentlyPermittedTimes: FOREVER }] as any
+        } as any
+      });
+      expect(res.success).toBe(true);
+    });
+
+    it('accepts an entry with only permanentlyForbiddenTimes', () => {
+      const res = handleSetPermissions({
+        permissions: {
+          canDeleteCollection: [{ permanentlyForbiddenTimes: FOREVER }] as any
+        } as any
+      });
+      expect(res.success).toBe(true);
+    });
+
+    it('error name prefix includes the array index of the offending entry', () => {
+      const res = handleSetPermissions({
+        permissions: {
+          canDeleteCollection: [
+            { permanentlyForbiddenTimes: FOREVER },
+            {} // <-- offender at [1]
+          ] as any
+        } as any
+      });
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/\[1\]/);
+    });
+  });
+
+  describe('session state', () => {
+    it('replaces permissions on re-call (set semantics)', () => {
+      handleSetPermissions({ preset: 'fully-immutable' });
+      handleSetPermissions({ preset: 'manager-controlled' });
+      const perms = getOrCreateSession().messages[0].value.collectionPermissions;
+      // Manager-controlled leaves approvals neutral
+      expect(perms.canUpdateCollectionApprovals).toEqual([]);
+    });
+
+    it('isolates permissions per sessionId', () => {
+      handleSetPermissions({ sessionId: 'a', preset: 'fully-immutable' });
+      handleSetPermissions({ sessionId: 'b', preset: 'manager-controlled' });
+      const a = getOrCreateSession('a').messages[0].value.collectionPermissions;
+      const b = getOrCreateSession('b').messages[0].value.collectionPermissions;
+      expect(a.canUpdateCollectionMetadata.length).toBeGreaterThan(0); // frozen
+      expect(b.canUpdateCollectionMetadata).toEqual([]); // neutral
+    });
+
+    it('auto-creates session with creatorAddress when supplied', () => {
+      handleSetPermissions({ sessionId: 'c', creatorAddress: 'bb1creator', preset: 'locked-approvals' });
+      const s = getOrCreateSession('c');
+      expect(s.messages[0].value.creator).toBe('bb1creator');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Second round of MCP builder session-setter unit tests, following up on #167. Adds specs for the three largest remaining untested handlers in `packages/bitbadgesjs-sdk/src/builder/tools/session/`.

- `setPermissions.spec.ts` (20 tests) — all three presets (fully-immutable / manager-controlled / locked-approvals), custom-over-preset override, auto-fill of the 11 required permission keys, 7 validation error branches (non-array, non-object entry, empty object, missing-both-times, indexed error message), re-call set semantics, sessionId isolation, creatorAddress threading.
- `setDefaultBalances.spec.ts` (14 tests) — happy path, all three auto-approve flags preserved when explicitly `false`, `userPermissions` 5-key neutral auto-fill with caller-wins merge, zod schema defaults (arrays=[], auto-approve flags=true, userPermissions={}), re-call semantics, sessionId isolation.
- `addTransfer.spec.ts` (25 tests) — append at `messages[1]`, `collectionId="0"` wiring, creator inheritance from `messages[0].value.creator`, `"Mint"` pass-through, bb1 pass-through, multi-recipient and multi-transfer per call, schema defaults for every optional field, 8 validation error branches, session isolation, per-session `messageIndex` counter.

## Results

- 2254 → 2313 tests (+59), 73 → 76 suites, all passing.
- No bugs discovered — handlers behave exactly as documented.
- `npm run build` clean (no circular deps).

Backlog: 0325. Follow-ups queued for the remaining untested handlers (biggest: `addApproval.ts` at 589 LOC).

## Test plan

- [x] `npx jest src/builder/tools/session/{setPermissions,setDefaultBalances,addTransfer}.spec.ts` — 59/59 pass
- [x] Full suite `npx jest` — 2313/2313 pass
- [x] `npm run build` — clean, no circular deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)