### PR TITLE
fix(builder): validate_transaction auto-fills from session state — #0326

### DIFF
--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateTransaction.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateTransaction.spec.ts
@@ -2,16 +2,17 @@
  * Tests for `validate_transaction`.
  *
  * Thin wrapper around core/validate.ts — its job is to:
- *   1. Accept either a JSON string OR a pre-parsed object (via `transaction`)
- *   2. Normalize to JSON, parse it, and type-check (must be an object)
- *   3. Pass the parsed object to the full SDK validator
- *   4. Wrap parse/type errors in the standard issues[] format
+ *   1. Accept either a JSON string, a pre-parsed object (via `transaction`),
+ *      OR auto-fill from the current session state when neither is given
+ *   2. Normalize to an object, type-check, and pass to the full SDK validator
+ *   3. Wrap parse/type errors in the standard issues[] format
  *
  * Tests below hit every branch in the normalization layer. Business-logic
  * coverage lives in `src/core/validate.spec.ts` (separate suite).
  */
 
 import { handleValidateTransaction } from './validateTransaction.js';
+import { resetAllSessions, setStandards, addApproval } from '../../session/sessionState.js';
 
 describe('handleValidateTransaction — input normalization', () => {
   const validTx = {
@@ -21,6 +22,13 @@ describe('handleValidateTransaction — input normalization', () => {
     // Other fields may produce validator warnings, but the wrapper itself
     // doesn't care — it just needs to reach the inner `validateTransaction`.
   };
+
+  // Keep session state clean between tests — the wrapper falls back to
+  // session state now (#0326), so stale state from one test can leak into
+  // the next.
+  beforeEach(() => {
+    resetAllSessions();
+  });
 
   describe('transactionJson input', () => {
     it('accepts a valid JSON string and delegates to the core validator', () => {
@@ -40,10 +48,20 @@ describe('handleValidateTransaction — input normalization', () => {
       expect(res.issues[0].message).toMatch(/Invalid JSON/);
     });
 
-    it('treats an empty-string transactionJson as unparseable JSON', () => {
+    it('treats an empty-string transactionJson as "no input" and auto-fills from session (NOT "Unexpected EOF")', () => {
+      // Previously this returned "Invalid JSON: Unexpected EOF" — an
+      // unrecoverable error that agents loop on. Post-#0326, an empty
+      // string is treated like "no input provided" — the wrapper
+      // auto-fills from session state and returns the real validation
+      // issues (e.g. "missing creator") from the SDK validator, which
+      // the agent CAN act on.
       const res = handleValidateTransaction({ transactionJson: '' });
       expect(res.valid).toBe(false);
-      expect(res.issues[0].message).toMatch(/Invalid JSON/);
+      expect(res.issues.length).toBeGreaterThan(0);
+      for (const issue of res.issues) {
+        expect(issue.message).not.toMatch(/Unexpected EOF/);
+        expect(issue.message).not.toMatch(/Invalid JSON/);
+      }
     });
 
     it('rejects top-level JSON values that are not objects (arrays)', () => {
@@ -94,15 +112,51 @@ describe('handleValidateTransaction — input normalization', () => {
     });
   });
 
-  describe('missing-input edge cases', () => {
-    it('without transaction or transactionJson, returns an Invalid JSON issue (empty string path)', () => {
-      // The wrapper's `??` fallback turns missing input into '' → JSON.parse fails.
-      // (The Zod `.refine` schema would catch this *before* the wrapper runs in
-      // real MCP usage, but handleValidateTransaction itself is defensively
-      // callable with missing fields.)
+  describe('session-state auto-fill (#0326)', () => {
+    it('without transaction or transactionJson, auto-fills from session state', () => {
+      // Populate session state via the same per-field setters the MCP
+      // agent uses.
+      const sessionId = 'test-session-validate-autofill';
+      const creator = 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv';
+      setStandards(sessionId, ['BitBadges']);
+      addApproval(sessionId, {
+        fromListId: 'Mint',
+        toListId: 'All',
+        initiatedByListId: 'All',
+        transferTimes: [{ start: '1', end: '18446744073709551615' }],
+        tokenIds: [{ start: '1', end: '1' }],
+        ownershipTimes: [{ start: '1', end: '18446744073709551615' }],
+        approvalId: 'test-approval',
+        approvalCriteria: {}
+      });
+
+      // Agent-style call with no tx args — must NOT return "Invalid JSON:
+      // Unexpected EOF" (the bug #0326 fixed). Should either validate the
+      // session tx or return validation issues from the SDK validator.
+      const res = handleValidateTransaction({ sessionId, creatorAddress: creator } as any);
+      expect(res).toHaveProperty('valid');
+      expect(Array.isArray(res.issues)).toBe(true);
+      for (const issue of res.issues) {
+        expect(issue.message).not.toMatch(/Unexpected EOF/);
+        expect(issue.message).not.toMatch(/No transaction to validate/);
+      }
+    });
+
+    it('without any input and a fresh (auto-created) session, returns real validator issues — NOT "Unexpected EOF"', () => {
+      // No args at all. getOrCreateSession returns a template tx with
+      // all 11 canX permission arrays defaulted to []; validator runs
+      // against that template and surfaces real issues (e.g. missing
+      // creator) the agent can fix. Critically, this path must NOT
+      // surface "Invalid JSON: Unexpected EOF" — the bug pattern that
+      // caused #0326.
       const res = handleValidateTransaction({} as any);
       expect(res.valid).toBe(false);
-      expect(res.issues[0].message).toMatch(/Invalid JSON/);
+      expect(res.issues.length).toBeGreaterThan(0);
+      for (const issue of res.issues) {
+        expect(issue.severity).toBeDefined();
+        expect(issue.message).not.toMatch(/Unexpected EOF/);
+        expect(issue.message).not.toMatch(/Invalid JSON/);
+      }
     });
   });
 });

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateTransaction.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/validateTransaction.ts
@@ -3,16 +3,26 @@
  * Validate BitBadges transaction JSON against critical rules.
  *
  * Logic delegated to bitbadgesjs-sdk's validateTransaction().
+ *
+ * Like `simulate_transaction` and `review_collection`, this tool
+ * auto-fills from the current session state when neither
+ * `transactionJson` nor `transaction` is supplied. The master prompt
+ * relies on this contract ("validate_transaction … reads session state
+ * directly — does not need the tx JSON as input"); without auto-fill,
+ * agents that follow the prompt hit `JSON.parse('')` → "Unexpected
+ * EOF" and loop indefinitely until the build budget runs out (see
+ * backlog #0326).
  */
 
 import { z } from 'zod';
 import { validateTransaction, type ValidationIssue, type ValidationResult } from '../../../core/validate.js';
+import { getTransaction as getTransactionFromSession, ensureStringNumbers } from '../../session/sessionState.js';
 
 export const validateTransactionSchema = z.object({
-  transactionJson: z.string().optional().describe('The transaction JSON to validate (as a string)'),
-  transaction: z.object({}).passthrough().optional().describe('The transaction object to validate (alternative to transactionJson)')
-}).refine(data => data.transactionJson !== undefined || data.transaction !== undefined, {
-  message: 'Either transactionJson or transaction must be provided'
+  transactionJson: z.string().optional().describe('The transaction JSON to validate (as a string). If omitted, the current session transaction is used.'),
+  transaction: z.object({}).passthrough().optional().describe('The transaction object to validate (alternative to transactionJson). If omitted, the current session transaction is used.'),
+  sessionId: z.string().optional().describe('Session ID for per-request isolation (only needed when auto-filling from session state).'),
+  creatorAddress: z.string().optional().describe('Creator bb1... address (only needed when auto-filling from session state).')
 });
 
 export type ValidateTransactionInput = z.infer<typeof validateTransactionSchema>;
@@ -23,40 +33,69 @@ export interface ValidateTransactionResult extends ValidationResult {}
 
 export const validateTransactionTool = {
   name: 'validate_transaction',
-  description: 'Validate BitBadges transaction JSON against critical rules. Checks for common errors like numbers not being strings, missing required fields, and invalid list IDs.',
+  description: 'Validate BitBadges transaction JSON against critical rules. Checks for common errors like numbers not being strings, missing required fields, and invalid list IDs. If you omit transactionJson/transaction, the tool auto-fills from the current session state (same source as simulate_transaction and review_collection).',
   inputSchema: {
     type: 'object' as const,
     properties: {
       transactionJson: {
         type: 'string',
-        description: 'The transaction JSON to validate (as a string). Either this or transaction must be provided.'
+        description: 'The transaction JSON to validate (as a string). If omitted, the current session transaction is used.'
       },
       transaction: {
         type: 'object',
-        description: 'The transaction object to validate (alternative to transactionJson — pass the object directly without JSON.stringify).'
+        description: 'The transaction object to validate (alternative to transactionJson — pass the object directly without JSON.stringify). If omitted, the current session transaction is used.'
+      },
+      sessionId: {
+        type: 'string',
+        description: 'Session ID for per-request isolation (only needed when auto-filling).'
+      },
+      creatorAddress: {
+        type: 'string',
+        description: 'Creator address (bb1... or 0x...) (only needed when auto-filling).'
       }
     }
   }
 };
 
 export function handleValidateTransaction(input: ValidateTransactionInput): ValidateTransactionResult {
-  // Normalize: accept either a pre-parsed object or a JSON string
-  const resolvedJson: string = input.transaction !== undefined
-    ? JSON.stringify(input.transaction)
-    : (input.transactionJson ?? '');
+  // Resolve the transaction: explicit input first, then fall back to
+  // session state. This mirrors `handleSimulateTransaction` (see
+  // tools/queries/simulateTransaction.ts). The master prompt tells
+  // agents that validate/review/simulate all read session state —
+  // without this branch, a prompt-compliant call like
+  // `{ creatorAddress }` falls through to `JSON.parse('')` →
+  // "Unexpected EOF", which the agent cannot recover from and loops on.
+  let tx: unknown = null;
 
-  // Parse JSON
-  let tx: unknown;
-  try {
-    tx = JSON.parse(resolvedJson);
-  } catch (error) {
-    return {
-      valid: false,
-      issues: [{
-        severity: 'error',
-        message: `Invalid JSON: ${error instanceof Error ? error.message : String(error)}`
-      }]
-    };
+  if (input.transaction !== undefined) {
+    tx = input.transaction;
+  } else if (input.transactionJson !== undefined && input.transactionJson !== '') {
+    try {
+      tx = JSON.parse(input.transactionJson);
+    } catch (error) {
+      return {
+        valid: false,
+        issues: [{
+          severity: 'error',
+          message: `Invalid JSON: ${error instanceof Error ? error.message : String(error)}. Pass the transaction object directly via the \`transaction\` field, or omit both to auto-fill from session state.`
+        }]
+      };
+    }
+  } else {
+    // Neither field provided — auto-fill from session state, same
+    // source `get_transaction`, `simulate_transaction`, and
+    // `review_collection` read.
+    const sessionTx = getTransactionFromSession(input.sessionId, input.creatorAddress);
+    if (!sessionTx || !sessionTx.messages || sessionTx.messages.length === 0) {
+      return {
+        valid: false,
+        issues: [{
+          severity: 'error',
+          message: 'No transaction to validate: session state is empty and neither transactionJson nor transaction was provided. Build the collection first, then call validate_transaction.'
+        }]
+      };
+    }
+    tx = ensureStringNumbers(sessionTx);
   }
 
   if (!tx || typeof tx !== 'object') {


### PR DESCRIPTION
## Summary

- `validate_transaction` now mirrors `simulate_transaction` / `review_collection` and auto-fills from session state when `transactionJson`/`transaction` are omitted.
- Resolves the "Invalid JSON: JSON Parse error: Unexpected EOF" dead-end that caused AI-builder sessions to loop until the user disconnected.
- Closes backlog ticket #0326.

## Problem

`packages/bitbadgesjs-sdk/src/builder/agent/prompt.ts:239` tells agents:

> "validate_transaction, review_collection, and simulate_transaction read session state directly — they do not need the tx JSON as input."

That is accurate for `simulate_transaction` (see `tools/queries/simulateTransaction.ts:184-196`) and `review_collection`, but was **not** implemented in `handleValidateTransaction`. Following the prompt produced a call like `validate_transaction({ creatorAddress })`, which hit `transactionJson ?? ''` → `JSON.parse('')` → `"Invalid JSON: JSON Parse error: Unexpected EOF"`. The agent cannot distinguish this from a real validation failure and loops.

Observed production session `ses_bm9ibz0oagd0` (2026-04-23T01:48Z, model `haiku`) ran **six** identical retry cycles of `validate_transaction` → EOF → `review_collection` + `simulate_transaction` → unhelpful errors → trying a different `set_permissions` / `remove_approval` before the user aborted. 26,163 tokens burned.

## Fix

Rewritten `handleValidateTransaction` to mirror `handleSimulateTransaction`:

1. `transaction` (object) — used directly.
2. `transactionJson` (non-empty string) — `JSON.parse`-d as before.
3. Neither / empty — `getTransactionFromSession(sessionId, creatorAddress)` is read, ensured-string-numbers, and validated.

Schema additions: optional `sessionId` and `creatorAddress` fields (same shape as simulate). Tool description updated to advertise session auto-fill explicitly.

Error messages now include a hint to the agent about the alternate calling conventions, so a future misuse still lands somewhere actionable.

## Test plan

- [x] `npx jest src/builder/tools/utilities/validateTransaction.spec.ts --no-coverage` — 11/11 pass (7 pre-existing + 2 updated + 2 new for the auto-fill path).
- [x] `npx jest src/builder --no-coverage` — 544/544 pass across 31 suites.
- [x] `npm run build` — clean.
- [ ] Re-run prod eval suite once this merges and the SDK is symlinked into the indexer — expect the prediction-market eval to stop getting stuck on "Unexpected EOF".

Backlog ticket: [bitbadges-autopilot backlog/0326](https://github.com/BitBadges/bitbadges-autopilot/blob/main/backlog/0326-sdk-validate-transaction-no-session-auto-fill-agent-loops-forever.md) in the autopilot repo (private).

---

Generated with [Claude Code](https://claude.com/claude-code).