### PR TITLE
sdk: chaosnet messaging in testnet-offline error + README (#0340)

### DIFF
--- a/packages/bitbadgesjs-sdk/README.md
+++ b/packages/bitbadgesjs-sdk/README.md
@@ -149,7 +149,11 @@ const api = new BitBadgesAPI({
 
 ## Network configuration
 
-The SDK ships preset network configs (`mainnet`, `testnet`, `local`) used by `BitBadgesSigningClient` and the CLI's `--testnet` / `--local` flags. **Testnet is temporarily offline as of 2026-04-25** to reduce hosting costs — selecting `network: 'testnet'`, passing `--testnet`, or setting `network = testnet` in `~/.bitbadges/config.json` will throw a clear error pointing at mainnet. All testnet URLs and chain IDs are preserved in the config so the network can be revived by flipping a single `disabled` flag. If you're running a private chain at the testnet chain ID for local development, set `BITBADGES_TESTNET_OFFLINE=false` in your environment to bypass the assertion. See [docs.bitbadges.io](https://docs.bitbadges.io/for-developers/bitbadges-blockchain/testnet-mode) for full details.
+The SDK ships preset network configs (`mainnet`, `testnet`, `local`) used by `BitBadgesSigningClient` and the CLI's `--testnet` / `--local` flags.
+
+**Testnet is temporarily offline as of 2026-04-25** to reduce hosting costs. In the meantime, BitBadges **mainnet operates as a chaosnet** — fully live, but safe to experiment on. Network gas fees can be set to zero while activity is low, and you can transact with worthless tokens like CHAOS instead of real-value assets. Point your code at `network: 'mainnet'` to test contracts, transactions, and integrations on the live network without spending anything real — just choose your assets accordingly.
+
+Selecting `network: 'testnet'`, passing `--testnet`, or setting `network = testnet` in `~/.bitbadges/config.json` will throw a clear error nudging you toward mainnet. All testnet URLs and chain IDs are preserved in the config so the network can be revived by flipping a single `disabled` flag. If you're running a private chain at the testnet chain ID for local development, set `BITBADGES_TESTNET_OFFLINE=false` in your environment to bypass the assertion. See [docs.bitbadges.io](https://docs.bitbadges.io/for-developers/bitbadges-blockchain/testnet-mode) for full details.
 
 ## Core Concepts
 

--- a/packages/bitbadgesjs-sdk/src/signing/types.ts
+++ b/packages/bitbadgesjs-sdk/src/signing/types.ts
@@ -154,9 +154,14 @@ export function assertNetworkAvailable(network: string): void {
   if (config?.disabled === true) {
     throw new Error(
       'BitBadges testnet is temporarily offline as of 2026-04-25 to reduce hosting costs. ' +
-        'Please use mainnet (https://bitbadges.io) until further notice. ' +
-        'To override (e.g. for local dev pointing at a private chain), set the env var ' +
-        'BITBADGES_TESTNET_OFFLINE=false. ' +
+        'Mainnet now serves as a chaosnet — fully live, but safe to experiment on: ' +
+        'network gas fees can be set to zero while activity is low, and you can transact ' +
+        'with worthless tokens like CHAOS instead of real-value assets. ' +
+        "Switch to mainnet (network: 'mainnet') to test contracts, transactions, and " +
+        'integrations on the live network without spending anything real — just choose ' +
+        'your assets accordingly. ' +
+        'To override this guard for local dev (e.g. a private chain at the testnet chain ID), ' +
+        'set BITBADGES_TESTNET_OFFLINE=false. ' +
         'See https://docs.bitbadges.io/for-developers/bitbadges-blockchain/testnet-mode for details.'
     );
   }


### PR DESCRIPTION
## Summary

Follow-up to #189. Reframes the testnet-offline copy in both the thrown error message and the SDK README "Network configuration" section to explain that **mainnet now serves as a chaosnet** — fully live, but safe to experiment on. Network gas fees can be set to zero while activity is low, and developers can transact with worthless tokens like CHAOS to test contracts, transactions, and integrations on the live network without spending anything real.

This aligns the SDK voice with the EVM explorer's testnet-offline screen, so a developer hitting either surface gets the same story instead of two slightly different versions.

The override-hatch instruction (`BITBADGES_TESTNET_OFFLINE=false`) and the docs link are preserved.

## Test plan
- [x] SDK build clean (`npm run build`)
- [x] All 20 signing tests pass — error string still contains "testnet is temporarily offline" so the existing `/testnet is temporarily offline/i` regex keeps matching
- [ ] Reviewer eyeball: tone matches the explorer chaosnet card

🤖 Generated with [Claude Code](https://claude.com/claude-code)