### PR TITLE
daily-2026-04-24 SDK bundle: CollectionPermissions defaults + OpenAPI doc links

### DIFF
--- a/packages/bitbadgesjs-sdk/openapitypes-helpers/routes.yaml
+++ b/packages/bitbadgesjs-sdk/openapitypes-helpers/routes.yaml
@@ -27,7 +27,7 @@ info:
 
     ### OAuth 2.0 (Sign In with BitBadges)
     For performing actions on behalf of other users, use the standard OAuth 2.0 flow via Sign In with BitBadges.
-    See the [Sign In with BitBadges documentation](https://docs.bitbadges.io/for-developers/authenticating-with-bitbadges) for details.
+    See the [Sign In with BitBadges documentation](https://docs.bitbadges.io/for-developers/sign-in-with-bitbadges) for details.
 
     You will pass the access token in the Authorization header:
     ```
@@ -336,7 +336,7 @@ paths:
         - `readAuthenticationCodes` - Required if fetching private authentication codes
 
         Documentation References / Tutorials:
-        - **[Managing Views](https://docs.bitbadges.io/for-developers/bitbadges-api/tutorials/managing-views)**
+        - **[Managing Views](https://docs.bitbadges.io/for-developers/bitbadges-api/concepts/managing-views)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iGetAccountsPayload)**
@@ -508,7 +508,7 @@ paths:
         - `readPrivateClaimData` - Required if fetching private claim data (must also be the manager)
 
         Documentation References / Tutorials:
-        - **[Managing Views](https://docs.bitbadges.io/for-developers/bitbadges-api/tutorials/managing-views)**
+        - **[Managing Views](https://docs.bitbadges.io/for-developers/bitbadges-api/concepts/managing-views)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iGetCollectionsPayload)**
@@ -1657,8 +1657,8 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claim-builder/auto-complete-claims-w-bitbadges-api)**
-        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claim-builder)**
+        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claims/api-reference)**
+        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claims)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iCompleteClaimPayload)**
@@ -1741,8 +1741,8 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claim-builder/auto-complete-claims-w-bitbadges-api)**
-        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claim-builder)**
+        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claims/api-reference)**
+        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claims)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iSimulateClaimPayload)**
@@ -1810,8 +1810,8 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claim-builder/auto-complete-claims-w-bitbadges-api)**
-        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claim-builder)**
+        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claims/api-reference)**
+        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claims)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iGetReservedClaimCodesPayload)**
@@ -1875,8 +1875,8 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claim-builder/auto-complete-claims-w-bitbadges-api)**
-        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claim-builder)**
+        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claims/api-reference)**
+        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claims)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iGetClaimAttemptStatusPayload)**
@@ -2118,7 +2118,7 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Sign In with BitBadges](https://docs.bitbadges.io/for-developers/authenticating-with-bitbadges)**
+        - **[Sign In with BitBadges](https://docs.bitbadges.io/for-developers/sign-in-with-bitbadges)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iRotateSIWBBRequestPayload)**
@@ -2170,7 +2170,7 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Sign In with BitBadges](https://docs.bitbadges.io/for-developers/authenticating-with-bitbadges)**
+        - **[Sign In with BitBadges](https://docs.bitbadges.io/for-developers/sign-in-with-bitbadges)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iDeleteSIWBBRequestPayload)**
@@ -2223,7 +2223,7 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Sign In with BitBadges](https://docs.bitbadges.io/for-developers/authenticating-with-bitbadges)**
+        - **[Sign In with BitBadges](https://docs.bitbadges.io/for-developers/sign-in-with-bitbadges)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iCreateSIWBBRequestPayload)**
@@ -2280,7 +2280,7 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Sign In with BitBadges](https://docs.bitbadges.io/for-developers/authenticating-with-bitbadges)**
+        - **[Sign In with BitBadges](https://docs.bitbadges.io/for-developers/sign-in-with-bitbadges)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iGetSIWBBRequestsForDeveloperAppPayload)**
@@ -2548,8 +2548,8 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claim-builder/auto-complete-claims-w-bitbadges-api)**
-        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claim-builder)**
+        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claims/api-reference)**
+        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claims)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iSearchClaimsPayload)**
@@ -2606,8 +2606,8 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claim-builder/auto-complete-claims-w-bitbadges-api)**
-        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claim-builder)**
+        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claims/api-reference)**
+        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claims)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iGetClaimsPayloadV1)**
@@ -2659,8 +2659,8 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claim-builder/auto-complete-claims-w-bitbadges-api)**
-        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claim-builder)**
+        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claims/api-reference)**
+        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claims)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iCreateClaimPayload)**
@@ -2720,8 +2720,8 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claim-builder/auto-complete-claims-w-bitbadges-api)**
-        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claim-builder)**
+        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claims/api-reference)**
+        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claims)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iUpdateClaimPayload)**
@@ -2776,8 +2776,8 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claim-builder/auto-complete-claims-w-bitbadges-api)**
-        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claim-builder)**
+        - **[Completing Claims](https://docs.bitbadges.io/for-developers/claims/api-reference)**
+        - **[All About BitBadges Claims](https://docs.bitbadges.io/for-developers/claims)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iDeleteClaimPayload)**
@@ -3000,7 +3000,7 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Dynamic Stores](https://docs.bitbadges.io/for-developers/claim-builder/dynamic-stores)**
+        - **[Dynamic Stores](https://docs.bitbadges.io/for-developers/claims/dynamic-stores)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iPerformStoreActionPayload)**
@@ -3053,7 +3053,7 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Dynamic Stores](https://docs.bitbadges.io/for-developers/claim-builder/dynamic-stores)**
+        - **[Dynamic Stores](https://docs.bitbadges.io/for-developers/claims/dynamic-stores)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iPerformStoreActionPayload)**
@@ -3104,7 +3104,7 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Dynamic Stores](https://docs.bitbadges.io/for-developers/claim-builder/dynamic-stores)**
+        - **[Dynamic Stores](https://docs.bitbadges.io/for-developers/claims/dynamic-stores)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iGetDynamicDataStoresPayload)**
@@ -3155,7 +3155,7 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Dynamic Stores](https://docs.bitbadges.io/for-developers/claim-builder/dynamic-stores)**
+        - **[Dynamic Stores](https://docs.bitbadges.io/for-developers/claims/dynamic-stores)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iSearchDynamicDataStoresPayload)**
@@ -3207,7 +3207,7 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Dynamic Stores](https://docs.bitbadges.io/for-developers/claim-builder/dynamic-stores)**
+        - **[Dynamic Stores](https://docs.bitbadges.io/for-developers/claims/dynamic-stores)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iGetDynamicDataActivityPayload)**

--- a/packages/bitbadgesjs-sdk/src/api-indexer/requests/requests.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/requests/requests.ts
@@ -4441,7 +4441,7 @@ export class GetSwapActivitiesPayload extends CustomTypeClass<GetSwapActivitiesP
 /**
  * @category API Requests / Responses
  */
-export interface iGetSwapActivitiesSuccessResponse<T extends NumberType = NumberType> {
+export interface iGetSwapActivitiesSuccessResponse<T extends NumberType> {
   swapActivities: Array<{
     _docId: string;
     blockHeight: T;
@@ -4455,7 +4455,7 @@ export interface iGetSwapActivitiesSuccessResponse<T extends NumberType = Number
 /**
  * @category API Requests / Responses
  */
-export class GetSwapActivitiesSuccessResponse<T extends NumberType = NumberType>
+export class GetSwapActivitiesSuccessResponse<T extends NumberType>
   extends BaseNumberTypeClass<GetSwapActivitiesSuccessResponse<T>>
   implements iGetSwapActivitiesSuccessResponse<T>
 {
@@ -4496,14 +4496,14 @@ export class GetOnChainDynamicStorePayload extends EmptyResponseClass {}
 /**
  * @category API Requests / Responses
  */
-export interface iGetOnChainDynamicStoreSuccessResponse<T extends NumberType = NumberType> {
+export interface iGetOnChainDynamicStoreSuccessResponse<T extends NumberType> {
   store: iDynamicStoreDocWithDetails<T>;
 }
 
 /**
  * @category API Requests / Responses
  */
-export class GetOnChainDynamicStoreSuccessResponse<T extends NumberType = NumberType>
+export class GetOnChainDynamicStoreSuccessResponse<T extends NumberType>
   extends BaseNumberTypeClass<GetOnChainDynamicStoreSuccessResponse<T>>
   implements iGetOnChainDynamicStoreSuccessResponse<T>
 {
@@ -4536,14 +4536,14 @@ export class GetOnChainDynamicStoresByCreatorPayload extends EmptyResponseClass 
 /**
  * @category API Requests / Responses
  */
-export interface iGetOnChainDynamicStoresByCreatorSuccessResponse<T extends NumberType = NumberType> {
+export interface iGetOnChainDynamicStoresByCreatorSuccessResponse<T extends NumberType> {
   stores: iDynamicStoreDocWithDetails<T>[];
 }
 
 /**
  * @category API Requests / Responses
  */
-export class GetOnChainDynamicStoresByCreatorSuccessResponse<T extends NumberType = NumberType>
+export class GetOnChainDynamicStoresByCreatorSuccessResponse<T extends NumberType>
   extends BaseNumberTypeClass<GetOnChainDynamicStoresByCreatorSuccessResponse<T>>
   implements iGetOnChainDynamicStoresByCreatorSuccessResponse<T>
 {
@@ -4579,12 +4579,12 @@ export class GetOnChainDynamicStoreValuePayload extends EmptyResponseClass {}
 /**
  * @category API Requests / Responses
  */
-export interface iGetOnChainDynamicStoreValueSuccessResponse<T extends NumberType = NumberType> extends iDynamicStoreValueDoc<T> {}
+export interface iGetOnChainDynamicStoreValueSuccessResponse<T extends NumberType> extends iDynamicStoreValueDoc<T> {}
 
 /**
  * @category API Requests / Responses
  */
-export class GetOnChainDynamicStoreValueSuccessResponse<T extends NumberType = NumberType>
+export class GetOnChainDynamicStoreValueSuccessResponse<T extends NumberType>
   extends DynamicStoreValueDoc<T>
   implements iGetOnChainDynamicStoreValueSuccessResponse<T>
 {
@@ -4626,7 +4626,7 @@ export class GetOnChainDynamicStoreValuesPaginatedPayload
 /**
  * @category API Requests / Responses
  */
-export interface iGetOnChainDynamicStoreValuesPaginatedSuccessResponse<T extends NumberType = NumberType> {
+export interface iGetOnChainDynamicStoreValuesPaginatedSuccessResponse<T extends NumberType> {
   values: iDynamicStoreValueDoc<T>[];
   pagination: PaginationInfo;
 }
@@ -4634,7 +4634,7 @@ export interface iGetOnChainDynamicStoreValuesPaginatedSuccessResponse<T extends
 /**
  * @category API Requests / Responses
  */
-export class GetOnChainDynamicStoreValuesPaginatedSuccessResponse<T extends NumberType = NumberType>
+export class GetOnChainDynamicStoreValuesPaginatedSuccessResponse<T extends NumberType>
   extends BaseNumberTypeClass<GetOnChainDynamicStoreValuesPaginatedSuccessResponse<T>>
   implements iGetOnChainDynamicStoreValuesPaginatedSuccessResponse<T>
 {

--- a/packages/bitbadgesjs-sdk/src/core/permissions.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/permissions.spec.ts
@@ -677,6 +677,48 @@ describe('CollectionPermissions', () => {
       });
       expect(perms.canDeleteCollection.length).toBe(1);
     });
+
+    // Regression coverage for backlog #0327 — partial session state
+    // (e.g. from the MCP builder's incremental set_permissions tool)
+    // used to crash with `TypeError: undefined is not an object
+    // (evaluating 'msg.canDeleteCollection.map')`. Missing `canX`
+    // arrays should now default to `[]`.
+    it('defaults missing canX arrays to [] instead of throwing', () => {
+      // Cast to any — intentionally exercising the partial-input
+      // behavior the wrapper-class contract is supposed to tolerate.
+      const perms = new CollectionPermissions({
+        canArchiveCollection: [
+          new ActionPermission({
+            permanentlyPermittedTimes: [],
+            permanentlyForbiddenTimes: [{ start: 1n, end: 100n }]
+          })
+        ]
+        // All other canX fields omitted on purpose.
+      } as any);
+      expect(perms.canArchiveCollection.length).toBe(1);
+      expect(perms.canDeleteCollection).toEqual([]);
+      expect(perms.canUpdateStandards).toEqual([]);
+      expect(perms.canUpdateCustomData).toEqual([]);
+      expect(perms.canUpdateManager).toEqual([]);
+      expect(perms.canUpdateCollectionMetadata).toEqual([]);
+      expect(perms.canUpdateValidTokenIds).toEqual([]);
+      expect(perms.canUpdateTokenMetadata).toEqual([]);
+      expect(perms.canUpdateCollectionApprovals).toEqual([]);
+      expect(perms.canAddMoreAliasPaths).toEqual([]);
+      expect(perms.canAddMoreCosmosCoinWrapperPaths).toEqual([]);
+    });
+
+    it('accepts an entirely empty object without throwing', () => {
+      const perms = new CollectionPermissions({} as any);
+      expect(perms.canDeleteCollection).toEqual([]);
+      expect(perms.canAddMoreCosmosCoinWrapperPaths).toEqual([]);
+    });
+
+    it('CollectionPermissionsWithDetails mirrors the same guard', () => {
+      const perms = new CollectionPermissionsWithDetails({} as any);
+      expect(perms.canDeleteCollection).toEqual([]);
+      expect(perms.canUpdateCollectionApprovals).toEqual([]);
+    });
   });
 
   describe('validateUpdate', () => {

--- a/packages/bitbadgesjs-sdk/src/core/permissions.ts
+++ b/packages/bitbadgesjs-sdk/src/core/permissions.ts
@@ -409,17 +409,31 @@ export class CollectionPermissions<T extends NumberType> extends BaseNumberTypeC
 
   constructor(msg: iCollectionPermissions<T>) {
     super();
-    this.canDeleteCollection = msg.canDeleteCollection.map((x) => new ActionPermission(x));
-    this.canArchiveCollection = msg.canArchiveCollection.map((x) => new ActionPermission(x));
-    this.canUpdateStandards = msg.canUpdateStandards.map((x) => new ActionPermission(x));
-    this.canUpdateCustomData = msg.canUpdateCustomData.map((x) => new ActionPermission(x));
-    this.canUpdateManager = msg.canUpdateManager.map((x) => new ActionPermission(x));
-    this.canUpdateCollectionMetadata = msg.canUpdateCollectionMetadata.map((x) => new ActionPermission(x));
-    this.canUpdateValidTokenIds = msg.canUpdateValidTokenIds.map((x) => new TokenIdsActionPermission(x));
-    this.canUpdateTokenMetadata = msg.canUpdateTokenMetadata.map((x) => new TokenIdsActionPermission(x));
-    this.canUpdateCollectionApprovals = msg.canUpdateCollectionApprovals.map((x) => new CollectionApprovalPermission(x));
-    this.canAddMoreAliasPaths = msg.canAddMoreAliasPaths.map((x) => new ActionPermission(x));
-    this.canAddMoreCosmosCoinWrapperPaths = msg.canAddMoreCosmosCoinWrapperPaths.map((x) => new ActionPermission(x));
+    // Default any missing `canX` array to `[]` before mapping. Session
+    // state built up incrementally (e.g. from the MCP builder's
+    // `set_permissions` tool, which patches only the fields the agent
+    // writes) may arrive here with a subset of the 11 arrays populated.
+    // Without this normalization a single missing field turns into a
+    // raw `TypeError: undefined is not an object (evaluating
+    // 'msg.canX.map')`, which the outer dispatcher wraps in a generic
+    // "Invalid value for /tokenization.MsgUniversalUpdateCollection"
+    // shell — agents see no actionable hint about which field was
+    // missing and loop retrying the same setter. Normalizing here is
+    // the single choke point for every call path (wrapper-class
+    // construction, convert(), fromJson()), so no caller has to
+    // remember to fill in the blanks. See backlog #0327.
+    const arr = <X>(v: X[] | undefined): X[] => (Array.isArray(v) ? v : []);
+    this.canDeleteCollection = arr(msg.canDeleteCollection).map((x) => new ActionPermission(x));
+    this.canArchiveCollection = arr(msg.canArchiveCollection).map((x) => new ActionPermission(x));
+    this.canUpdateStandards = arr(msg.canUpdateStandards).map((x) => new ActionPermission(x));
+    this.canUpdateCustomData = arr(msg.canUpdateCustomData).map((x) => new ActionPermission(x));
+    this.canUpdateManager = arr(msg.canUpdateManager).map((x) => new ActionPermission(x));
+    this.canUpdateCollectionMetadata = arr(msg.canUpdateCollectionMetadata).map((x) => new ActionPermission(x));
+    this.canUpdateValidTokenIds = arr(msg.canUpdateValidTokenIds).map((x) => new TokenIdsActionPermission(x));
+    this.canUpdateTokenMetadata = arr(msg.canUpdateTokenMetadata).map((x) => new TokenIdsActionPermission(x));
+    this.canUpdateCollectionApprovals = arr(msg.canUpdateCollectionApprovals).map((x) => new CollectionApprovalPermission(x));
+    this.canAddMoreAliasPaths = arr(msg.canAddMoreAliasPaths).map((x) => new ActionPermission(x));
+    this.canAddMoreCosmosCoinWrapperPaths = arr(msg.canAddMoreCosmosCoinWrapperPaths).map((x) => new ActionPermission(x));
   }
 
   convert<U extends NumberType>(convertFunction: (item: NumberType) => U, options?: ConvertOptions): CollectionPermissions<U> {
@@ -1010,7 +1024,9 @@ export class CollectionPermissionsWithDetails<T extends NumberType>
 
   constructor(data: iCollectionPermissionsWithDetails<T>) {
     super(data);
-    this.canUpdateCollectionApprovals = data.canUpdateCollectionApprovals.map(
+    // Mirror the base-class guard — partial session state may also
+    // omit this field. See backlog #0327.
+    this.canUpdateCollectionApprovals = (Array.isArray(data.canUpdateCollectionApprovals) ? data.canUpdateCollectionApprovals : []).map(
       (canUpdateCollectionApproval) => new CollectionApprovalPermissionWithDetails(canUpdateCollectionApproval)
     );
   }


### PR DESCRIPTION
## Summary
Bundles two targeted daily-automation fixes in the SDK:

1. **`CollectionPermissions` constructor defaults missing `canX` arrays to `[]`** — partial session state from the MCP builder's incremental `set_permissions` tool no longer crashes with a raw `TypeError: undefined is not an object (evaluating 'msg.canDeleteCollection.map')`. Same guard mirrored into `CollectionPermissionsWithDetails`. 3 new regression tests.
2. **OpenAPI routes.yaml — fixes 5 of 9 broken `docs.bitbadges.io` links** after the `/claim-builder/` → `/claims/` site restructure. All mechanical 1:1 remappings (plus `authenticating-with-bitbadges` → `sign-in-with-bitbadges`). Four genuinely ambiguous links are left as-is for a human pass (`native-chain-algorithm`, `universal-approach-claim-codes`, `getting-claims`, `managing-claims`).

Also carries one pre-existing commit on this daily branch (`#0305` — swap/dynamic-store response interface generics, merged earlier).

## Tickets covered
- Implements backlog #0327 — CollectionPermissions constructor unhelpful error on missing field
- Implements backlog #0306 — OpenAPI docs links 404 after site restructure (partial — 5 of 9; 4 left for human judgment)

## Test plan
- [x] `bun run test` → `src/core/permissions.spec.ts` 178/178 passing
- [x] `bun run build` clean, no circular deps
- [ ] GitBook render of `/for-developers/sign-in-with-bitbadges` and `/for-developers/claims/api-reference` to confirm the remapped OpenAPI links resolve