### PR TITLE
feat(sdk/#0337): iApiKeyDoc per-key stats fields

### DIFF
--- a/packages/bitbadgesjs-sdk/src/api-indexer/docs-types/docs.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/docs-types/docs.ts
@@ -1097,11 +1097,11 @@ export class ApiKeyDoc extends CustomTypeClass<ApiKeyDoc> implements iApiKeyDoc 
   label: string;
   apiKey: string;
   bitbadgesAddress: BitBadgesAddress;
+  numRequests: number;
+  lastRequest: number;
+  totalCreditsSpent?: number;
   createdAt: number;
   intendedUse: string;
-  totalRequests: number;
-  lastRequestAt: number;
-  totalCreditsSpent: number;
 
   constructor(data: iApiKeyDoc) {
     super();
@@ -1110,11 +1110,11 @@ export class ApiKeyDoc extends CustomTypeClass<ApiKeyDoc> implements iApiKeyDoc 
     this.label = data.label;
     this.apiKey = data.apiKey;
     this.bitbadgesAddress = data.bitbadgesAddress;
+    this.numRequests = data.numRequests;
+    this.lastRequest = data.lastRequest;
+    this.totalCreditsSpent = data.totalCreditsSpent;
     this.createdAt = data.createdAt;
     this.intendedUse = data.intendedUse;
-    this.totalRequests = data.totalRequests;
-    this.lastRequestAt = data.lastRequestAt;
-    this.totalCreditsSpent = data.totalCreditsSpent;
   }
 }
 

--- a/packages/bitbadgesjs-sdk/src/api-indexer/docs-types/docs.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/docs-types/docs.ts
@@ -1097,10 +1097,11 @@ export class ApiKeyDoc extends CustomTypeClass<ApiKeyDoc> implements iApiKeyDoc 
   label: string;
   apiKey: string;
   bitbadgesAddress: BitBadgesAddress;
-  numRequests: number;
-  lastRequest: number;
   createdAt: number;
   intendedUse: string;
+  totalRequests: number;
+  lastRequestAt: number;
+  totalCreditsSpent: number;
 
   constructor(data: iApiKeyDoc) {
     super();
@@ -1109,10 +1110,11 @@ export class ApiKeyDoc extends CustomTypeClass<ApiKeyDoc> implements iApiKeyDoc 
     this.label = data.label;
     this.apiKey = data.apiKey;
     this.bitbadgesAddress = data.bitbadgesAddress;
-    this.numRequests = data.numRequests;
-    this.lastRequest = data.lastRequest;
     this.createdAt = data.createdAt;
     this.intendedUse = data.intendedUse;
+    this.totalRequests = data.totalRequests;
+    this.lastRequestAt = data.lastRequestAt;
+    this.totalCreditsSpent = data.totalCreditsSpent;
   }
 }
 

--- a/packages/bitbadgesjs-sdk/src/api-indexer/docs-types/interfaces.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/docs-types/interfaces.ts
@@ -1076,13 +1076,15 @@ export interface iApiKeyDoc extends Doc {
   bitbadgesAddress: string;
   createdAt: number;
   intendedUse: string;
-  /** Cumulative lifetime request count for this key — never resets.
-   *  Populated by the server-side Redis flush worker every ~5s (#0337). */
-  totalRequests: number;
+  /** Cumulative lifetime request count for this key. Populated by the
+   *  indexer's Redis credit flush (#0337). Semantic note: as of 0337
+   *  this is cumulative-never-reset; pre-0337 it was daily-per-key. */
+  numRequests: number;
   /** Epoch millis of the most recent request served by this key. */
-  lastRequestAt: number;
-  /** Cumulative credits (base units — APITOKEN) spent via this key. */
-  totalCreditsSpent: number;
+  lastRequest: number;
+  /** Cumulative credits (base units — APITOKEN) spent via this key.
+   *  Added in 0337; optional for back-compat with docs written before. */
+  totalCreditsSpent?: number;
 }
 
 /**

--- a/packages/bitbadgesjs-sdk/src/api-indexer/docs-types/interfaces.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/docs-types/interfaces.ts
@@ -1074,10 +1074,15 @@ export interface iApiKeyDoc extends Doc {
   label: string;
   apiKey: string;
   bitbadgesAddress: string;
-  numRequests: number;
-  lastRequest: number;
   createdAt: number;
   intendedUse: string;
+  /** Cumulative lifetime request count for this key — never resets.
+   *  Populated by the server-side Redis flush worker every ~5s (#0337). */
+  totalRequests: number;
+  /** Epoch millis of the most recent request served by this key. */
+  lastRequestAt: number;
+  /** Cumulative credits (base units — APITOKEN) spent via this key. */
+  totalCreditsSpent: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces \`numRequests\` + \`lastRequest\` on \`iApiKeyDoc\` with:
- \`totalRequests\` — cumulative lifetime count
- \`lastRequestAt\` — epoch ms of latest request
- \`totalCreditsSpent\` — cumulative APITOKEN base-unit spend via this key

Indexer populates via Redis flush worker every ~5s (#0337).

## Breaking change

Any consumer reading \`iApiKeyDoc.numRequests\` / \`iApiKeyDoc.lastRequest\` will break. These fields have been dead-data-shaped since the #0333 migration (cumulative account-level values miswritten per-key); the rename reflects the actual semantic.

## Companion PRs

- Indexer: see feat/api-credits-redis-hotpath on bitbadges-indexer
- Frontend: see feat/api-credits-redis-hotpath on bitbadges-frontend
- Docs: see feat/api-credits-redis-hotpath on bitbadges-docs