### PR TITLE
sdk(cli): surface collectionId reliably from create-with-burner + --mainnet shortcut

### DIFF
--- a/packages/bitbadgesjs-sdk/src/cli/commands/createWithBurner.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/createWithBurner.ts
@@ -222,7 +222,7 @@ createWithBurnerCommand.action(async (input: string | undefined, opts: any) => {
       ephemeralAddress: result.ephemeralAddress,
       recoveryPath: result.recoveryPath,
       txHash: result.txHash,
-      collectionId: result.collectionId,
+      collectionId: result.collectionId ?? null,
       paused: result.paused,
       error: result.error
     };

--- a/packages/bitbadgesjs-sdk/src/cli/utils/burner.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/burner.ts
@@ -520,12 +520,14 @@ export async function runBurnerCreate(
  * Poll the LCD for a given tx hash and pull the created collection ID
  * out of its events. The sync-mode broadcast response returned from the
  * indexer doesn't include block events (check_tx runs before the block
- * commits), so we re-query once the block lands. We try up to ~6s — one
- * extra block at the current ~4s block time is plenty.
+ * commits), so we re-query once the block lands. We try up to ~20s —
+ * mainnet block time is ~4s but LCD indexing lag past the commit can
+ * push the tx past a tighter window, leaving callers with a successful
+ * txHash but no collectionId.
  */
 async function fetchCollectionIdFromTx(nodeUrl: string, txHash: string): Promise<string | undefined> {
   const axios = (await import('axios')).default;
-  const attempts = 3;
+  const attempts = 10;
   const delayMs = 2_000;
   for (let i = 0; i < attempts; i++) {
     try {

--- a/packages/bitbadgesjs-sdk/src/cli/utils/io.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/io.ts
@@ -98,6 +98,8 @@ export interface NetworkOptions {
   testnet?: boolean;
   /** Legacy boolean shorthand. Equivalent to `--network local`. */
   local?: boolean;
+  /** Boolean shorthand. Equivalent to `--network mainnet`. */
+  mainnet?: boolean;
   /** Custom API base URL — overrides every other selector. */
   url?: string;
 }
@@ -105,12 +107,13 @@ export interface NetworkOptions {
 /**
  * Resolve a network name from a mix of long-form and legacy flags.
  * `--url` always wins; otherwise `--network` > `--local` > `--testnet`
- * > env > config > mainnet default.
+ * > `--mainnet` > env > config > mainnet default.
  */
 export function resolveNetwork(options: NetworkOptions): NetworkName {
   if (options.network) return options.network;
   if (options.local) return 'local';
   if (options.testnet) return 'testnet';
+  if (options.mainnet) return 'mainnet';
   return 'mainnet';
 }
 
@@ -182,6 +185,7 @@ export function addNetworkOptions(cmd: Command): Command {
       '--network <name>',
       'Network: mainnet | testnet | local. Picks the matching API base URL and config apiKey.'
     )
+    .option('--mainnet', 'Shortcut for --network mainnet')
     .option('--testnet', 'Shortcut for --network testnet')
     .option('--local', 'Shortcut for --network local (http://localhost:3001)')
     .option('--url <url>', 'Custom API base URL (overrides --network)');


### PR DESCRIPTION
## Summary
Three small CLI fixes uncovered while broadcasting a real `payment-request` collection on mainnet via `create-with-burner`:

- **`collectionId` was silently dropped from the JSON output.** The tx broadcast cleanly (mainnet height 10025548, code 0) but the orchestrator's 6s LCD post-broadcast poll timed out before the tx was indexable, so `runBurnerCreate` returned `collectionId: undefined` and `JSON.stringify` dropped the field. Bumped the polling window to ~20s (10 × 2s) and now always emit the field as `null` when missing so the payload shape is stable for automation.
- **`--mainnet` shortcut.** `addNetworkOptions` already had `--testnet` and `--local`; symmetry was missing. Added `--mainnet` plus the matching `NetworkOptions.mainnet` and `resolveNetwork` branch (still defaults to mainnet when nothing is passed).

## Test plan
- [x] `npm run build` (clean, no circular deps)
- [x] `bitbadges-cli builder create-with-burner --help` shows `--mainnet` next to `--testnet` / `--local`
- [ ] End-to-end: pipe a `templates payment-request` into `create-with-burner --mainnet --new --non-interactive` and confirm the JSON payload includes a non-null `collectionId` for the produced tx
- [ ] Reviewer: any other commands that hand-roll their network flag set should pick up `--mainnet` automatically via `addNetworkOptions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)