### PR TITLE
sdk: gate testnet network behind feature flag, throw early (#0340)

### DIFF
--- a/packages/bitbadgesjs-sdk/README.md
+++ b/packages/bitbadgesjs-sdk/README.md
@@ -147,6 +147,10 @@ const api = new BitBadgesAPI({
 
 > **Note**: The SDK uses defensive checks (`typeof process !== 'undefined'`) to support both environments. No polyfills needed.
 
+## Network configuration
+
+The SDK ships preset network configs (`mainnet`, `testnet`, `local`) used by `BitBadgesSigningClient` and the CLI's `--testnet` / `--local` flags. **Testnet is temporarily offline as of 2026-04-25** to reduce hosting costs — selecting `network: 'testnet'`, passing `--testnet`, or setting `network = testnet` in `~/.bitbadges/config.json` will throw a clear error pointing at mainnet. All testnet URLs and chain IDs are preserved in the config so the network can be revived by flipping a single `disabled` flag. If you're running a private chain at the testnet chain ID for local development, set `BITBADGES_TESTNET_OFFLINE=false` in your environment to bypass the assertion. See [docs.bitbadges.io](https://docs.bitbadges.io/for-developers/bitbadges-blockchain/testnet-mode) for full details.
+
 ## Core Concepts
 
 ### Number Types

--- a/packages/bitbadgesjs-sdk/src/cli/commands/config.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/config.ts
@@ -6,6 +6,7 @@ import {
   SUPPORTED_CONFIG_KEYS,
   type ConfigKey,
 } from '../utils/config.js';
+import { assertNetworkAvailable } from '../../signing/types.js';
 
 export const configCommand = new Command('config').description(
   'Manage CLI configuration (~/.bitbadges/config.json)'
@@ -53,6 +54,19 @@ configCommand
       console.error('Invalid network value. Must be one of: mainnet, testnet, local');
       process.exitCode = 1;
       return;
+    }
+
+    // Fail fast if the user tries to persist a currently-disabled network
+    // (e.g. testnet is temporarily offline). This catches misconfiguration
+    // at config-write time rather than at every later command.
+    if (key === 'network') {
+      try {
+        assertNetworkAvailable(value);
+      } catch (err) {
+        console.error((err as Error).message);
+        process.exitCode = 1;
+        return;
+      }
     }
 
     const config = loadConfig();

--- a/packages/bitbadgesjs-sdk/src/cli/utils/api-client.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/api-client.ts
@@ -3,6 +3,7 @@
  * Uses native fetch. Adds x-api-key header. Returns parsed JSON.
  */
 
+import { assertNetworkAvailable } from '../../signing/types.js';
 import { getConfigApiKey, getConfigBaseUrl } from './config.js';
 
 export interface ApiRequestOptions {
@@ -31,7 +32,11 @@ export function resolveBaseUrl(options?: {
 }): string {
   if (options?.baseUrl) return options.baseUrl;
   if (options?.local) return 'http://localhost:3001/api/v0';
-  if (options?.testnet) return 'https://api.testnet.bitbadges.io/api/v0';
+  if (options?.testnet) {
+    // Fail fast if testnet is currently disabled. Override via env var.
+    assertNetworkAvailable('testnet');
+    return 'https://api.testnet.bitbadges.io/api/v0';
+  }
   if (process.env.BITBADGES_API_URL) return process.env.BITBADGES_API_URL;
   const configUrl = getConfigBaseUrl();
   if (configUrl) return configUrl;

--- a/packages/bitbadgesjs-sdk/src/cli/utils/config.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/config.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { assertNetworkAvailable } from '../../signing/types.js';
 
 export interface Config {
   apiKey?: string;
@@ -63,6 +64,10 @@ export function getConfigApiKey(network?: 'mainnet' | 'testnet' | 'local'): stri
 export function getConfigBaseUrl(): string | undefined {
   const config = loadConfig();
   if (config.url) return config.url;
+  // Fail fast if the persisted network is currently disabled. Override via
+  // BITBADGES_TESTNET_OFFLINE=false. We only assert when the user has actually
+  // selected a network in their config — undefined means "default to mainnet".
+  if (config.network) assertNetworkAvailable(config.network);
   switch (config.network) {
     case 'testnet':
       return 'https://api.testnet.bitbadges.io/api/v0';

--- a/packages/bitbadgesjs-sdk/src/cli/utils/io.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/io.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import type { Command } from 'commander';
 import { getConfigBaseUrl, getConfigApiKey } from './config.js';
+import { assertNetworkAvailable } from '../../signing/types.js';
 
 /**
  * Read JSON input from multiple sources:
@@ -139,6 +140,9 @@ export function getApiUrl(options: NetworkOptions): string {
     return process.env.BITBADGES_API_URL;
   }
   const network = resolveNetwork(options);
+  // Fail fast if the resolved network is currently disabled. Override via
+  // BITBADGES_TESTNET_OFFLINE=false for local dev pointing at a private chain.
+  assertNetworkAvailable(network);
   if (network === 'local') {
     return 'http://localhost:3001';
   }

--- a/packages/bitbadgesjs-sdk/src/signing/BitBadgesSigningClient.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/signing/BitBadgesSigningClient.spec.ts
@@ -3,6 +3,17 @@ import type { WalletAdapter } from './adapters/WalletAdapter.js';
 import type { SigningResult, EvmTransaction } from './types.js';
 import type { TransactionPayload } from '@/transactions/messages/base.js';
 
+// Restore env between tests so the BITBADGES_TESTNET_OFFLINE override doesn't
+// leak across test cases.
+const ORIGINAL_TESTNET_OFFLINE = process.env.BITBADGES_TESTNET_OFFLINE;
+afterEach(() => {
+  if (ORIGINAL_TESTNET_OFFLINE === undefined) {
+    delete process.env.BITBADGES_TESTNET_OFFLINE;
+  } else {
+    process.env.BITBADGES_TESTNET_OFFLINE = ORIGINAL_TESTNET_OFFLINE;
+  }
+});
+
 // Mock axios
 jest.mock('axios', () => ({
   create: jest.fn(() => ({
@@ -86,7 +97,7 @@ describe('BitBadgesSigningClient', () => {
         adapter,
         apiUrl: 'https://custom-api.example.com',
         nodeUrl: 'https://custom-node.example.com:1317',
-        network: 'testnet',
+        network: 'mainnet',
         sequenceRetryEnabled: false,
         maxSequenceRetries: 5,
         gasMultiplier: 1.5,
@@ -94,6 +105,21 @@ describe('BitBadgesSigningClient', () => {
       });
 
       expect(client.address).toBe(adapter.address);
+    });
+
+    it('should throw when network is testnet (temporarily offline)', () => {
+      const adapter = new MockCosmosAdapter();
+      expect(() => new BitBadgesSigningClient({ adapter, network: 'testnet' })).toThrow(
+        /testnet is temporarily offline/i
+      );
+    });
+
+    it('should allow testnet when BITBADGES_TESTNET_OFFLINE=false override is set', () => {
+      process.env.BITBADGES_TESTNET_OFFLINE = 'false';
+      const adapter = new MockCosmosAdapter();
+      const client = new BitBadgesSigningClient({ adapter, network: 'testnet' });
+      expect(client).toBeDefined();
+      expect(client.config.cosmosChainId).toBe('bitbadges-2');
     });
 
     it('should handle EVM adapter address conversion', () => {
@@ -214,12 +240,11 @@ describe('SigningClientOptions', () => {
   it('should respect network mode', () => {
     const adapter = new MockCosmosAdapter();
     const clientMainnet = new BitBadgesSigningClient({ adapter, network: 'mainnet' });
-    const clientTestnet = new BitBadgesSigningClient({ adapter, network: 'testnet' });
     const clientLocal = new BitBadgesSigningClient({ adapter, network: 'local' });
 
-    // All should be created successfully
+    // Mainnet + local should be created successfully. Testnet is currently
+    // disabled and is covered by the dedicated throw / override tests above.
     expect(clientMainnet).toBeDefined();
-    expect(clientTestnet).toBeDefined();
     expect(clientLocal).toBeDefined();
   });
 

--- a/packages/bitbadgesjs-sdk/src/signing/BitBadgesSigningClient.ts
+++ b/packages/bitbadgesjs-sdk/src/signing/BitBadgesSigningClient.ts
@@ -7,6 +7,7 @@ import axios, { type AxiosInstance } from 'axios';
 import type { WalletAdapter } from './adapters/WalletAdapter.js';
 import {
   NETWORK_CONFIGS,
+  assertNetworkAvailable,
   type AccountInfo,
   type BroadcastResult,
   type NetworkConfig,
@@ -90,6 +91,9 @@ export class BitBadgesSigningClient {
 
     // Resolve network configuration from preset or custom values
     const network: NetworkMode = options.network || 'mainnet';
+    // Fail fast if the selected network is currently disabled (e.g. testnet
+    // shutdown). Override via BITBADGES_TESTNET_OFFLINE=false for local dev.
+    assertNetworkAvailable(network);
     const baseConfig = NETWORK_CONFIGS[network];
 
     this.networkConfig = {

--- a/packages/bitbadgesjs-sdk/src/signing/index.ts
+++ b/packages/bitbadgesjs-sdk/src/signing/index.ts
@@ -56,7 +56,7 @@ export type {
 } from './types.js';
 
 // Network configuration presets
-export { NETWORK_CONFIGS } from './types.js';
+export { NETWORK_CONFIGS, assertNetworkAvailable } from './types.js';
 
 // Adapters
 export {

--- a/packages/bitbadgesjs-sdk/src/signing/types.ts
+++ b/packages/bitbadgesjs-sdk/src/signing/types.ts
@@ -89,6 +89,13 @@ export interface NetworkConfig {
   evmChainId: number;
   /** EVM JSON-RPC URL for server-side EVM signing */
   evmRpcUrl: string;
+  /**
+   * If true, this network is currently offline / disabled. Selecting it
+   * will throw via `assertNetworkAvailable` unless the override env var
+   * `BITBADGES_TESTNET_OFFLINE=false` is set. URL fields are kept intact
+   * so the network can be revived by flipping this flag back to false.
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -105,11 +112,15 @@ export const NETWORK_CONFIGS: Record<NetworkMode, NetworkConfig> = {
     evmRpcUrl: 'https://evm-rpc.bitbadges.io'
   },
   testnet: {
+    // NOTE: Testnet is temporarily offline as of 2026-04-25 to reduce hosting
+    // costs. URL fields are intentionally preserved so the network can be
+    // revived by flipping `disabled` back to false. See `assertNetworkAvailable`.
     apiUrl: 'https://api.bitbadges.io/testnet',
     nodeUrl: 'https://lcd-testnet.bitbadges.io',
     cosmosChainId: 'bitbadges-2',
     evmChainId: 50025,
-    evmRpcUrl: 'https://evm-rpc-testnet.bitbadges.io'
+    evmRpcUrl: 'https://evm-rpc-testnet.bitbadges.io',
+    disabled: true
   },
   local: {
     apiUrl: 'http://localhost:3001',
@@ -119,6 +130,37 @@ export const NETWORK_CONFIGS: Record<NetworkMode, NetworkConfig> = {
     evmRpcUrl: 'http://localhost:8545'
   }
 };
+
+/**
+ * Throws a descriptive error if the requested network is currently
+ * disabled in `NETWORK_CONFIGS`. Acts as the single choke point for the
+ * temporary testnet shutdown so SDK consumers fail fast with a clear
+ * message instead of silently hitting dead hosts.
+ *
+ * Override hatch: set `BITBADGES_TESTNET_OFFLINE=false` in the
+ * environment to bypass the assertion (useful when running a private
+ * chain at the testnet chain ID for local development).
+ *
+ * @category Signing
+ */
+export function assertNetworkAvailable(network: string): void {
+  // Guarded process access — SDK runs in browsers too.
+  const env = typeof process !== 'undefined' ? process.env : undefined;
+  if (env && env.BITBADGES_TESTNET_OFFLINE === 'false') {
+    return;
+  }
+
+  const config = (NETWORK_CONFIGS as Record<string, NetworkConfig | undefined>)[network];
+  if (config?.disabled === true) {
+    throw new Error(
+      'BitBadges testnet is temporarily offline as of 2026-04-25 to reduce hosting costs. ' +
+        'Please use mainnet (https://bitbadges.io) until further notice. ' +
+        'To override (e.g. for local dev pointing at a private chain), set the env var ' +
+        'BITBADGES_TESTNET_OFFLINE=false. ' +
+        'See https://docs.bitbadges.io/for-developers/bitbadges-blockchain/testnet-mode for details.'
+    );
+  }
+}
 
 /**
  * Options for the signing client.


### PR DESCRIPTION
## Summary

BitBadges testnet is being temporarily shut down as of 2026-04-25 to reduce infra costs (tracked as autopilot ticket #0340). Without this change, any SDK consumer selecting `network: 'testnet'` (or passing `--testnet` to the CLI) would silently make requests to dead hosts. This PR makes that path fail fast with a descriptive error pointing the user at mainnet.

- Adds an optional `disabled?: boolean` field to `NetworkConfig` in `signing/types.ts` and sets `disabled: true` on the `testnet` entry. **All testnet URL/chainId fields are kept intact** so revival is a single-line flip.
- Adds `assertNetworkAvailable(network: string)` next to `NETWORK_CONFIGS`. It throws a clear message naming mainnet as the alternative and documenting the override env var + docs link.
- Wires the assert into the natural choke points where a user-supplied network enters the system:
  - `BitBadgesSigningClient` constructor
  - CLI `resolveBaseUrl` (api-client.ts) and `getApiUrl` (io.ts)
  - CLI `getConfigBaseUrl` (config.ts) — for persisted `network: 'testnet'`
  - CLI `config set network <value>` validator — fail at write time
- Updates `BitBadgesSigningClient.spec.ts`: existing `network: 'testnet'` test rewritten to expect the throw, plus a new test that sets `BITBADGES_TESTNET_OFFLINE=false` and verifies the override path produces a working client. Env restored via `afterEach` so it doesn't leak across tests.
- Adds a short "Network configuration" paragraph to `packages/bitbadgesjs-sdk/README.md` so readers who hit the error find the override hatch.

## Override hatch

Set `BITBADGES_TESTNET_OFFLINE=false` in your environment to bypass the assertion. This is the escape valve for local-dev users running a private chain at the testnet chain ID (50025) — they should not be locked out by a hosted-testnet shutdown.

## Release

Will ship in the next published version of `bitbadges`.

## Test plan

- [x] `npm run build` succeeds (full SDK build, dist symlink consumers unaffected)
- [x] `npm test` — full suite (76 suites, 2319 tests) passes
- [x] New tests pass:
  - `should throw when network is testnet (temporarily offline)`
  - `should allow testnet when BITBADGES_TESTNET_OFFLINE=false override is set`
- [ ] Manual: `bitbadges-cli --testnet ...` shows the new error
- [ ] Manual: `BITBADGES_TESTNET_OFFLINE=false bitbadges-cli --testnet ...` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)