### PR TITLE
sdk: phase 1 — inline customData metadata + builders/CLI two-mode contract (#0371)

### DIFF
--- a/packages/bitbadgesjs-sdk/package.json
+++ b/packages/bitbadgesjs-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitbadges",
   "description": "BitBadges — programmable tokens on Cosmos. SDK, CLI, and builder tools for humans and agents. (Previously published as 'bitbadgesjs-sdk'.)",
-  "version": "0.35.5",
+  "version": "0.35.6",
   "license": "MIT",
   "keywords": [
     "bitbadges",

--- a/packages/bitbadgesjs-sdk/src/api-indexer/metadata/index.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/metadata/index.ts
@@ -2,3 +2,4 @@ export * from './tokenMetadata.js';
 export * from './metadataIds.js';
 export * from './metadata.js';
 export * from './inlineCustomData.js';
+export * from './inlineImage.js';

--- a/packages/bitbadgesjs-sdk/src/api-indexer/metadata/index.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/metadata/index.ts
@@ -1,3 +1,4 @@
 export * from './tokenMetadata.js';
 export * from './metadataIds.js';
 export * from './metadata.js';
+export * from './inlineCustomData.js';

--- a/packages/bitbadgesjs-sdk/src/api-indexer/metadata/inlineCustomData.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/metadata/inlineCustomData.spec.ts
@@ -1,0 +1,182 @@
+import { parseInlineCustomData } from './inlineCustomData.js';
+import { Metadata } from './metadata.js';
+
+describe('parseInlineCustomData', () => {
+  test('parses minimal {name, image, description}', () => {
+    const out = parseInlineCustomData(
+      JSON.stringify({ name: 'Test', image: 'ipfs://abc', description: 'hi' })
+    );
+    expect(out).toBeInstanceOf(Metadata);
+    expect(out!.name).toBe('Test');
+    expect(out!.image).toBe('ipfs://abc');
+    expect(out!.description).toBe('hi');
+  });
+
+  test('accepts name-only (legacy permissive)', () => {
+    const out = parseInlineCustomData(JSON.stringify({ name: 'Solo' }));
+    expect(out).not.toBeNull();
+    expect(out!.name).toBe('Solo');
+    expect(out!.image).toBe('');
+    expect(out!.description).toBe('');
+  });
+
+  test('accepts image-only', () => {
+    const out = parseInlineCustomData(JSON.stringify({ image: 'ipfs://x' }));
+    expect(out).not.toBeNull();
+    expect(out!.image).toBe('ipfs://x');
+  });
+
+  test('accepts description-only', () => {
+    const out = parseInlineCustomData(JSON.stringify({ description: 'd' }));
+    expect(out).not.toBeNull();
+    expect(out!.description).toBe('d');
+  });
+
+  test('returns null on oversized payload (>32KB)', () => {
+    const big = 'x'.repeat(33 * 1024);
+    const payload = JSON.stringify({ name: 'X', description: big });
+    expect(payload.length).toBeGreaterThan(32 * 1024);
+    expect(parseInlineCustomData(payload)).toBeNull();
+  });
+
+  test('returns null on malformed JSON', () => {
+    expect(parseInlineCustomData('{not valid json')).toBeNull();
+    expect(parseInlineCustomData('hello')).toBeNull();
+  });
+
+  test('returns null on JSON array', () => {
+    expect(parseInlineCustomData('[]')).toBeNull();
+    expect(parseInlineCustomData('[{"name":"x"}]')).toBeNull();
+  });
+
+  test('returns null on JSON primitive', () => {
+    expect(parseInlineCustomData('"a string"')).toBeNull();
+    expect(parseInlineCustomData('42')).toBeNull();
+    expect(parseInlineCustomData('true')).toBeNull();
+  });
+
+  test('returns null on JSON null', () => {
+    expect(parseInlineCustomData('null')).toBeNull();
+  });
+
+  test('returns null on empty string', () => {
+    expect(parseInlineCustomData('')).toBeNull();
+  });
+
+  test('returns null on empty object (no required field)', () => {
+    expect(parseInlineCustomData('{}')).toBeNull();
+  });
+
+  test('returns null when required fields are not strings', () => {
+    expect(parseInlineCustomData(JSON.stringify({ name: 0 }))).toBeNull();
+    expect(parseInlineCustomData(JSON.stringify({ name: null }))).toBeNull();
+    expect(parseInlineCustomData(JSON.stringify({ name: '', image: '' }))).toBeNull();
+  });
+
+  test('drops wrong-typed image but keeps valid name', () => {
+    const out = parseInlineCustomData(JSON.stringify({ name: 'Solo', image: 12345 }));
+    expect(out).not.toBeNull();
+    expect(out!.name).toBe('Solo');
+    expect(out!.image).toBe('');
+  });
+
+  test('drops unknown keys', () => {
+    const out = parseInlineCustomData(
+      JSON.stringify({ name: 'X', evil: '<script>', _internal: 'x', randomGarbage: { a: 1 } })
+    );
+    expect(out).not.toBeNull();
+    expect((out as any).evil).toBeUndefined();
+    expect((out as any)._internal).toBeUndefined();
+    expect((out as any).randomGarbage).toBeUndefined();
+  });
+
+  test('coerces optional string fields when valid', () => {
+    const out = parseInlineCustomData(
+      JSON.stringify({
+        name: 'X',
+        bannerImage: 'ipfs://b',
+        category: 'Education',
+        externalUrl: 'https://example.com'
+      })
+    );
+    expect(out).not.toBeNull();
+    expect(out!.bannerImage).toBe('ipfs://b');
+    expect(out!.category).toBe('Education');
+    expect(out!.externalUrl).toBe('https://example.com');
+  });
+
+  test('drops wrong-typed optional string fields', () => {
+    const out = parseInlineCustomData(
+      JSON.stringify({ name: 'X', bannerImage: 5, category: { foo: 'bar' } })
+    );
+    expect(out).not.toBeNull();
+    expect(out!.bannerImage).toBeUndefined();
+    expect(out!.category).toBeUndefined();
+  });
+
+  test('coerces tags as string array', () => {
+    const out = parseInlineCustomData(JSON.stringify({ name: 'X', tags: ['a', 'b', 3, null] }));
+    expect(out).not.toBeNull();
+    expect(out!.tags).toEqual(['a', 'b']);
+  });
+
+  test('drops tags entirely when not an array', () => {
+    const out = parseInlineCustomData(JSON.stringify({ name: 'X', tags: 'not-an-array' }));
+    expect(out).not.toBeNull();
+    expect(out!.tags).toBeUndefined();
+  });
+
+  test('coerces attributes when shape matches', () => {
+    const out = parseInlineCustomData(
+      JSON.stringify({
+        name: 'X',
+        attributes: [
+          { type: 'string', name: 'rarity', value: 'rare' },
+          { type: 'number', name: 'level', value: 5 },
+          { name: 'malformed', value: 'no type' },
+          { type: 'string', name: 'good', value: true }
+        ]
+      })
+    );
+    expect(out).not.toBeNull();
+    expect(out!.attributes).toEqual([
+      { type: 'string', name: 'rarity', value: 'rare' },
+      { type: 'number', name: 'level', value: 5 },
+      { type: 'string', name: 'good', value: true }
+    ]);
+  });
+
+  test('coerces socials as string-keyed string map', () => {
+    const out = parseInlineCustomData(
+      JSON.stringify({
+        name: 'X',
+        socials: { twitter: '@bitbadges', evil: 5, github: 'bitbadges' }
+      })
+    );
+    expect(out).not.toBeNull();
+    expect(out!.socials).toEqual({ twitter: '@bitbadges', github: 'bitbadges' });
+  });
+
+  test('drops malformed sub-fields without rejecting whole metadata', () => {
+    const out = parseInlineCustomData(
+      JSON.stringify({
+        name: 'Survivor',
+        attributes: 'not-an-array',
+        socials: 'not-an-object',
+        tags: { not: 'an-array' }
+      })
+    );
+    expect(out).not.toBeNull();
+    expect(out!.name).toBe('Survivor');
+    expect(out!.attributes).toBeUndefined();
+    expect(out!.socials).toBeUndefined();
+    expect(out!.tags).toBeUndefined();
+  });
+
+  test('returns a fresh Metadata instance, not the raw parsed object', () => {
+    const raw = { name: 'X', __proto__: { polluted: true } };
+    const out = parseInlineCustomData(JSON.stringify(raw));
+    expect(out).toBeInstanceOf(Metadata);
+    expect((out as any).polluted).toBeUndefined();
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/api-indexer/metadata/inlineCustomData.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/metadata/inlineCustomData.ts
@@ -12,6 +12,23 @@
  * anything in it. The pipeline below validates and sanitizes
  * defensively, returning `null` on any failure rather than throwing or
  * surfacing attacker-controlled shapes.
+ *
+ * ## Cost note
+ *
+ * Inline customData is stored on-chain — every byte costs gas
+ * (~10 gas/byte) and the bytes live in chain state forever. Use it
+ * for the metadata wrapper (name, description, attributes, links to
+ * images) — NOT for image bytes or any large/binary payload.
+ *
+ * If you want zero-hosting AND an image, see `generatePlaceholderArt`
+ * (re-exported from this module): produces a deterministic 1-8 KB
+ * `data:image/svg+xml;base64,...` URI you can drop straight into the
+ * `image` field. You still pay ~80k gas for the 8 KB of SVG bytes,
+ * so it's a convenience trade-off, not a free lunch.
+ *
+ * For full pricing breakdown see the cost-considerations callout in
+ * the BitBadges docs (`token-standard/learn/collection-setup-fields.md
+ * #cost-considerations-keep-images-off-chain`).
  */
 import { BigIntify } from '@/common/string-numbers.js';
 import { Metadata, type iMetadata } from './metadata.js';

--- a/packages/bitbadgesjs-sdk/src/api-indexer/metadata/inlineCustomData.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/metadata/inlineCustomData.ts
@@ -1,0 +1,132 @@
+/**
+ * Inline customData JSON metadata parser.
+ *
+ * Every metadata-bearing entity on chain (collection, token, approval,
+ * address list, dynamic store, alias path, wrapper path) carries a
+ * `(uri, customData)` pair. Phase 1 makes inline JSON in `customData`
+ * a first-class fallback for the read path: when `uri` is empty, the
+ * indexer / SDK / frontend try to parse `customData` as off-chain
+ * metadata before giving up.
+ *
+ * `customData` is a free-form on-chain string — anyone can stuff
+ * anything in it. The pipeline below validates and sanitizes
+ * defensively, returning `null` on any failure rather than throwing or
+ * surfacing attacker-controlled shapes.
+ */
+import { BigIntify } from '@/common/string-numbers.js';
+import { Metadata, type iMetadata } from './metadata.js';
+
+/** Hard cap on customData byte length before we even try to parse. */
+const MAX_INLINE_CUSTOM_DATA_BYTES = 32 * 1024;
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0;
+}
+
+function coerceStringArray(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out: string[] = [];
+  for (const item of v) {
+    if (typeof item === 'string') out.push(item);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function coerceAttributes(v: unknown): iMetadata<bigint>['attributes'] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out: NonNullable<iMetadata<bigint>['attributes']> = [];
+  for (const item of v) {
+    if (!isPlainObject(item)) continue;
+    const type = item.type;
+    const name = item.name;
+    const value = item.value;
+    if (typeof type !== 'string' || typeof name !== 'string') continue;
+    if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') continue;
+    out.push({ type, name, value });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function coerceSocials(v: unknown): Record<string, string> | undefined {
+  if (!isPlainObject(v)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, val] of Object.entries(v)) {
+    if (typeof val === 'string') out[k] = val;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function coerceAdditionalInfo(v: unknown): iMetadata<bigint>['additionalInfo'] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out: NonNullable<iMetadata<bigint>['additionalInfo']> = [];
+  for (const item of v) {
+    if (!isPlainObject(item)) continue;
+    const name = item.name;
+    const image = item.image;
+    const description = item.description;
+    if (typeof name !== 'string' || typeof image !== 'string' || typeof description !== 'string') continue;
+    const entry: NonNullable<iMetadata<bigint>['additionalInfo']>[number] = { name, image, description };
+    if (typeof item.url === 'string') entry.url = item.url;
+    out.push(entry);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Parse + sanitize a free-form `customData` string into a `Metadata`
+ * object. Returns `null` on any failure (oversized, malformed JSON,
+ * wrong type, missing required shape, etc.). Never throws, never
+ * returns the raw parsed object.
+ *
+ * Required shape gate: must have at least one of `name`, `image`, or
+ * `description` as a non-empty string. Per-preset stricter shapes are
+ * enforced at write time by builders / CLI; this read-side helper
+ * stays permissive on optionals so legacy customData with name-only
+ * still resolves.
+ */
+export function parseInlineCustomData(customData: string): Metadata<bigint> | null {
+  if (typeof customData !== 'string') return null;
+  if (customData.length === 0) return null;
+  if (customData.length > MAX_INLINE_CUSTOM_DATA_BYTES) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(customData);
+  } catch {
+    return null;
+  }
+
+  if (!isPlainObject(parsed)) return null;
+
+  const hasRequired =
+    isNonEmptyString(parsed.name) || isNonEmptyString(parsed.image) || isNonEmptyString(parsed.description);
+  if (!hasRequired) return null;
+
+  const cleaned: iMetadata<bigint> = {
+    name: typeof parsed.name === 'string' ? parsed.name : '',
+    description: typeof parsed.description === 'string' ? parsed.description : '',
+    image: typeof parsed.image === 'string' ? parsed.image : ''
+  };
+
+  if (typeof parsed.bannerImage === 'string') cleaned.bannerImage = parsed.bannerImage;
+  if (typeof parsed.category === 'string') cleaned.category = parsed.category;
+  if (typeof parsed.externalUrl === 'string') cleaned.externalUrl = parsed.externalUrl;
+
+  const tags = coerceStringArray(parsed.tags);
+  if (tags) cleaned.tags = tags;
+
+  const socials = coerceSocials(parsed.socials);
+  if (socials) cleaned.socials = socials;
+
+  const attributes = coerceAttributes(parsed.attributes);
+  if (attributes) cleaned.attributes = attributes;
+
+  const additionalInfo = coerceAdditionalInfo(parsed.additionalInfo);
+  if (additionalInfo) cleaned.additionalInfo = additionalInfo;
+
+  return new Metadata<bigint>(cleaned).convert(BigIntify);
+}

--- a/packages/bitbadgesjs-sdk/src/api-indexer/metadata/inlineImage.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/metadata/inlineImage.ts
@@ -1,0 +1,79 @@
+/**
+ * Inline image option for zero-hosting metadata.
+ *
+ * Re-export of the deterministic SVG placeholder-art generator that
+ * lives under `builder/generators/placeholder-art/`. Surfaces it as a
+ * public, top-level option for any caller that wants to populate the
+ * `image` field of inline `customData` metadata without uploading to
+ * IPFS or any other host.
+ *
+ * The placeholder-art generator produces 1-8 KB
+ * `data:image/svg+xml;base64,...` URIs that look intentional and live
+ * entirely inside the on-chain JSON. End-to-end zero-hosting:
+ *
+ * ```ts
+ * import { generatePlaceholderArt, parseInlineCustomData } from 'bitbadges';
+ *
+ * const art = generatePlaceholderArt({ seed: 'My Collection' });
+ * const inline = JSON.stringify({
+ *   name: 'My Collection',
+ *   description: '...',
+ *   image: art.imageUri,   // data:image/svg+xml;base64,...
+ * });
+ * // Set on-chain: collectionMetadata.uri = '', collectionMetadata.customData = inline
+ * ```
+ *
+ * Deterministic: the same seed always produces the same art (six
+ * curated presets × 24 palettes, hash-picked from the seed). Pin a
+ * specific look with `style` / `paletteName` if needed.
+ *
+ * ## Cost trade-off — inline SVG is convenient, NOT free
+ *
+ * Inline SVG side-steps IPFS hosting, but the bytes still live on-chain.
+ * You're shifting the cost from a hosting fee to chain gas, not
+ * eliminating it.
+ *
+ * Per the cost-considerations callout in the BitBadges docs
+ * (`token-standard/learn/collection-setup-fields.md#cost-considerations-keep-images-off-chain`):
+ * - Every byte of `customData` is stored on-chain forever.
+ * - Gas runs roughly 10 gas/byte. An 8 KB SVG ≈ ~80,000 gas per write.
+ * - Block size is hard-capped (~1 MB), so very large inline payloads
+ *   start fighting block limits during bulk updates.
+ *
+ * Compared to the alternatives:
+ * - **Inline SVG (this generator)**: zero hosting, ~1-8 KB on-chain,
+ *   ~10-80k gas extra per write, deterministic, no raster detail.
+ *   Great for fungible tokens, subscriptions, vaults, generic
+ *   placeholder-y looks where you don't have art and don't want to
+ *   maintain an IPFS pin.
+ * - **Inline customData with URL image (`ipfs://...`)**: tiny on-chain
+ *   wrapper (~250 B) + IPFS pin for the image only. Cheapest on-chain
+ *   path when you have an image; needs hosting for the image.
+ * - **Full URI mode (`uri` set, `customData` empty)**: smallest
+ *   on-chain footprint (~50 B URL) + IPFS pin for JSON + image.
+ *   Cheapest on-chain when you have any sizable JSON; needs hosting.
+ *
+ * Pick inline SVG when "no hosting setup at all" is worth more than
+ * the extra ~80k gas per write. For high-frequency mints / updates,
+ * or anything image-heavy, prefer a hosted image URL.
+ *
+ * See `parseInlineCustomData` for the read-side resolution.
+ */
+
+export {
+  generatePlaceholderArt,
+  hashSeed,
+  deriveSymbol,
+  resolveStyle,
+  PALETTES,
+  pickPalette,
+  toDataUri,
+  minifySvg,
+  base64Encode,
+  GLYPH_NAMES,
+  type PlaceholderArtStyle,
+  type PlaceholderArtVibe,
+  type GeneratePlaceholderArtInput,
+  type GeneratePlaceholderArtResult,
+  type Palette
+} from '../../builder/generators/placeholder-art/index.js';

--- a/packages/bitbadgesjs-sdk/src/api-indexer/verify-standards.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/verify-standards.ts
@@ -14,6 +14,18 @@
 import { CollectionDoc } from './docs-types/docs.js';
 import { doesCollectionFollowSubscriptionProtocol } from '../core/subscriptions.js';
 import { normalizeForReview } from '../core/review-normalize.js';
+import { parseInlineCustomData } from './metadata/inlineCustomData.js';
+
+/**
+ * True if a metadata entity carries inline JSON in `customData` that
+ * resolves to a valid Metadata via parseInlineCustomData. Used by the
+ * placeholder-URI / missing-URI checks below to suppress warnings for
+ * the inline-customData configuration (Phase 1 of metadata hosting).
+ */
+function hasInlineCustomData(m: any): boolean {
+  if (!m || typeof m !== 'object') return false;
+  return parseInlineCustomData(typeof m.customData === 'string' ? m.customData : '') !== null;
+}
 
 const MAX_UINT64 = 18446744073709551615n;
 const FOREVER = [{ start: 1n, end: MAX_UINT64 }];
@@ -1088,12 +1100,12 @@ function verifyApprovalMetadata(value: any): StandardViolation[] {
     // Check: if the collection uses placeholder metadata pattern, approvals should match
     const collUri = value.collectionMetadata?.uri || '';
     const usesPlaceholders = collUri.startsWith('ipfs://METADATA_');
-    if (usesPlaceholders && (!a.uri || a.uri === '')) {
+    if (usesPlaceholders && (!a.uri || a.uri === '') && !hasInlineCustomData(a)) {
       violations.push({
         standard: 'Common',
         field: `collectionApprovals[${id}].uri`,
-        message: `Approval "${id}" has no metadata URI. All approvals should have a placeholder URI (e.g. "ipfs://METADATA_APPROVAL_${id.toUpperCase().replace(/[^A-Z0-9]/g, '_')}") with corresponding metadata set via set_metadata_placeholders. The frontend renders approval cards and needs name/description/image for each.`,
-        fix: `Set uri to a placeholder like "ipfs://METADATA_APPROVAL_${id.toUpperCase().replace(/[^A-Z0-9]/g, '_')}" and call set_metadata_placeholders with a descriptive name and description for this approval.`
+        message: `Approval "${id}" has no metadata URI. All approvals should have a placeholder URI (e.g. "ipfs://METADATA_APPROVAL_${id.toUpperCase().replace(/[^A-Z0-9]/g, '_')}") with corresponding metadata set via set_metadata_placeholders, OR carry inline JSON metadata in customData. The frontend renders approval cards and needs name/description for each.`,
+        fix: `Set uri to a placeholder like "ipfs://METADATA_APPROVAL_${id.toUpperCase().replace(/[^A-Z0-9]/g, '_')}" and call set_metadata_placeholders with a descriptive name and description, or write {"name":"...","description":"..."} JSON into customData.`
       });
     }
   }
@@ -1366,12 +1378,16 @@ function verifyMetadataPlaceholders(value: any): StandardViolation[] {
         message: `Alias path "${ap.denom || i}" is missing PathMetadata entirely. All alias paths MUST have metadata: { uri, customData }.`,
         fix: `Add metadata: { uri: "ipfs://METADATA_ALIAS_${ap.denom || '<DENOM>'}", customData: "" } and upload the image inside the JSON at that URI via the auto-apply flow.`
       });
-    } else if (isFakeOrMissingUri(ap.metadata?.uri) && !isPreApplyMetadata(ap.metadata)) {
+    } else if (
+      isFakeOrMissingUri(ap.metadata?.uri) &&
+      !isPreApplyMetadata(ap.metadata) &&
+      !hasInlineCustomData(ap.metadata)
+    ) {
       violations.push({
         standard: std,
         field: `aliasPathsToAdd[${i}].metadata.uri`,
-        message: `Alias path "${ap.denom || i}" metadata.uri is missing or is a fake placeholder. The image must live inside the off-chain JSON at this URI.`,
-        fix: `Set metadata.uri to a placeholder like "ipfs://METADATA_ALIAS_${ap.denom || '<DENOM>'}" (the metadata auto-apply flow replaces this with a real upload) or to a real uploaded URI directly.`
+        message: `Alias path "${ap.denom || i}" metadata.uri is missing or is a fake placeholder, and metadata.customData does not carry inline JSON metadata. The image must live inside the off-chain JSON at this URI (or inline in customData).`,
+        fix: `Set metadata.uri to a placeholder like "ipfs://METADATA_ALIAS_${ap.denom || '<DENOM>'}" (the metadata auto-apply flow replaces this with a real upload), to a real uploaded URI directly, or stash {"name":"...","image":"...","description":"..."} JSON in metadata.customData.`
       });
     }
     if ('image' in (ap.metadata || {})) {
@@ -1393,12 +1409,16 @@ function verifyMetadataPlaceholders(value: any): StandardViolation[] {
             message: `Denom unit "${du.symbol || j}" is missing PathMetadata entirely. All denomUnits MUST have metadata: { uri, customData }.`,
             fix: `Add metadata: { uri: "ipfs://METADATA_ALIAS_${ap.denom || '<DENOM>'}_UNIT", customData: "" }.`
           });
-        } else if (isFakeOrMissingUri(du.metadata?.uri) && !isPreApplyMetadata(du.metadata)) {
+        } else if (
+          isFakeOrMissingUri(du.metadata?.uri) &&
+          !isPreApplyMetadata(du.metadata) &&
+          !hasInlineCustomData(du.metadata)
+        ) {
           violations.push({
             standard: std,
             field: `aliasPathsToAdd[${i}].denomUnits[${j}].metadata.uri`,
-            message: `Denom unit "${du.symbol || j}" metadata.uri is missing or is a fake placeholder.`,
-            fix: `Set metadata.uri to a placeholder like "ipfs://METADATA_ALIAS_${ap.denom || '<DENOM>'}_UNIT" or to a real uploaded URI directly.`
+            message: `Denom unit "${du.symbol || j}" metadata.uri is missing or is a fake placeholder, and metadata.customData does not carry inline JSON metadata.`,
+            fix: `Set metadata.uri to a placeholder like "ipfs://METADATA_ALIAS_${ap.denom || '<DENOM>'}_UNIT", to a real uploaded URI directly, or stash inline JSON metadata in metadata.customData.`
           });
         }
         if ('image' in (du.metadata || {})) {
@@ -1424,12 +1444,12 @@ function verifyMetadataPlaceholders(value: any): StandardViolation[] {
         message: `Cosmos coin wrapper path is missing PathMetadata entirely. MUST have metadata: { uri, customData }.`,
         fix: `Add metadata: { uri: "ipfs://METADATA_WRAPPER_${wp.denom || '<DENOM>'}", customData: "" }.`
       });
-    } else if (isFakeOrMissingUri(wp.metadata?.uri)) {
+    } else if (isFakeOrMissingUri(wp.metadata?.uri) && !hasInlineCustomData(wp.metadata)) {
       violations.push({
         standard: std,
         field: `cosmosCoinWrapperPathsToAdd[${i}].metadata.uri`,
-        message: `Cosmos coin wrapper path metadata.uri is missing or is a fake placeholder.`,
-        fix: `Set metadata.uri to a placeholder like "ipfs://METADATA_WRAPPER_${wp.denom || '<DENOM>'}" or a real uploaded URI.`
+        message: `Cosmos coin wrapper path metadata.uri is missing or is a fake placeholder, and metadata.customData does not carry inline JSON metadata.`,
+        fix: `Set metadata.uri to a placeholder like "ipfs://METADATA_WRAPPER_${wp.denom || '<DENOM>'}", a real uploaded URI, or stash inline JSON metadata in metadata.customData.`
       });
     }
     if ('image' in (wp.metadata || {})) {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/templates.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/templates.ts
@@ -1,12 +1,6 @@
 import { Command } from 'commander';
 import { output, readJsonInput } from '../utils/io.js';
-import {
-  renderReview,
-  renderValidate,
-  renderMetadataPlaceholders,
-  collectMetadataPlaceholders,
-  renderSimulate
-} from '../utils/terminal.js';
+import { renderReview, renderValidate, renderResolvedMetadata, renderSimulate } from '../utils/terminal.js';
 import { isCollectionMsg, normalizeToCreateOrUpdate } from '../utils/normalizeMsg.js';
 import { addNetworkOptions } from '../utils/io.js';
 
@@ -97,51 +91,6 @@ async function emit(
     }
   }
 
-  // Pre-fill the metadataPlaceholders sidecar from the user's --name /
-  // --description / --image flags. Walk every placeholder URI in the tx
-  // and supply the user's content for any URI the template didn't already
-  // populate. Approval URIs derive a name from the approvalId so the
-  // user's "My Vault" doesn't accidentally label every approval as
-  // "My Vault" — they keep their own descriptive default.
-  if (isCollectionTx && (opts.name || opts.description || opts.image)) {
-    const meta = (data.value._meta = data.value._meta || {});
-    const sidecar: Record<string, { name: string; description: string; image: string }> = (meta.metadataPlaceholders =
-      meta.metadataPlaceholders || {});
-    const fallbackName = opts.name || 'Untitled';
-    const fallbackDescription = opts.description || '';
-    const fallbackImage = opts.image || 'ipfs://QmNTpizCkY5tcMpPMf1kkn7Y5YxFQo3oT54A9oKP5ijP9E';
-    const found = collectMetadataPlaceholders(data);
-    for (const p of found) {
-      if (sidecar[p.uri]) continue; // already filled by the template
-      // Approval / alias / wrapper / denom-unit URIs should keep a
-      // descriptive default rooted in their own identifier rather than
-      // the user's collection name.
-      if (p.uri.startsWith('ipfs://METADATA_APPROVAL_')) {
-        const approvalId = p.uri.replace('ipfs://METADATA_APPROVAL_', '');
-        sidecar[p.uri] = {
-          name: approvalId.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
-          description: '',
-          image: '' // approval images MUST be empty per the standards
-        };
-        continue;
-      }
-      if (p.uri.startsWith('ipfs://METADATA_ALIAS_') || p.uri.startsWith('ipfs://METADATA_WRAPPER_')) {
-        sidecar[p.uri] = {
-          name: `${fallbackName} ${p.uri.startsWith('ipfs://METADATA_ALIAS_') ? 'alias path' : 'wrapper path'}`,
-          description: fallbackDescription,
-          image: fallbackImage
-        };
-        continue;
-      }
-      // Collection / token / anything else gets the user's flag values.
-      sidecar[p.uri] = {
-        name: fallbackName,
-        description: fallbackDescription,
-        image: fallbackImage
-      };
-    }
-  }
-
   // Emit the JSON payload FIRST. Scroll order on an interactive terminal
   // naturally puts the most recently-written bytes at the bottom, so the
   // review summary appearing *after* the JSON means the user's final
@@ -151,18 +100,9 @@ async function emit(
   // TTYs, so writing JSON before the stderr review keeps the visible
   // order stable across both cases.
   //
-  // We deliberately keep `value._meta.metadataPlaceholders` on the emitted
-  // JSON so that re-reading the file via `bitbadges-cli builder verify` (or
-  // any other downstream tool that walks the same sidecar) preserves the
-  // PROVIDED state. Chain proto serialization drops unknown fields on
-  // `value`, so the `_meta` annotation never reaches the wire — it's
-  // purely a CLI / off-chain pipeline annotation scoped to this specific
-  // msg. Narrow Universal → MsgCreateCollection / MsgUpdateCollection
-  // right at the write boundary. Agents and humans see the proto's real
-  // per-intent message type; only legacy internal tooling sees the
-  // Universal superset. The `value._meta.metadataPlaceholders` sidecar is
-  // preserved — it rides on the same msg.value and the chain strips
-  // unknown fields on serialization.
+  // Narrow Universal → MsgCreateCollection / MsgUpdateCollection right at
+  // the write boundary. Agents and humans see the proto's real per-intent
+  // message type; only legacy internal tooling sees the Universal superset.
   const outData = isCollectionTx ? normalizeToCreateOrUpdate(data) : data;
   output(outData, { condensed: opts.condensed, outputFile: opts.outputFile });
 
@@ -212,23 +152,15 @@ async function emit(
       process.stderr.write(`Review skipped: ${err instanceof Error ? err.message : String(err)}\n`);
     }
 
-    // Metadata To Upload — every placeholder URI on the tx that the
-    // metadata auto-apply flow will later substitute. The user (or a
-    // downstream tool) needs to produce JSON for each of these URIs and
-    // upload it somewhere the chain can resolve before broadcast.
+    // Resolved Metadata — the final on-chain `(uri, customData)` pairs
+    // for every metadata-bearing entity in this tx, after the two-mode
+    // resolution. Helps the user verify they got the mode they expected
+    // (URI mode keeps customData empty; inline mode keeps uri empty and
+    // surfaces a parsed name/image preview from customData).
     try {
-      const placeholders = collectMetadataPlaceholders(data);
-      if (placeholders.length > 0) {
-        process.stderr.write(
-          '\n' +
-            renderMetadataPlaceholders(placeholders, data.value?._meta?.metadataPlaceholders, {
-              stream: process.stderr
-            }) +
-            '\n'
-        );
-      }
+      process.stderr.write('\n' + renderResolvedMetadata(data, { stream: process.stderr }) + '\n');
     } catch (err) {
-      process.stderr.write(`Metadata placeholder scan skipped: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.stderr.write(`Resolved-metadata preview skipped: ${err instanceof Error ? err.message : String(err)}\n`);
     }
 
     // Auto-Simulate — opt-in via --simulate. Posts to the BitBadges API's
@@ -300,17 +232,13 @@ async function emit(
   }
 }
 
-// renderValidate, renderMetadataPlaceholders, and collectMetadataPlaceholders
-// live in src/cli/utils/terminal.ts so the standalone `builder verify`
-// command and the templates auto-review path share one implementation.
+// renderValidate and renderResolvedMetadata live in src/cli/utils/terminal.ts.
 
 /**
  * Add a shared option only if the per-template command hasn't already
  * declared it. Avoids commander "duplicate flag" errors for templates
  * (vault, subscription, bounty, …) that already define their own --name
- * / --description / --image flags. Those template-level flags double as
- * the metadataPlaceholders content because emit() reads opts.name etc.
- * directly — no extra plumbing needed.
+ * / --description / --image / --uri flags.
  */
 function addOptionIfMissing(cmd: Command, flags: string, description: string): Command {
   const longFlag = flags.match(/--[a-z][a-z0-9-]*/)?.[0];
@@ -333,12 +261,18 @@ const sharedOpts = (cmd: Command) => {
   // API, but we add the flags universally so `templates vault
   // --simulate --network local` works without parser surprises.
   addNetworkOptions(cmd);
-  // Metadata flags — only added when the template doesn't already declare
-  // them. Templates that DO declare them keep their own description string;
-  // emit() reads opts.name / description / image regardless.
-  addOptionIfMissing(cmd, '--name <name>', 'Display name written into unfilled metadataPlaceholders entries (collection / tokens / alias paths)');
-  addOptionIfMissing(cmd, '--description <text>', 'Description written into unfilled metadataPlaceholders entries');
-  addOptionIfMissing(cmd, '--image <url>', 'Image URL written into unfilled metadataPlaceholders entries');
+  // Two-mode metadata flags — every metadata-bearing template accepts
+  // EITHER `--uri <pre-hosted-uri>` (the on-chain `uri` field gets the
+  // value, customData stays empty) OR the per-preset field flags
+  // `--name <name>` + `--image <url>` + `--description <text>` (which
+  // are serialized to JSON into the on-chain `customData` field, with
+  // `uri` left empty). The builder throws MetadataMissingError if
+  // neither mode is satisfied. Approval-only templates omit `--image`
+  // (approvals are text-only).
+  addOptionIfMissing(cmd, '--uri <url>', 'Mode 1: pre-hosted metadata URI (skips the per-field flags below)');
+  addOptionIfMissing(cmd, '--name <name>', 'Mode 2: collection name (required with --image + --description if --uri not set)');
+  addOptionIfMissing(cmd, '--description <text>', 'Mode 2: collection description (required with --name + --image if --uri not set)');
+  addOptionIfMissing(cmd, '--image <url>', 'Mode 2: collection image URI (required with --name + --description if --uri not set)');
   return cmd;
 };
 
@@ -349,12 +283,9 @@ const sharedOpts = (cmd: Command) => {
 sharedOpts(
   templatesCommand
     .command('vault')
-    .description('Create an IBC-backed vault token')
+    .description('Create an IBC-backed vault token. Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--backing-coin <symbol>', 'Backing coin symbol (USDC, BADGE, ATOM, OSMO)')
-    .option('--name <name>', 'Collection name', 'Vault')
     .option('--symbol <symbol>', 'Display symbol (e.g. vUSDC)')
-    .option('--image <url>', 'Image URL')
-    .option('--description <text>', 'Description')
     .option('--daily-withdraw-limit <n>', 'Max daily withdrawal (display units)')
     .option('--require-2fa <collectionId>', '2FA collection ID for withdrawal gating')
     .option('--emergency-recovery <address>', 'Recovery address for emergency migration')
@@ -362,7 +293,7 @@ sharedOpts(
   const { buildVault } = await import('../../core/builders/vault.js');
   if (opts.json) { emit(buildVault(readJsonInput(opts.json)), opts); return; }
   emit(buildVault({
-    backingCoin: opts.backingCoin, name: opts.name, symbol: opts.symbol, image: opts.image,
+    backingCoin: opts.backingCoin, uri: opts.uri, name: opts.name, symbol: opts.symbol, image: opts.image,
     description: opts.description, dailyWithdrawLimit: opts.dailyWithdrawLimit ? Number(opts.dailyWithdrawLimit) : undefined,
     require2fa: opts.require2fa, emergencyRecovery: opts.emergencyRecovery
   }), opts);
@@ -371,7 +302,7 @@ sharedOpts(
 sharedOpts(
   templatesCommand
     .command('subscription')
-    .description('Create a recurring subscription collection')
+    .description('Create a recurring subscription collection. Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--interval <duration>', 'Interval: daily, monthly, annually, or shorthand (30d)')
     .option('--price <amount>', 'Price per interval (display units) — use with --denom/--recipient')
     .option('--denom <symbol>', 'Payment coin (USDC, BADGE)')
@@ -379,11 +310,18 @@ sharedOpts(
     .option('--payouts <json>', 'Multiple payouts JSON: [{"recipient","amount","denom"}]')
     .option('--tiers <n>', 'Number of tiers', '1')
     .option('--transferable', 'Allow post-mint P2P transfers')
-    .option('--name <name>', 'Collection name', 'Subscription')
 ).action(async (opts) => {
   const { buildSubscription } = await import('../../core/builders/subscription.js');
   if (opts.json) { emit(buildSubscription(readJsonInput(opts.json)), opts); return; }
-  const params: any = { interval: opts.interval, tiers: Number(opts.tiers), transferable: !!opts.transferable, name: opts.name };
+  const params: any = {
+    interval: opts.interval,
+    tiers: Number(opts.tiers),
+    transferable: !!opts.transferable,
+    uri: opts.uri,
+    name: opts.name,
+    description: opts.description,
+    image: opts.image
+  };
   if (opts.payouts) {
     params.payouts = JSON.parse(opts.payouts);
   } else {
@@ -397,30 +335,31 @@ sharedOpts(
 sharedOpts(
   templatesCommand
     .command('bounty')
-    .description('Create a bounty escrow collection')
+    .description('Create a bounty escrow collection. Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--amount <n>', 'Bounty amount (display units)')
     .requiredOption('--denom <symbol>', 'Coin (USDC, BADGE)')
     .requiredOption('--verifier <address>', 'Verifier address (bb1...)')
     .requiredOption('--recipient <address>', 'Recipient address (bb1...)')
     .option('--expiration <duration>', 'Expiration duration', '30d')
-    .option('--name <name>', 'Collection name', 'Bounty')
 ).action(async (opts) => {
   const { buildBounty } = await import('../../core/builders/bounty.js');
   if (opts.json) { emit(buildBounty(readJsonInput(opts.json)), opts); return; }
-  emit(buildBounty({ amount: Number(opts.amount), denom: opts.denom, verifier: opts.verifier, recipient: opts.recipient, expiration: opts.expiration, name: opts.name }), opts);
+  emit(buildBounty({
+    amount: Number(opts.amount), denom: opts.denom, verifier: opts.verifier, recipient: opts.recipient,
+    expiration: opts.expiration, uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
+  }), opts);
 });
 
 sharedOpts(
   templatesCommand
     .command('payment-request')
-    .description('Create an agent-initiated payment request (no-escrow inverse of bounty)')
+    .description('Create an agent-initiated payment request (no-escrow inverse of bounty). Metadata: pass --uri OR --name + --image + (--description OR --context).')
     .requiredOption('--amount <n>', 'Payment amount (display units)')
     .requiredOption('--denom <symbol>', 'Coin (USDC, BADGE)')
     .requiredOption('--payer <address>', 'Payer address (bb1...) — the human approver')
     .requiredOption('--recipient <address>', 'Recipient address (bb1...) — agent/merchant')
     .option('--expiration <duration>', 'Expiration duration', '30d')
-    .option('--name <name>', 'Collection name', 'Payment Request')
-    .option('--context <text>', 'Rationale shown to the payer at approval time (≥100 chars recommended)')
+    .option('--context <text>', 'Rationale shown to the payer at approval time (≥100 chars recommended). Used as the inline description if --description not set.')
 ).action(async (opts) => {
   const { buildPaymentRequest } = await import('../../core/builders/payment-request.js');
   if (opts.json) { emit(buildPaymentRequest(readJsonInput(opts.json)), opts); return; }
@@ -430,141 +369,155 @@ sharedOpts(
     payer: opts.payer,
     recipient: opts.recipient,
     expiration: opts.expiration,
+    uri: opts.uri,
     name: opts.name,
-    context: opts.context
+    image: opts.image,
+    context: opts.context || opts.description
   }), opts);
 });
 
 sharedOpts(
   templatesCommand
     .command('crowdfund')
-    .description('Create a crowdfunding collection')
+    .description('Create a crowdfunding collection. Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--goal <n>', 'Funding goal (display units)')
     .requiredOption('--denom <symbol>', 'Coin (USDC, BADGE)')
     .option('--crowdfunder <address>', 'Who receives funds on success (bb1...)')
     .option('--deadline <duration>', 'Deadline duration', '30d')
-    .option('--name <name>', 'Collection name', 'Crowdfund')
 ).action(async (opts) => {
   const { buildCrowdfund } = await import('../../core/builders/crowdfund.js');
   if (opts.json) { emit(buildCrowdfund(readJsonInput(opts.json)), opts); return; }
-  emit(buildCrowdfund({ goal: Number(opts.goal), denom: opts.denom, crowdfunder: opts.crowdfunder, deadline: opts.deadline, name: opts.name, creator: opts.creator }), opts);
+  emit(buildCrowdfund({
+    goal: Number(opts.goal), denom: opts.denom, crowdfunder: opts.crowdfunder, deadline: opts.deadline,
+    uri: opts.uri, name: opts.name, description: opts.description, image: opts.image, creator: opts.creator
+  }), opts);
 });
 
 sharedOpts(
   templatesCommand
     .command('auction')
-    .description('Create an auction collection')
+    .description('Create an auction collection. Metadata: pass --uri OR --name + --image + --description.')
     .option('--bid-deadline <duration>', 'Bidding window', '7d')
     .option('--accept-window <duration>', 'Accept window after bid deadline', '7d')
-    .option('--name <name>', 'Item name', 'Auction')
-    .option('--description <text>', 'Item description')
-    .option('--image <url>', 'Item image URL')
     .option('--seller <address>', 'Seller address — only this address can accept the winning bid (defaults to --creator)')
 ).action(async (opts) => {
   const { buildAuction } = await import('../../core/builders/auction.js');
   if (opts.json) { emit(buildAuction(readJsonInput(opts.json)), opts); return; }
-  emit(buildAuction({ bidDeadline: opts.bidDeadline, acceptWindow: opts.acceptWindow, name: opts.name, description: opts.description, image: opts.image, seller: opts.seller, creator: opts.creator }), opts);
+  emit(buildAuction({
+    bidDeadline: opts.bidDeadline, acceptWindow: opts.acceptWindow,
+    uri: opts.uri, name: opts.name, description: opts.description, image: opts.image,
+    seller: opts.seller, creator: opts.creator
+  }), opts);
 });
 
 sharedOpts(
   templatesCommand
     .command('product-catalog')
-    .description('Create a product catalog collection')
-    .requiredOption('--products <json>', 'Product array JSON: [{"name","price","denom","maxSupply?","burn?"}]')
+    .description('Create a product catalog collection. Metadata: pass --uri OR --name + --image + --description (per-product image/description live inside the products JSON).')
+    .requiredOption('--products <json>', 'Product array JSON: [{"name","price","denom","maxSupply?","burn?","uri?","image?","description?"}]')
     .requiredOption('--store-address <address>', 'Payment recipient (bb1...)')
-    .option('--name <name>', 'Collection name', 'Product Catalog')
 ).action(async (opts) => {
   const { buildProductCatalog } = await import('../../core/builders/product-catalog.js');
   if (opts.json) { emit(buildProductCatalog(readJsonInput(opts.json)), opts); return; }
   const products = JSON.parse(opts.products);
-  emit(buildProductCatalog({ products, storeAddress: opts.storeAddress, name: opts.name }), opts);
+  emit(buildProductCatalog({
+    products, storeAddress: opts.storeAddress,
+    uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
+  }), opts);
 });
 
 sharedOpts(
   templatesCommand
     .command('prediction-market')
-    .description('Create a binary prediction market (YES/NO)')
+    .description('Create a binary prediction market (YES/NO). Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--verifier <address>', 'Market resolver address (bb1...)')
     .option('--denom <symbol>', 'Payment coin', 'USDC')
-    .option('--name <name>', 'Market question', 'Prediction Market')
-    .option('--description <text>', 'Market details')
-    .option('--image <url>', 'Market image URL')
 ).action(async (opts) => {
   const { buildPredictionMarket } = await import('../../core/builders/prediction-market.js');
   if (opts.json) { emit(buildPredictionMarket(readJsonInput(opts.json)), opts); return; }
-  emit(buildPredictionMarket({ verifier: opts.verifier, denom: opts.denom, name: opts.name, description: opts.description, image: opts.image }), opts);
+  emit(buildPredictionMarket({
+    verifier: opts.verifier, denom: opts.denom,
+    uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
+  }), opts);
 });
 
 sharedOpts(
   templatesCommand
     .command('smart-account')
-    .description('Create an IBC-backed smart account')
+    .description('Create an IBC-backed smart account. Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--backing-coin <symbol>', 'Backing coin (USDC, BADGE, ATOM, OSMO)')
     .option('--symbol <symbol>', 'Display symbol')
-    .option('--image <url>', 'Token image URL')
     .option('--tradable', 'Enable liquidity pool trading')
     .option('--ai-agent-vault', 'Add AI Agent Vault standard tag')
 ).action(async (opts) => {
   const { buildSmartAccount } = await import('../../core/builders/smart-account.js');
   if (opts.json) { emit(buildSmartAccount(readJsonInput(opts.json)), opts); return; }
-  emit(buildSmartAccount({ backingCoin: opts.backingCoin, symbol: opts.symbol, image: opts.image, tradable: !!opts.tradable, aiAgentVault: !!opts.aiAgentVault }), opts);
+  emit(buildSmartAccount({
+    backingCoin: opts.backingCoin, symbol: opts.symbol, tradable: !!opts.tradable, aiAgentVault: !!opts.aiAgentVault,
+    uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
+  }), opts);
 });
 
 sharedOpts(
   templatesCommand
     .command('credit-token')
-    .description('Create a credit/prepaid token')
+    .description('Create a credit/prepaid token. Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--payment-denom <symbol>', 'Payment coin (USDC, BADGE)')
     .requiredOption('--recipient <address>', 'Payment recipient (bb1...)')
     .option('--symbol <symbol>', 'Token symbol', 'CREDIT')
     .option('--tokens-per-unit <n>', 'Tokens per 1 display unit of payment', '100')
-    .option('--name <name>', 'Collection name', 'Credit Token')
 ).action(async (opts) => {
   const { buildCreditToken } = await import('../../core/builders/credit-token.js');
   if (opts.json) { emit(buildCreditToken(readJsonInput(opts.json)), opts); return; }
-  emit(buildCreditToken({ paymentDenom: opts.paymentDenom, recipient: opts.recipient, symbol: opts.symbol, tokensPerUnit: Number(opts.tokensPerUnit), name: opts.name }), opts);
+  emit(buildCreditToken({
+    paymentDenom: opts.paymentDenom, recipient: opts.recipient, symbol: opts.symbol,
+    tokensPerUnit: Number(opts.tokensPerUnit),
+    uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
+  }), opts);
 });
 
 sharedOpts(
   templatesCommand
     .command('custom-2fa')
-    .description('Create a custom 2FA token')
-    .requiredOption('--name <name>', 'Token name')
-    .option('--image <url>', 'Token image URL')
-    .option('--description <text>', 'Description')
+    .description('Create a custom 2FA token. Metadata: pass --uri OR --name + --image + --description.')
     .option('--burnable', 'Allow burning')
     .option('--transferable', 'Allow post-mint P2P transfers')
 ).action(async (opts) => {
   const { buildCustom2FA } = await import('../../core/builders/custom-2fa.js');
   if (opts.json) { emit(buildCustom2FA(readJsonInput(opts.json)), opts); return; }
-  emit(buildCustom2FA({ name: opts.name, image: opts.image, description: opts.description, burnable: !!opts.burnable, transferable: !!opts.transferable }), opts);
+  emit(buildCustom2FA({
+    uri: opts.uri, name: opts.name, image: opts.image, description: opts.description,
+    burnable: !!opts.burnable, transferable: !!opts.transferable
+  }), opts);
 });
 
 sharedOpts(
   templatesCommand
     .command('quests')
-    .description('Create a quest/reward collection')
+    .description('Create a quest/reward collection. Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--reward <n>', 'Reward per claim (display units)')
     .requiredOption('--denom <symbol>', 'Reward coin (USDC, BADGE)')
     .requiredOption('--max-claims <n>', 'Maximum number of claims')
-    .option('--name <name>', 'Collection name', 'Quest')
 ).action(async (opts) => {
   const { buildQuests } = await import('../../core/builders/quests.js');
   if (opts.json) { emit(buildQuests(readJsonInput(opts.json)), opts); return; }
-  emit(buildQuests({ reward: Number(opts.reward), denom: opts.denom, maxClaims: Number(opts.maxClaims), name: opts.name }), opts);
+  emit(buildQuests({
+    reward: Number(opts.reward), denom: opts.denom, maxClaims: Number(opts.maxClaims),
+    uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
+  }), opts);
 });
 
 sharedOpts(
   templatesCommand
     .command('address-list')
-    .description('Create an on-chain address list')
-    .requiredOption('--name <name>', 'List name')
-    .option('--image <url>', 'List image URL')
-    .option('--description <text>', 'Description')
+    .description('Create an on-chain address list. Metadata: pass --uri OR --name + --image + --description.')
 ).action(async (opts) => {
   const { buildAddressList } = await import('../../core/builders/address-list.js');
   if (opts.json) { emit(buildAddressList(readJsonInput(opts.json)), opts); return; }
-  emit(buildAddressList({ name: opts.name, image: opts.image, description: opts.description, manager: opts.manager, creator: opts.creator }), opts);
+  emit(buildAddressList({
+    uri: opts.uri, name: opts.name, image: opts.image, description: opts.description,
+    manager: opts.manager, creator: opts.creator
+  }), opts);
 });
 
 // ============================================================

--- a/packages/bitbadgesjs-sdk/src/cli/commands/templates.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/templates.ts
@@ -1,8 +1,9 @@
 import { Command } from 'commander';
-import { output, readJsonInput } from '../utils/io.js';
+import { output, readJsonInput, addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
 import { renderReview, renderValidate, renderResolvedMetadata, renderSimulate } from '../utils/terminal.js';
 import { isCollectionMsg, normalizeToCreateOrUpdate } from '../utils/normalizeMsg.js';
-import { addNetworkOptions } from '../utils/io.js';
+import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
+import { runBurnerCreate, pickBurner, type BurnerNetwork } from '../utils/burner.js';
 
 export const templatesCommand = new Command('templates').description('Deterministic transaction templates — flag-based generators for vaults, NFTs, subscriptions, bounties, and more.');
 
@@ -24,11 +25,26 @@ async function emit(
     simulate?: boolean;
     events?: boolean;
     // Network selection — passed through addNetworkOptions on the
-    // shared sharedOpts() helper. Only consulted when --simulate is on.
+    // shared sharedOpts() helper. Consulted by --simulate AND
+    // --deploy-with-burner.
     network?: 'mainnet' | 'local' | 'testnet';
     testnet?: boolean;
     local?: boolean;
     url?: string;
+    nodeUrl?: string;
+    apiKey?: string;
+    // --deploy-with-burner — broadcast the just-built msg via the
+    // ephemeral burner flow, equivalent to piping the JSON output
+    // into `bb cli builder create-with-burner`.
+    deployWithBurner?: boolean;
+    fund?: 'faucet' | 'manual';
+    fee?: string;
+    feeDenom?: string;
+    gas?: string | number;
+    new?: boolean;
+    reuse?: string;
+    nonInteractive?: boolean;
+    pollTimeout?: string | number;
   }
 ) {
   // User-level approval templates produce
@@ -230,6 +246,73 @@ async function emit(
       '\nAuto-Simulate skipped — wrap user-level approvals inside an alternative approval message to simulate end-to-end. Auto-Validate ran above.\n'
     );
   }
+
+  // ── --deploy-with-burner ────────────────────────────────────────────────
+  // Composes the template + create-with-burner pipeline into one step.
+  // Equivalent to piping the JSON output to `bb cli builder
+  // create-with-burner --msg-stdin --manager <addr>`. CREATE-ONLY: the
+  // burner flow rejects updates, transfers, approvals — runBurnerCreate
+  // throws a clear error if the resolved msg isn't MsgCreateCollection
+  // (or MsgUniversalUpdateCollection with collectionId=0).
+  if (opts.deployWithBurner) {
+    if (!opts.manager) {
+      process.stderr.write(
+        '\nError: --deploy-with-burner requires --manager <bb1...>. The burner is a throwaway signer; the manager address captures lasting collection ownership.\n'
+      );
+      process.exit(2);
+    }
+
+    const networkName = resolveNetwork(opts);
+    const network: BurnerNetwork = networkName as NetworkMode;
+    const apiUrl = getApiUrl(opts);
+    const nodeUrl = (opts as any).nodeUrl || NETWORK_CONFIGS[network].nodeUrl;
+    const apiKey = getApiKeyForNetwork(opts);
+
+    if ((opts.fund ?? 'faucet') === 'faucet' && !apiKey && network !== 'local') {
+      process.stderr.write(
+        'Warning: --fund faucet requires an API key on non-local networks. Set BITBADGES_API_KEY or `bb cli config set apiKey <key>`.\n'
+      );
+    }
+
+    const choice = await pickBurner({
+      network,
+      nodeUrl,
+      forceNew: Boolean(opts.new),
+      reuseSelector: opts.reuse
+    });
+
+    try {
+      const result = await runBurnerCreate({
+        msg: outData,
+        network,
+        apiUrl,
+        nodeUrl,
+        manager: opts.manager,
+        fund: opts.fund === 'manual' ? 'manual' : 'faucet',
+        apiKey,
+        fee: { amount: String(opts.fee ?? '0'), denom: String(opts.feeDenom ?? 'ubadge') },
+        gas: Number(opts.gas ?? 400000),
+        reuseRecord: choice.kind === 'reuse' ? choice.record : undefined,
+        nonInteractive: Boolean(opts.nonInteractive) || !process.stdout.isTTY,
+        pollTimeoutMs: Number(opts.pollTimeout ?? 60) * 1000
+      });
+
+      const payload = {
+        success: result.success,
+        ephemeralAddress: result.ephemeralAddress,
+        recoveryPath: result.recoveryPath,
+        txHash: result.txHash,
+        collectionId: result.collectionId ?? null,
+        paused: result.paused,
+        error: result.error
+      };
+      process.stdout.write('\n' + JSON.stringify(payload, null, 2) + '\n');
+      if (!result.success && !result.paused) process.exit(1);
+    } catch (err: any) {
+      process.stderr.write(`Burner deploy failed: ${err?.message || err}\n`);
+      process.exit(1);
+    }
+  }
 }
 
 // renderValidate and renderResolvedMetadata live in src/cli/utils/terminal.ts.
@@ -273,6 +356,20 @@ const sharedOpts = (cmd: Command) => {
   addOptionIfMissing(cmd, '--name <name>', 'Mode 2: collection name (required with --image + --description if --uri not set)');
   addOptionIfMissing(cmd, '--description <text>', 'Mode 2: collection description (required with --name + --image if --uri not set)');
   addOptionIfMissing(cmd, '--image <url>', 'Mode 2: collection image URI (required with --name + --description if --uri not set)');
+  // --deploy-with-burner — collapses the template + create-with-burner
+  // pipeline into a single command. CREATE-ONLY: rejects updates,
+  // transfers, approvals (the burner is a one-shot signer; ownership
+  // lives on --manager). Equivalent to:
+  //   bb cli builder templates <preset> ... | bb cli builder create-with-burner --msg-stdin --manager <addr>
+  cmd.option('--deploy-with-burner', 'After building, broadcast via the throwaway burner flow (CREATE-ONLY). Requires --manager.');
+  cmd.option('--fund <mode>', 'When deploying: funding source for the burner (faucet | manual)', 'faucet');
+  cmd.option('--fee <amount>', 'When deploying: fee amount in base units', '0');
+  cmd.option('--fee-denom <denom>', 'When deploying: fee denom', 'ubadge');
+  cmd.option('--gas <number>', 'When deploying: gas limit', '400000');
+  cmd.option('--new', 'When deploying: skip the burner picker and always create a fresh wallet');
+  cmd.option('--reuse <selector>', 'When deploying: reuse a specific saved burner by address or recovery file path');
+  cmd.option('--non-interactive', 'When deploying: never prompt; on any prompt point save state and exit for later resume');
+  cmd.option('--poll-timeout <seconds>', 'When deploying: seconds to wait for funding to land before prompting/exiting', '60');
   return cmd;
 };
 

--- a/packages/bitbadgesjs-sdk/src/cli/utils/terminal.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/terminal.ts
@@ -810,8 +810,20 @@ export function renderMetadataPlaceholders(
   lines.push(
     c(
       'dim',
-      '  Upload each Needed entry as off-chain JSON (name, description, image) and\n' +
-        '  substitute the placeholder URI with the real upload URI before broadcast.'
+      '  For each Needed entry, choose a hosting option:\n' +
+        '\n' +
+        '  • IPFS (Pinata, web3.storage, etc.) — durable, content-addressed.\n' +
+        '    Most common path. Substitute the placeholder URI with ipfs://<cid>.\n' +
+        '\n' +
+        '  • HTTPS host (S3, your own server) — chain stores the URL only.\n' +
+        '    No permanence guarantee — if the host goes down or the URL changes,\n' +
+        '    the metadata is lost.\n' +
+        '\n' +
+        '  • Inline on-chain via customData — set uri to "" and put the JSON in\n' +
+        '    customData directly. No hosting, ~250B on-chain wrapper. Example:\n' +
+        '      uri: "",\n' +
+        '      customData: \'{"name":"...","description":"...","image":"ipfs://..."}\'\n' +
+        '    Image stays a URL — do NOT inline image bytes (gas cost).'
     )
   );
   lines.push(c('gray', rule('━', width)));

--- a/packages/bitbadgesjs-sdk/src/cli/utils/terminal.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/terminal.ts
@@ -817,3 +817,186 @@ export function renderMetadataPlaceholders(
   lines.push(c('gray', rule('━', width)));
   return lines.join('\n');
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Resolved Metadata renderer — replaces the old Metadata To Upload section
+// for the CLI templates two-mode contract path. Walks the emitted msg and
+// shows each metadata-bearing entity's final on-chain (uri, customData)
+// pair, classifying each as URI mode or INLINE mode.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ResolvedEntry {
+  kind: string;
+  location: string;
+  uri: string;
+  customData: string;
+}
+
+function collectResolvedEntries(input: any): ResolvedEntry[] {
+  const out: ResolvedEntry[] = [];
+  let value: any = null;
+  if (Array.isArray(input?.messages)) {
+    const isCollection = (t: unknown) =>
+      typeof t === 'string' &&
+      (t.endsWith('.MsgCreateCollection') ||
+        t.endsWith('.MsgUpdateCollection') ||
+        t.endsWith('.MsgUniversalUpdateCollection'));
+    const msg = input.messages.find((m: any) => isCollection(m?.typeUrl)) || input.messages[0];
+    value = msg?.value || msg;
+  } else if (input?.value) {
+    value = input.value;
+  } else {
+    value = input;
+  }
+  if (!value || typeof value !== 'object') return out;
+
+  const push = (kind: string, location: string, m: any) => {
+    if (!m) return;
+    out.push({ kind, location, uri: typeof m.uri === 'string' ? m.uri : '', customData: typeof m.customData === 'string' ? m.customData : '' });
+  };
+
+  if (value.collectionMetadata) push('Collection', 'collectionMetadata', value.collectionMetadata);
+  if (Array.isArray(value.tokenMetadata)) {
+    for (let i = 0; i < value.tokenMetadata.length; i++) {
+      const tm = value.tokenMetadata[i];
+      const ids = Array.isArray(tm?.tokenIds) && tm.tokenIds.length > 0
+        ? tm.tokenIds.map((r: any) => `${r.start}-${r.end}`).join(', ')
+        : 'all';
+      push(`Token (ids: ${ids})`, `tokenMetadata[${i}]`, tm);
+    }
+  }
+  if (Array.isArray(value.collectionApprovals)) {
+    for (let i = 0; i < value.collectionApprovals.length; i++) {
+      const a = value.collectionApprovals[i];
+      push(`Approval "${a?.approvalId || i}"`, `collectionApprovals[${i}]`, a);
+    }
+  }
+  if (Array.isArray(value.aliasPathsToAdd)) {
+    for (let i = 0; i < value.aliasPathsToAdd.length; i++) {
+      const ap = value.aliasPathsToAdd[i];
+      push(`Alias path "${ap?.denom || i}"`, `aliasPathsToAdd[${i}].metadata`, ap?.metadata);
+      if (Array.isArray(ap?.denomUnits)) {
+        for (let j = 0; j < ap.denomUnits.length; j++) {
+          const du = ap.denomUnits[j];
+          push(`Denom unit "${du?.symbol || j}" of ${ap?.denom || i}`, `aliasPathsToAdd[${i}].denomUnits[${j}].metadata`, du?.metadata);
+        }
+      }
+    }
+  }
+  if (Array.isArray(value.cosmosCoinWrapperPathsToAdd)) {
+    for (let i = 0; i < value.cosmosCoinWrapperPathsToAdd.length; i++) {
+      const wp = value.cosmosCoinWrapperPathsToAdd[i];
+      push(`Wrapper path "${wp?.denom || i}"`, `cosmosCoinWrapperPathsToAdd[${i}].metadata`, wp?.metadata);
+      if (Array.isArray(wp?.denomUnits)) {
+        for (let j = 0; j < wp.denomUnits.length; j++) {
+          const du = wp.denomUnits[j];
+          push(`Wrapper denom unit "${du?.symbol || j}" of ${wp?.denom || i}`, `cosmosCoinWrapperPathsToAdd[${i}].denomUnits[${j}].metadata`, du?.metadata);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Render the resolved on-chain `(uri, customData)` pair for each
+ * metadata-bearing entity in the emitted msg. Categorizes each as
+ *   - URI    — `uri` non-empty, `customData` empty (mode 1)
+ *   - INLINE — `uri` empty, `customData` is JSON metadata (mode 2)
+ *   - EMPTY  — both empty (only valid for approvals that won't render)
+ *   - MIXED  — both non-empty (uri wins per the resolution rule, but
+ *              shown so the user notices)
+ * For INLINE entries, parses the customData JSON to surface a quick
+ * name/image preview so the user can verify content at a glance.
+ */
+export function renderResolvedMetadata(
+  input: any,
+  opts?: { stream?: NodeJS.WriteStream; title?: string }
+): string {
+  const stream = opts?.stream || process.stderr;
+  const { c } = makeColor(stream);
+  const width = Math.min(80, (stream as any).columns || 80);
+  const entries = collectResolvedEntries(input);
+
+  const lines: string[] = [];
+  lines.push(c('gray', rule('━', width, opts?.title || 'Resolved Metadata')));
+  lines.push('');
+
+  if (entries.length === 0) {
+    lines.push(`  ${c('gray', '·')} No metadata-bearing entities`);
+    lines.push('');
+    lines.push(c('gray', rule('━', width)));
+    return lines.join('\n');
+  }
+
+  let uriCount = 0;
+  let inlineCount = 0;
+  let emptyCount = 0;
+  let mixedCount = 0;
+
+  for (const e of entries) {
+    const hasUri = e.uri.length > 0;
+    const hasCustom = e.customData.length > 0;
+    let mode: 'URI' | 'INLINE' | 'EMPTY' | 'MIXED';
+    let badge: string;
+    if (hasUri && hasCustom) {
+      mode = 'MIXED';
+      mixedCount++;
+      badge = `${c('yellow', '▲')} ${c('bold', c('yellow', 'MIXED   '))}`;
+    } else if (hasUri) {
+      mode = 'URI';
+      uriCount++;
+      badge = `${c('cyan', '●')} ${c('bold', c('cyan', 'URI     '))}`;
+    } else if (hasCustom) {
+      mode = 'INLINE';
+      inlineCount++;
+      badge = `${c('green', '✓')} ${c('bold', c('green', 'INLINE  '))}`;
+    } else {
+      mode = 'EMPTY';
+      emptyCount++;
+      badge = `${c('gray', '·')} ${c('bold', c('gray', 'EMPTY   '))}`;
+    }
+    lines.push(`  ${badge}  ${c('bold', e.kind)}  ${c('dim', e.location)}`);
+    if (mode === 'URI' || mode === 'MIXED') {
+      lines.push(`      ${c('gray', '→')} uri: ${e.uri}`);
+    }
+    if (mode === 'INLINE' || mode === 'MIXED') {
+      const preview = previewInlineCustomData(e.customData);
+      lines.push(`      ${c('gray', '→')} customData: ${preview}`);
+    }
+    if (mode === 'EMPTY') {
+      lines.push(`      ${c('gray', '→')} (no metadata — only valid for approvals that don't surface in UI)`);
+    }
+    lines.push('');
+  }
+
+  lines.push(c('gray', rule('━', width)));
+  const summaryParts = [
+    uriCount > 0 ? c('cyan', `${uriCount} URI`) : c('gray', `${uriCount} URI`),
+    inlineCount > 0 ? c('green', `${inlineCount} inline`) : c('gray', `${inlineCount} inline`),
+    emptyCount > 0 ? c('gray', `${emptyCount} empty`) : c('gray', `${emptyCount} empty`),
+    mixedCount > 0 ? c('yellow', `${mixedCount} mixed (uri wins)`) : c('gray', `${mixedCount} mixed`)
+  ];
+  lines.push(`  ${c('bold', 'Summary')}  ${summaryParts.join('  ·  ')}`);
+  lines.push(c('gray', rule('━', width)));
+  return lines.join('\n');
+}
+
+function previewInlineCustomData(raw: string): string {
+  if (raw.length > 200) {
+    return `<inline JSON, ${raw.length} bytes>`;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const bits: string[] = [];
+      if (typeof parsed.name === 'string') bits.push(`name: "${parsed.name}"`);
+      if (typeof parsed.image === 'string') bits.push(`image: ${parsed.image}`);
+      if (typeof parsed.description === 'string' && parsed.description.length <= 60) bits.push(`description: "${parsed.description}"`);
+      return bits.length > 0 ? bits.join('  ') : `<inline JSON, ${raw.length} bytes>`;
+    }
+  } catch {
+    /* fall through */
+  }
+  return `<inline JSON, ${raw.length} bytes>`;
+}

--- a/packages/bitbadgesjs-sdk/src/core/audit.ts
+++ b/packages/bitbadgesjs-sdk/src/core/audit.ts
@@ -7,6 +7,7 @@
  */
 
 import { normalizeForReview } from './review-normalize.js';
+import { parseInlineCustomData } from '../api-indexer/metadata/inlineCustomData.js';
 
 const MAX_UINT64 = 18446744073709551615n;
 
@@ -649,24 +650,30 @@ export function auditCollection(input: { collection: Record<string, unknown>; co
     // 6. METADATA & STANDARDS CHECKS
     // ========================================
 
-    // Collection metadata URI placeholder check — suppressed when the
-    // frontend WithDetails shape is present (nested metadata.metadata
-    // with inline name / image / description). In that state the URI is
-    // intentionally blank pre-upload; the auto-apply flow resolves it
-    // on submit. `ipfs://METADATA_*` internal placeholders from the
-    // session/template flow are also valid and don't trigger this.
+    // Collection metadata URI presence — three valid configurations:
+    //   1. `uri` is a real (or `ipfs://METADATA_*` placeholder) URI.
+    //   2. The frontend WithDetails shape is present (nested
+    //      metadata.metadata with inline name/image/description) and
+    //      the auto-apply flow will hoist it to a real URI on submit.
+    //   3. `customData` carries inline JSON metadata (the indexer
+    //      resolves it stateless via parseInlineCustomData).
+    // Only emit the info finding when none of these apply.
     const collectionMeta: any = col.collectionMetadata;
     const collectionUri: string = collectionMeta?.uri || '';
+    const collectionCustomData: string = typeof collectionMeta?.customData === 'string' ? collectionMeta.customData : '';
     const collectionInline = collectionMeta?.metadata;
     const hasInlineContent = !!(collectionInline && (collectionInline.name || collectionInline.image || collectionInline.description));
     const isInternalPlaceholder = /^ipfs:\/\/METADATA_[A-Z]/.test(collectionUri);
-    if (!hasInlineContent && !isInternalPlaceholder && collectionUri === '') {
+    const hasInlineCustomData = !!parseInlineCustomData(collectionCustomData);
+    if (!hasInlineContent && !isInternalPlaceholder && collectionUri === '' && !hasInlineCustomData) {
       findings.push({
         severity: 'info',
         category: 'metadata',
         title: 'Collection metadata URI is not set',
-        detail: 'collectionMetadata.uri is empty. Upload metadata to IPFS and set the URI, or populate inline metadata so the auto-apply flow can substitute it on submit.',
-        recommendation: 'Set collectionMetadata.uri to an uploaded IPFS URI, or populate collectionMetadata.metadata with name/image/description so the auto-apply flow handles it.'
+        detail:
+          'collectionMetadata.uri is empty and collectionMetadata.customData does not carry inline JSON metadata. Set the URI to an uploaded IPFS URI, populate inline metadata for the auto-apply flow, or stash inline JSON metadata directly in customData (zero-config alternative to IPFS hosting).',
+        recommendation:
+          'Pick one: (a) set collectionMetadata.uri to an uploaded IPFS URI, (b) populate collectionMetadata.metadata with name/image/description for the auto-apply flow, or (c) write {"name":"...","image":"...","description":"..."} JSON into collectionMetadata.customData.'
       });
     }
 
@@ -685,16 +692,33 @@ export function auditCollection(input: { collection: Record<string, unknown>; co
       }
     }
 
-    // Approval metadata image check
+    // Approval metadata image check. Approvals carry name+description
+    // only — never image. When the URI is a real IPFS link we can't
+    // peek inside, so emit a soft reminder. When the metadata is
+    // stashed inline in customData, we CAN inspect it; only emit the
+    // reminder if the inline payload accidentally carries an image.
     for (const appr of approvals) {
-      if (appr.uri && appr.uri !== '' && !appr.uri.startsWith('ipfs://METADATA_')) {
+      const apprUri: string = appr.uri || '';
+      const apprCustomData: string = typeof appr.customData === 'string' ? appr.customData : '';
+      if (apprUri && apprUri !== '' && !apprUri.startsWith('ipfs://METADATA_')) {
         findings.push({
           severity: 'info',
           category: 'metadata',
           title: `Approval "${appr.approvalId}" has metadata URI`,
-          detail: `Approval metadata images MUST be empty string (""). Verify the metadata at ${appr.uri} has image: "".`,
+          detail: `Approval metadata images MUST be empty string (""). Verify the metadata at ${apprUri} has image: "".`,
           recommendation: 'Ensure approval metadata has image: "" (empty string). Non-empty images on approvals cause display issues.'
         });
+      } else if (apprUri === '' && apprCustomData !== '') {
+        const inline = parseInlineCustomData(apprCustomData);
+        if (inline && inline.image && inline.image !== '') {
+          findings.push({
+            severity: 'info',
+            category: 'metadata',
+            title: `Approval "${appr.approvalId}" inline customData carries an image`,
+            detail: 'Approval metadata images MUST be empty string (""). The inline JSON in customData includes a non-empty image field.',
+            recommendation: 'Remove the image field from the inline JSON in customData (or set it to "").'
+          });
+        }
       }
     }
 

--- a/packages/bitbadgesjs-sdk/src/core/audit.ts
+++ b/packages/bitbadgesjs-sdk/src/core/audit.ts
@@ -692,31 +692,23 @@ export function auditCollection(input: { collection: Record<string, unknown>; co
       }
     }
 
-    // Approval metadata image check. Approvals carry name+description
-    // only — never image. When the URI is a real IPFS link we can't
-    // peek inside, so emit a soft reminder. When the metadata is
-    // stashed inline in customData, we CAN inspect it; only emit the
-    // reminder if the inline payload accidentally carries an image.
+    // Approval metadata is typically text-only (name + description).
+    // Images on approvals are supported but uncommon — most approval
+    // surfaces in the UI render text only. When inline customData
+    // carries an image we can detect it; flag as a low-priority
+    // suggestion, not a violation.
     for (const appr of approvals) {
       const apprUri: string = appr.uri || '';
       const apprCustomData: string = typeof appr.customData === 'string' ? appr.customData : '';
-      if (apprUri && apprUri !== '' && !apprUri.startsWith('ipfs://METADATA_')) {
-        findings.push({
-          severity: 'info',
-          category: 'metadata',
-          title: `Approval "${appr.approvalId}" has metadata URI`,
-          detail: `Approval metadata images MUST be empty string (""). Verify the metadata at ${apprUri} has image: "".`,
-          recommendation: 'Ensure approval metadata has image: "" (empty string). Non-empty images on approvals cause display issues.'
-        });
-      } else if (apprUri === '' && apprCustomData !== '') {
+      if (apprUri === '' && apprCustomData !== '') {
         const inline = parseInlineCustomData(apprCustomData);
         if (inline && inline.image && inline.image !== '') {
           findings.push({
             severity: 'info',
             category: 'metadata',
             title: `Approval "${appr.approvalId}" inline customData carries an image`,
-            detail: 'Approval metadata images MUST be empty string (""). The inline JSON in customData includes a non-empty image field.',
-            recommendation: 'Remove the image field from the inline JSON in customData (or set it to "").'
+            detail: 'Approval metadata is typically text-only (name + description). Images on approvals are supported but most surfaces render text only.',
+            recommendation: 'Consider omitting the image field unless you have a UI surface that renders it.'
           });
         }
       }

--- a/packages/bitbadgesjs-sdk/src/core/builders/address-list.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/address-list.ts
@@ -7,11 +7,16 @@ import {
   BURN_ADDRESS,
   buildMsg,
   baselinePermissions,
-  defaultBalances
+  defaultBalances,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface AddressListParams {
-  name: string;
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
+  name?: string;
   image?: string;
   description?: string;
   manager?: string; // bb1... address that can add/remove members (defaults to creator)
@@ -70,6 +75,16 @@ export function buildAddressList(params: AddressListParams): any {
     }
   ];
 
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('address-list collectionMetadata', ['name', 'image', 'description']);
+  }
+
   return buildMsg({
     collectionApprovals,
     standards: ['Address List'],
@@ -79,6 +94,8 @@ export function buildAddressList(params: AddressListParams): any {
       noCustomOwnershipTimes: true,
       disablePoolCreation: true
     },
-    defaultBalances: defaultBalances({ autoApproveAllIncomingTransfers: true })
+    defaultBalances: defaultBalances({ autoApproveAllIncomingTransfers: true }),
+    collectionMetadata: collectionSource,
+    tokenMetadata: [tokenMetadataEntry([{ start: '1', end: '1' }], collectionSource, 'list-membership token')]
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/address-list.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/address-list.ts
@@ -10,7 +10,8 @@ import {
   defaultBalances,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface AddressListParams {
@@ -44,6 +45,10 @@ export function buildAddressList(params: AddressListParams): any {
       toListId: 'All',
       initiatedByListId: initiatedBy,
       approvalId: 'manager-add',
+      ...approvalMetadata(
+        'Add to List',
+        'Allows the manager to add addresses by minting membership tokens'
+      ),
       transferTimes: FOREVER,
       tokenIds: [{ start: '1', end: '1' }],
       ownershipTimes: FOREVER,
@@ -64,6 +69,10 @@ export function buildAddressList(params: AddressListParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: initiatedBy,
       approvalId: 'manager-remove',
+      ...approvalMetadata(
+        'Remove from List',
+        'Allows the manager to remove addresses by burning membership tokens'
+      ),
       transferTimes: FOREVER,
       tokenIds: [{ start: '1', end: '1' }],
       ownershipTimes: FOREVER,

--- a/packages/bitbadgesjs-sdk/src/core/builders/auction.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/auction.ts
@@ -10,13 +10,17 @@ import {
   buildMsg,
   frozenPermissions,
   defaultBalances,
-  metadataPlaceholders,
-  zeroMaxTransfers
+  zeroMaxTransfers,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface AuctionParams {
   bidDeadline?: string; // duration shorthand, default "7d"
   acceptWindow?: string; // duration shorthand, default "7d"
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
   name?: string;
   description?: string;
   image?: string;
@@ -108,19 +112,18 @@ export function buildAuction(params: AuctionParams): any {
     }
   ];
 
-  // Auctions are 1-of-1 NFTs, so the token-level metadata is always an
-  // identical mirror of the collection-level metadata. Reuse the default
-  // token entry emitted by metadataPlaceholders() (keyed by
-  // ipfs://METADATA_TOKEN_DEFAULT, same content as the collection) and
-  // narrow its tokenIds range to [1,1] so it doesn't bleed into any
-  // future higher IDs. This matches the custom-2fa / single-NFT pattern
-  // where collection image == token image automatically — no separate
-  // tokenMetadata path to drift out of sync.
-  const { collectionMetadata, tokenMetadata, placeholders: collectionPlaceholders } = metadataPlaceholders(
-    params.name || 'Auction',
-    params.description,
-    params.image
-  );
+  // Auctions are 1-of-1 NFTs — token-level metadata mirrors the
+  // collection-level metadata. Reuse the same source for both so they
+  // can't drift.
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('auction collectionMetadata', ['name', 'image', 'description']);
+  }
 
   return buildMsg({
     collectionApprovals,
@@ -141,11 +144,7 @@ export function buildAuction(params: AuctionParams): any {
     // doesn't need a fungible representation; the NFT itself is the only
     // tradable surface.
     aliasPathsToAdd: [],
-    collectionMetadata,
-    tokenMetadata: tokenMetadata.map((entry) => ({
-      ...entry,
-      tokenIds: [{ start: '1', end: '1' }]
-    })),
-    metadataPlaceholders: collectionPlaceholders
+    collectionMetadata: collectionSource,
+    tokenMetadata: [tokenMetadataEntry([{ start: '1', end: '1' }], collectionSource, 'auction NFT')]
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/auction.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/auction.ts
@@ -13,7 +13,8 @@ import {
   zeroMaxTransfers,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface AuctionParams {
@@ -76,6 +77,10 @@ export function buildAuction(params: AuctionParams): any {
       toListId: 'All',
       initiatedByListId: sellerAddr,
       approvalId: `auction-mint-to-winner-${randomId()}`,
+      ...approvalMetadata(
+        'Accept Bid',
+        'Seller mints the NFT directly to the winning bidder during the accept window'
+      ),
       transferTimes: [{ start: bidDeadlineTs, end: acceptEndTs }],
       tokenIds: [{ start: '1', end: '1' }],
       ownershipTimes: FOREVER,
@@ -105,6 +110,7 @@ export function buildAuction(params: AuctionParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: 'All',
       approvalId: `auction-burn-${randomId()}`,
+      ...approvalMetadata('Burn', 'Burn the auction token'),
       transferTimes: FOREVER,
       tokenIds: [{ start: '1', end: '1' }],
       ownershipTimes: FOREVER,

--- a/packages/bitbadgesjs-sdk/src/core/builders/bid.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/bid.ts
@@ -12,7 +12,8 @@ import {
   toBaseUnits,
   durationToTimestamp,
   uniqueId,
-  buildUserApprovalMsg
+  buildUserApprovalMsg,
+  approvalMetadata
 } from './shared.js';
 
 export interface BidParams {
@@ -41,6 +42,10 @@ export function buildBid(params: BidParams): any {
 
   const approval = {
     approvalId: id,
+    ...approvalMetadata(
+      'Bid',
+      'This approval is a proposal for this address to receive a token if certain conditions are met.'
+    ),
     fromListId: 'All',
     initiatedByListId: 'All',
     transferTimes: [{ start: '1', end: expirationTs }],

--- a/packages/bitbadgesjs-sdk/src/core/builders/bounty.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/bounty.ts
@@ -18,7 +18,8 @@ import {
   zeroMaxTransfers,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface BountyParams {
@@ -46,6 +47,10 @@ export function buildBounty(params: BountyParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: 'All',
       approvalId: 'bounty-accept',
+      ...approvalMetadata(
+        'Accept',
+        'Verifier accepts bounty — payout to recipient'
+      ),
       transferTimes: [{ start: '1', end: expirationTs }],
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,
@@ -81,6 +86,10 @@ export function buildBounty(params: BountyParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: 'All',
       approvalId: 'bounty-deny',
+      ...approvalMetadata(
+        'Deny',
+        'Verifier denies bounty — refund to submitter'
+      ),
       transferTimes: [{ start: '1', end: expirationTs }],
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,
@@ -116,6 +125,10 @@ export function buildBounty(params: BountyParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: 'All',
       approvalId: 'bounty-expire',
+      ...approvalMetadata(
+        'Expire',
+        'Bounty expired — refund to submitter'
+      ),
       transferTimes: [{ start: String(BigInt(expirationTs) + 1n), end: MAX_UINT64 }],
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,

--- a/packages/bitbadgesjs-sdk/src/core/builders/bounty.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/bounty.ts
@@ -13,10 +13,12 @@ import {
   buildMsg,
   frozenPermissions,
   defaultBalances,
-  metadataPlaceholders,
   mintToBurnBalances,
   zeroAmounts,
-  zeroMaxTransfers
+  zeroMaxTransfers,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface BountyParams {
@@ -25,7 +27,11 @@ export interface BountyParams {
   verifier: string; // bb1... address
   recipient: string; // bb1... address
   expiration?: string; // duration shorthand, default "30d"
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
   name?: string;
+  description?: string;
+  image?: string;
 }
 
 export function buildBounty(params: BountyParams): any {
@@ -134,7 +140,15 @@ export function buildBounty(params: BountyParams): any {
     }
   ];
 
-  const { collectionMetadata, tokenMetadata, placeholders } = metadataPlaceholders(params.name || 'Bounty');
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('bounty collectionMetadata', ['name', 'image', 'description']);
+  }
 
   return buildMsg({
     collectionApprovals,
@@ -152,8 +166,7 @@ export function buildBounty(params: BountyParams): any {
     // `decimals: 0` which the chain rejects.
     aliasPathsToAdd: [],
     mintEscrowCoinsToTransfer: [{ amount: baseAmount, denom: coin.denom }],
-    collectionMetadata,
-    tokenMetadata,
-    metadataPlaceholders: placeholders
+    collectionMetadata: collectionSource,
+    tokenMetadata: [tokenMetadataEntry(FOREVER, collectionSource, 'bounty receipt')]
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
@@ -36,6 +36,9 @@ function verifyBuilder(msg: any) {
   return verifyStandardsCompliance({ messages: [msg] });
 }
 
+/** Required metadata fields for collection-style builders (post-#0371). */
+const META = { name: 'Test', description: 'Test description for the spec.', image: 'ipfs://test-image' };
+
 // ── Shared utility tests ─────────────────────────────────────────────────────
 
 describe('shared utilities', () => {
@@ -85,7 +88,7 @@ describe('shared utilities', () => {
 // ── Collection builder tests ─────────────────────────────────────────────────
 
 describe('vault builder', () => {
-  const msg = buildVault({ backingCoin: 'USDC' });
+  const msg = buildVault({ backingCoin: 'USDC', ...META });
   const r = val(msg);
 
   test('produces { typeUrl, value }', () => {
@@ -126,21 +129,21 @@ describe('vault builder', () => {
     approvals.find((a: any) => typeof a.approvalId === 'string' && a.approvalId.startsWith('vault-withdraw-'));
 
   test('daily withdraw limit adds approvalAmounts', () => {
-    const limited = val(buildVault({ backingCoin: 'USDC', dailyWithdrawLimit: 100 }));
+    const limited = val(buildVault({ backingCoin: 'USDC', dailyWithdrawLimit: 100, ...META }));
     const withdrawal = findWithdraw(limited.collectionApprovals);
     expect(withdrawal.approvalCriteria.approvalAmounts).toBeDefined();
     expect(withdrawal.approvalCriteria.approvalAmounts.perInitiatedByAddressApprovalAmount).toBe('100000000');
   });
 
   test('require2fa adds mustOwnTokens', () => {
-    const twoFa = val(buildVault({ backingCoin: 'USDC', require2fa: '74' }));
+    const twoFa = val(buildVault({ backingCoin: 'USDC', require2fa: '74', ...META }));
     const withdrawal = findWithdraw(twoFa.collectionApprovals);
     expect(withdrawal.approvalCriteria.mustOwnTokens).toBeDefined();
     expect(withdrawal.approvalCriteria.mustOwnTokens[0].collectionId).toBe('74');
   });
 
   test('emergency recovery adds migration approval', () => {
-    const recovery = val(buildVault({ backingCoin: 'USDC', emergencyRecovery: 'bb1recovery' }));
+    const recovery = val(buildVault({ backingCoin: 'USDC', emergencyRecovery: 'bb1recovery', ...META }));
     expect(recovery.collectionApprovals.length).toBe(3);
     const migration = recovery.collectionApprovals.find((a: any) => a.approvalId === 'vault-emergency-migration');
     expect(migration.toListId).toBe('bb1recovery');
@@ -154,7 +157,7 @@ describe('vault builder', () => {
 });
 
 describe('smart-account builder', () => {
-  const msg = buildSmartAccount({ backingCoin: 'USDC' });
+  const msg = buildSmartAccount({ backingCoin: 'USDC', ...META });
   const r = val(msg);
 
   test('has Smart Token standard', () => { expect(r.standards).toContain('Smart Token'); });
@@ -166,12 +169,12 @@ describe('smart-account builder', () => {
     expect(ids).toContain('smart-account-unbacking');
   });
   test('tradable adds Liquidity Pools', () => {
-    const t = val(buildSmartAccount({ backingCoin: 'USDC', tradable: true }));
+    const t = val(buildSmartAccount({ backingCoin: 'USDC', tradable: true, ...META }));
     expect(t.standards).toContain('Liquidity Pools');
     expect(t.invariants.disablePoolCreation).toBe(false);
   });
   test('aiAgentVault adds standard', () => {
-    const t = val(buildSmartAccount({ backingCoin: 'USDC', aiAgentVault: true }));
+    const t = val(buildSmartAccount({ backingCoin: 'USDC', aiAgentVault: true, ...META }));
     expect(t.standards).toContain('AI Agent Vault');
   });
   test('passes verification', () => {
@@ -180,7 +183,7 @@ describe('smart-account builder', () => {
 });
 
 describe('subscription builder', () => {
-  const msg = buildSubscription({ interval: 'monthly', price: 10, denom: 'USDC', recipient: 'bb1test' });
+  const msg = buildSubscription({ interval: 'monthly', price: 10, denom: 'USDC', recipient: 'bb1test', ...META });
   const r = val(msg);
 
   test('has Subscriptions standard', () => { expect(r.standards).toEqual(['Subscriptions']); });
@@ -194,7 +197,7 @@ describe('subscription builder', () => {
   });
   test('noCustomOwnershipTimes is false', () => { expect(r.invariants.noCustomOwnershipTimes).toBe(false); });
   test('multi-tier', () => {
-    const mt = val(buildSubscription({ interval: 'monthly', price: 10, denom: 'USDC', recipient: 'bb1test', tiers: 3 }));
+    const mt = val(buildSubscription({ interval: 'monthly', price: 10, denom: 'USDC', recipient: 'bb1test', tiers: 3, ...META }));
     expect(mt.validTokenIds).toEqual([{ start: '1', end: '3' }]);
     expect(mt.collectionApprovals.length).toBe(3);
   });
@@ -207,7 +210,8 @@ describe('subscription builder', () => {
       payouts: [
         { recipient: 'bb1a', amount: 5, denom: 'USDC' },
         { recipient: 'bb1b', amount: 3, denom: 'USDC' }
-      ]
+      ],
+      ...META
     }));
     const cts = mp.collectionApprovals[0].approvalCriteria.coinTransfers;
     expect(cts.length).toBe(2);
@@ -232,7 +236,7 @@ describe('subscription builder', () => {
 });
 
 describe('bounty builder', () => {
-  const msg = buildBounty({ amount: 100, denom: 'USDC', verifier: 'bb1verifier', recipient: 'bb1recipient' });
+  const msg = buildBounty({ amount: 100, denom: 'USDC', verifier: 'bb1verifier', recipient: 'bb1recipient', ...META });
   const r = val(msg);
 
   test('has Bounty standard', () => { expect(r.standards).toEqual(['Bounty']); });
@@ -262,7 +266,9 @@ describe('payment-request builder', () => {
     denom: 'USDC',
     payer: 'bb1payer',
     recipient: 'bb1recipient',
-    context: 'Agent X requesting payment for completed task Y on behalf of org Z under approved budget envelope.'
+    context: 'Agent X requesting payment for completed task Y on behalf of org Z under approved budget envelope.',
+    name: 'Test',
+    image: 'ipfs://test-image'
   });
   const r = val(msg);
 
@@ -299,14 +305,14 @@ describe('payment-request builder', () => {
 });
 
 describe('crowdfund builder', () => {
-  const msg = buildCrowdfund({ goal: 1000, denom: 'USDC' });
+  const msg = buildCrowdfund({ goal: 1000, denom: 'USDC', ...META });
   const r = val(msg);
 
   test('has Crowdfund standard', () => { expect(r.standards).toEqual(['Crowdfund']); });
   test('2 token IDs', () => { expect(r.validTokenIds).toEqual([{ start: '1', end: '2' }]); });
   test('at least 4 approvals', () => { expect(r.collectionApprovals.length).toBeGreaterThanOrEqual(4); });
   test('crowdfunder address used', () => {
-    const cf = val(buildCrowdfund({ goal: 1000, denom: 'USDC', crowdfunder: 'bb1fund' }));
+    const cf = val(buildCrowdfund({ goal: 1000, denom: 'USDC', crowdfunder: 'bb1fund', ...META }));
     const progress = cf.collectionApprovals.find((a: any) => a.approvalId === 'deposit-progress');
     expect(progress.toListId).toBe('bb1fund');
   });
@@ -316,7 +322,7 @@ describe('crowdfund builder', () => {
 });
 
 describe('auction builder', () => {
-  const msg = buildAuction({});
+  const msg = buildAuction({ ...META });
   const r = val(msg);
 
   test('has Auction standard', () => { expect(r.standards).toEqual(['Auction']); });
@@ -336,7 +342,8 @@ describe('auction builder', () => {
 describe('product-catalog builder', () => {
   const msg = buildProductCatalog({
     products: [{ name: 'T-Shirt', price: 25, denom: 'USDC' }, { name: 'Mug', price: 15, denom: 'USDC', maxSupply: 50 }],
-    storeAddress: 'bb1store'
+    storeAddress: 'bb1store',
+    ...META
   });
   const r = val(msg);
 
@@ -354,7 +361,7 @@ describe('product-catalog builder', () => {
 });
 
 describe('prediction-market builder', () => {
-  const msg = buildPredictionMarket({ verifier: 'bb1verifier' });
+  const msg = buildPredictionMarket({ verifier: 'bb1verifier', ...META });
   const r = val(msg);
 
   test('has Prediction Market standard', () => { expect(r.standards).toEqual(['Prediction Market']); });
@@ -373,7 +380,7 @@ describe('prediction-market builder', () => {
 });
 
 describe('credit-token builder', () => {
-  const msg = buildCreditToken({ paymentDenom: 'USDC', recipient: 'bb1recipient' });
+  const msg = buildCreditToken({ paymentDenom: 'USDC', recipient: 'bb1recipient', ...META });
   const r = val(msg);
 
   test('has Credit Token standard', () => { expect(r.standards).toEqual(['Credit Token']); });
@@ -386,14 +393,14 @@ describe('credit-token builder', () => {
 });
 
 describe('custom-2fa builder', () => {
-  const msg = buildCustom2FA({ name: 'My 2FA Token' });
+  const msg = buildCustom2FA({ name: 'My 2FA Token', description: 'A 2FA token for testing.', image: 'ipfs://test-image' });
   const r = val(msg);
 
   test('has Custom-2FA standard', () => { expect(r.standards).toEqual(['Custom-2FA']); });
   test('allowPurgeIfExpired', () => { expect(r.collectionApprovals[0].approvalCriteria.autoDeletionOptions.allowPurgeIfExpired).toBe(true); });
   test('disablePoolCreation', () => { expect(r.invariants.disablePoolCreation).toBe(true); });
   test('burnable adds burn approval', () => {
-    expect(val(buildCustom2FA({ name: 'Test', burnable: true })).collectionApprovals.length).toBe(2);
+    expect(val(buildCustom2FA({ name: 'Test', description: 'A 2FA token for testing.', image: 'ipfs://test-image', burnable: true })).collectionApprovals.length).toBe(2);
   });
   test('passes verification', () => {
     expect(verifyBuilder(msg).violations.filter((vi: any) => vi.standard === 'Custom-2FA')).toEqual([]);
@@ -401,7 +408,7 @@ describe('custom-2fa builder', () => {
 });
 
 describe('quests builder', () => {
-  const msg = buildQuests({ reward: 10, denom: 'BADGE', maxClaims: 100 });
+  const msg = buildQuests({ reward: 10, denom: 'BADGE', maxClaims: 100, ...META });
   const r = val(msg);
 
   test('has Quests standard', () => { expect(r.standards).toEqual(['Quests']); });
@@ -417,7 +424,7 @@ describe('quests builder', () => {
 });
 
 describe('address-list builder', () => {
-  const msg = buildAddressList({ name: 'My List' });
+  const msg = buildAddressList({ name: 'My List', description: 'A test list.', image: 'ipfs://test-image' });
   const r = val(msg);
 
   test('has Address List standard', () => { expect(r.standards).toEqual(['Address List']); });
@@ -522,34 +529,34 @@ describe('pm-buy-intent builder', () => {
 
 describe('all collection builders pass verifyStandardsCompliance with zero violations', () => {
   const builders: [string, any][] = [
-    ['vault', buildVault({ backingCoin: 'USDC' })],
-    ['vault (with limits)', buildVault({ backingCoin: 'USDC', dailyWithdrawLimit: 100, require2fa: '74', emergencyRecovery: 'bb1recovery' })],
-    ['smart-account', buildSmartAccount({ backingCoin: 'USDC' })],
-    ['smart-account (tradable)', buildSmartAccount({ backingCoin: 'USDC', tradable: true })],
-    ['smart-account (ai-agent)', buildSmartAccount({ backingCoin: 'BADGE', aiAgentVault: true })],
-    ['subscription (single)', buildSubscription({ interval: 'monthly', price: 10, denom: 'USDC', recipient: 'bb1test' })],
-    ['subscription (multi-tier)', buildSubscription({ interval: 'daily', price: 5, denom: 'BADGE', recipient: 'bb1r', tiers: 3 })],
+    ['vault', buildVault({ backingCoin: 'USDC', ...META })],
+    ['vault (with limits)', buildVault({ backingCoin: 'USDC', dailyWithdrawLimit: 100, require2fa: '74', emergencyRecovery: 'bb1recovery', ...META })],
+    ['smart-account', buildSmartAccount({ backingCoin: 'USDC', ...META })],
+    ['smart-account (tradable)', buildSmartAccount({ backingCoin: 'USDC', tradable: true, ...META })],
+    ['smart-account (ai-agent)', buildSmartAccount({ backingCoin: 'BADGE', aiAgentVault: true, ...META })],
+    ['subscription (single)', buildSubscription({ interval: 'monthly', price: 10, denom: 'USDC', recipient: 'bb1test', ...META })],
+    ['subscription (multi-tier)', buildSubscription({ interval: 'daily', price: 5, denom: 'BADGE', recipient: 'bb1r', tiers: 3, ...META })],
     // Subscription faucet approvals must use a SINGLE denom — see
     // buildSubscription's runtime check and the proto-level
     // `doesCollectionFollowSubscriptionProtocol()` rule. Multiple
     // recipients sharing one denom is valid (treasury split); mixing
     // denoms is not.
-    ['subscription (multi-payout)', buildSubscription({ interval: 'monthly', payouts: [{ recipient: 'bb1a', amount: 5, denom: 'USDC' }, { recipient: 'bb1b', amount: 3, denom: 'USDC' }] })],
-    ['bounty', buildBounty({ amount: 100, denom: 'USDC', verifier: 'bb1v', recipient: 'bb1r' })],
-    ['bounty (BADGE)', buildBounty({ amount: 50, denom: 'BADGE', verifier: 'bb1v', recipient: 'bb1r', expiration: '7d' })],
-    ['crowdfund', buildCrowdfund({ goal: 1000, denom: 'USDC' })],
-    ['crowdfund (with crowdfunder)', buildCrowdfund({ goal: 500, denom: 'BADGE', crowdfunder: 'bb1fund', deadline: '14d' })],
-    ['auction', buildAuction({})],
-    ['auction (custom times)', buildAuction({ bidDeadline: '3d', acceptWindow: '1d' })],
-    ['product-catalog', buildProductCatalog({ products: [{ name: 'Item', price: 10, denom: 'USDC' }], storeAddress: 'bb1s' })],
-    ['product-catalog (multi)', buildProductCatalog({ products: [{ name: 'A', price: 5, denom: 'BADGE' }, { name: 'B', price: 10, denom: 'USDC', maxSupply: 50, burn: true }], storeAddress: 'bb1s' })],
-    ['prediction-market', buildPredictionMarket({ verifier: 'bb1v' })],
-    ['credit-token', buildCreditToken({ paymentDenom: 'USDC', recipient: 'bb1r' })],
-    ['credit-token (custom)', buildCreditToken({ paymentDenom: 'BADGE', recipient: 'bb1r', symbol: 'CRED', tokensPerUnit: 50 })],
-    ['custom-2fa', buildCustom2FA({ name: 'My 2FA' })],
-    ['custom-2fa (burnable)', buildCustom2FA({ name: 'Burnable 2FA', burnable: true })],
-    ['quests', buildQuests({ reward: 10, denom: 'BADGE', maxClaims: 100 })],
-    ['address-list', buildAddressList({ name: 'My List' })],
+    ['subscription (multi-payout)', buildSubscription({ interval: 'monthly', payouts: [{ recipient: 'bb1a', amount: 5, denom: 'USDC' }, { recipient: 'bb1b', amount: 3, denom: 'USDC' }], ...META })],
+    ['bounty', buildBounty({ amount: 100, denom: 'USDC', verifier: 'bb1v', recipient: 'bb1r', ...META })],
+    ['bounty (BADGE)', buildBounty({ amount: 50, denom: 'BADGE', verifier: 'bb1v', recipient: 'bb1r', expiration: '7d', ...META })],
+    ['crowdfund', buildCrowdfund({ goal: 1000, denom: 'USDC', ...META })],
+    ['crowdfund (with crowdfunder)', buildCrowdfund({ goal: 500, denom: 'BADGE', crowdfunder: 'bb1fund', deadline: '14d', ...META })],
+    ['auction', buildAuction({ ...META })],
+    ['auction (custom times)', buildAuction({ bidDeadline: '3d', acceptWindow: '1d', ...META })],
+    ['product-catalog', buildProductCatalog({ products: [{ name: 'Item', price: 10, denom: 'USDC' }], storeAddress: 'bb1s', ...META })],
+    ['product-catalog (multi)', buildProductCatalog({ products: [{ name: 'A', price: 5, denom: 'BADGE' }, { name: 'B', price: 10, denom: 'USDC', maxSupply: 50, burn: true }], storeAddress: 'bb1s', ...META })],
+    ['prediction-market', buildPredictionMarket({ verifier: 'bb1v', ...META })],
+    ['credit-token', buildCreditToken({ paymentDenom: 'USDC', recipient: 'bb1r', ...META })],
+    ['credit-token (custom)', buildCreditToken({ paymentDenom: 'BADGE', recipient: 'bb1r', symbol: 'CRED', tokensPerUnit: 50, ...META })],
+    ['custom-2fa', buildCustom2FA({ name: 'My 2FA', description: 'A 2FA token.', image: 'ipfs://test-image' })],
+    ['custom-2fa (burnable)', buildCustom2FA({ name: 'Burnable 2FA', burnable: true, description: 'A burnable 2FA token.', image: 'ipfs://test-image' })],
+    ['quests', buildQuests({ reward: 10, denom: 'BADGE', maxClaims: 100, ...META })],
+    ['address-list', buildAddressList({ name: 'My List', description: 'A test list.', image: 'ipfs://test-image' })],
   ];
 
   for (const [name, msg] of builders) {
@@ -581,24 +588,24 @@ describe('error handling', () => {
   });
 
   test('buildBounty with zero amount still produces valid structure', () => {
-    const msg = buildBounty({ amount: 0, denom: 'BADGE', verifier: 'bb1v', recipient: 'bb1r' });
+    const msg = buildBounty({ amount: 0, denom: 'BADGE', verifier: 'bb1v', recipient: 'bb1r', ...META });
     expect(msg.typeUrl).toBe('/tokenization.MsgUniversalUpdateCollection');
     expect(msg.value.collectionApprovals.length).toBe(3);
   });
 
   test('buildProductCatalog with empty products produces burn-only collection', () => {
-    const msg = buildProductCatalog({ products: [], storeAddress: 'bb1s' });
+    const msg = buildProductCatalog({ products: [], storeAddress: 'bb1s', ...META });
     // Only burn approval, no purchase approvals
     expect(msg.value.collectionApprovals.length).toBe(1);
   });
 
   test('buildCrowdfund goal of 1 base unit works', () => {
-    const msg = buildCrowdfund({ goal: 0.000001, denom: 'USDC' });
+    const msg = buildCrowdfund({ goal: 0.000001, denom: 'USDC', ...META });
     expect(msg.value.collectionApprovals.length).toBeGreaterThanOrEqual(4);
   });
 
   test('buildAuction with very short windows works', () => {
-    const msg = buildAuction({ bidDeadline: '1m', acceptWindow: '1m' });
+    const msg = buildAuction({ bidDeadline: '1m', acceptWindow: '1m', ...META });
     expect(msg.typeUrl).toBe('/tokenization.MsgUniversalUpdateCollection');
   });
 

--- a/packages/bitbadgesjs-sdk/src/core/builders/credit-token.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/credit-token.ts
@@ -11,7 +11,10 @@ import {
   sanitizeCosmosPathName,
   frozenPermissions,
   defaultBalances,
-  scalingBalances
+  scalingBalances,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface CreditTokenParams {
@@ -19,7 +22,11 @@ export interface CreditTokenParams {
   recipient: string; // bb1... payment recipient
   symbol?: string; // default "CREDIT"
   tokensPerUnit?: number; // tokens per 1 display unit of payment, default 100
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
   name?: string;
+  description?: string;
+  image?: string;
 }
 
 export function buildCreditToken(params: CreditTokenParams): any {
@@ -59,7 +66,22 @@ export function buildCreditToken(params: CreditTokenParams): any {
     }
   };
 
-  const alias = buildAliasPath('u' + symbol.toLowerCase(), symbol, coin.decimals, undefined, params.name);
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('credit-token collectionMetadata', ['name', 'image', 'description']);
+  }
+  const aliasPath = buildAliasPath({
+    denom: 'u' + symbol.toLowerCase(),
+    symbol,
+    decimals: coin.decimals,
+    pathMetadata: collectionSource,
+    unitMetadata: collectionSource
+  });
 
   return buildMsg({
     collectionApprovals: [creditMint],
@@ -72,7 +94,8 @@ export function buildCreditToken(params: CreditTokenParams): any {
       noForcefulPostMintTransfers: true,
       disablePoolCreation: true
     },
-    aliasPathsToAdd: [alias.path],
-    metadataPlaceholders: { ...alias.placeholders }
+    aliasPathsToAdd: [aliasPath],
+    collectionMetadata: collectionSource,
+    tokenMetadata: [tokenMetadataEntry([{ start: '1', end: '1' }], collectionSource, 'credit token')]
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/credit-token.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/credit-token.ts
@@ -14,7 +14,8 @@ import {
   scalingBalances,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface CreditTokenParams {
@@ -38,6 +39,10 @@ export function buildCreditToken(params: CreditTokenParams): any {
 
   const creditMint = {
     approvalId: 'credit-scaled',
+    ...approvalMetadata(
+      'Mint credits',
+      'Pay the configured price to mint credit tokens at the fixed exchange rate.'
+    ),
     fromListId: 'Mint',
     toListId: 'All',
     initiatedByListId: 'All',

--- a/packages/bitbadgesjs-sdk/src/core/builders/crowdfund.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/crowdfund.ts
@@ -12,9 +12,10 @@ import {
   buildMsg,
   frozenPermissions,
   defaultBalances,
-  metadataPlaceholders,
-  singleTokenMetadata,
-  scalingBalances
+  scalingBalances,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface CrowdfundParams {
@@ -22,7 +23,11 @@ export interface CrowdfundParams {
   denom: string;
   crowdfunder?: string; // bb1... address — who receives funds on success (creator fills in if empty)
   deadline?: string; // duration shorthand, default "30d"
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
   name?: string;
+  description?: string;
+  image?: string;
   /**
    * Creator address — used as the default crowdfunder when `crowdfunder`
    * isn't specified. The CLI passes this through from `--creator`.
@@ -212,17 +217,40 @@ export function buildCrowdfund(params: CrowdfundParams): any {
     }
   ];
 
-  const { collectionMetadata, placeholders: collectionPlaceholders } = metadataPlaceholders(
-    params.name || 'Crowdfund'
-  );
-  const refundToken = singleTokenMetadata('1', 'Refund Token', 'Refundable share of the crowdfund pool.');
-  const progressToken = singleTokenMetadata('2', 'Progress Token', 'Tracks total deposits in the crowdfund pool.');
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('crowdfund collectionMetadata', ['name', 'image', 'description']);
+  }
 
-  // Strip the per-token default that metadataPlaceholders() seeds — this
-  // template defines its own per-token entries below, so the default
-  // ipfs://METADATA_TOKEN_DEFAULT shouldn't end up in the sidecar.
-  const { 'ipfs://METADATA_TOKEN_DEFAULT': _drop, ...collectionOnlyPlaceholders } = collectionPlaceholders;
-  void _drop;
+  // Per-token metadata: refund + progress receipts use distinct fixed
+  // names regardless of the caller's --name (the standard expects
+  // these specific receipt names). When the caller passed --uri,
+  // they've taken responsibility for hosting the per-token JSON too
+  // and we reuse the same uri. In inline mode we serialize the
+  // standard receipt names + the caller's image.
+  const refundSource: any = params.uri
+    ? { uri: params.uri }
+    : {
+        inlineMetadata: {
+          name: 'Refund Token',
+          description: 'Refundable share of the crowdfund pool.',
+          image: params.image as string
+        }
+      };
+  const progressSource: any = params.uri
+    ? { uri: params.uri }
+    : {
+        inlineMetadata: {
+          name: 'Progress Token',
+          description: 'Tracks total deposits in the crowdfund pool.',
+          image: params.image as string
+        }
+      };
 
   return buildMsg({
     collectionApprovals,
@@ -242,12 +270,10 @@ export function buildCrowdfund(params: CrowdfundParams): any {
     // fractional denom unit needed. The previous version added alias
     // paths with `decimals: 0` which the chain rejects.
     aliasPathsToAdd: [],
-    collectionMetadata,
-    tokenMetadata: [refundToken.entry, progressToken.entry],
-    metadataPlaceholders: {
-      ...collectionOnlyPlaceholders,
-      [refundToken.placeholder.uri]: refundToken.placeholder.content,
-      [progressToken.placeholder.uri]: progressToken.placeholder.content
-    }
+    collectionMetadata: collectionSource,
+    tokenMetadata: [
+      tokenMetadataEntry([{ start: '1', end: '1' }], refundSource, 'refund token'),
+      tokenMetadataEntry([{ start: '2', end: '2' }], progressSource, 'progress token')
+    ]
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/crowdfund.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/crowdfund.ts
@@ -15,7 +15,8 @@ import {
   scalingBalances,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface CrowdfundParams {
@@ -56,6 +57,10 @@ export function buildCrowdfund(params: CrowdfundParams): any {
       toListId: 'All',
       initiatedByListId: 'All',
       approvalId: 'deposit-refund',
+      ...approvalMetadata(
+        'Deposit',
+        'Contribute USDC and receive a refund token'
+      ),
       transferTimes: [{ start: '1', end: deadlineTs }],
       tokenIds: [{ start: '1', end: '1' }],
       ownershipTimes: FOREVER,
@@ -86,6 +91,10 @@ export function buildCrowdfund(params: CrowdfundParams): any {
       toListId: crowdfunderAddr,
       initiatedByListId: 'All',
       approvalId: 'deposit-progress',
+      ...approvalMetadata(
+        'Progress Tracker',
+        'Tracks cumulative contributions to crowdfunder'
+      ),
       transferTimes: [{ start: '1', end: deadlineTs }],
       tokenIds: [{ start: '2', end: '2' }],
       ownershipTimes: FOREVER,
@@ -111,6 +120,10 @@ export function buildCrowdfund(params: CrowdfundParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: crowdfunderAddr,
       approvalId: 'success',
+      ...approvalMetadata(
+        'Withdraw',
+        'Crowdfunder withdraws funds when goal is met'
+      ),
       // Strictly AFTER deadline — `deadlineTs + 1` prevents the
       // success claim from racing the final deposit at the exact
       // deadline second. Matches CrowdfundRegistry's
@@ -158,6 +171,10 @@ export function buildCrowdfund(params: CrowdfundParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: 'All',
       approvalId: 'refund',
+      ...approvalMetadata(
+        'Refund',
+        'After deadline, burn refund token to reclaim deposit'
+      ),
       // Same `deadlineTs + 1` boundary as the success approval — no
       // refunds at the exact deadline second, only strictly after.
       transferTimes: [{ start: String(BigInt(deadlineTs) + 1n), end: MAX_UINT64 }],
@@ -210,6 +227,7 @@ export function buildCrowdfund(params: CrowdfundParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: 'All',
       approvalId: 'burn',
+      ...approvalMetadata('Burn', 'Burn leftover refund tokens'),
       transferTimes: FOREVER,
       tokenIds: [{ start: '1', end: '2' }],
       ownershipTimes: FOREVER,

--- a/packages/bitbadgesjs-sdk/src/core/builders/custom-2fa.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/custom-2fa.ts
@@ -8,11 +8,16 @@ import {
   buildMsg,
   baselinePermissions,
   alwaysLockedPermission,
-  alwaysLockedTokenIdsPermission
+  alwaysLockedTokenIdsPermission,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface Custom2FAParams {
-  name: string;
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
+  name?: string;
   image?: string;
   description?: string;
   burnable?: boolean;
@@ -117,6 +122,16 @@ export function buildCustom2FA(params: Custom2FAParams): any {
     canAddMoreCosmosCoinWrapperPaths: [alwaysLockedPermission()]
   };
 
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('custom-2fa collectionMetadata', ['name', 'image', 'description']);
+  }
+
   return buildMsg({
     collectionApprovals,
     standards: ['Custom-2FA'],
@@ -126,6 +141,8 @@ export function buildCustom2FA(params: Custom2FAParams): any {
       maxSupplyPerId: '0',
       noForcefulPostMintTransfers: false,
       disablePoolCreation: true
-    }
+    },
+    collectionMetadata: collectionSource,
+    tokenMetadata: [tokenMetadataEntry([{ start: '1', end: '1' }], collectionSource, '2FA token')]
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/custom-2fa.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/custom-2fa.ts
@@ -11,7 +11,8 @@ import {
   alwaysLockedTokenIdsPermission,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface Custom2FAParams {
@@ -32,6 +33,10 @@ export function buildCustom2FA(params: Custom2FAParams): any {
       toListId: 'All',
       initiatedByListId: 'All',
       approvalId: 'custom-2fa-mint',
+      ...approvalMetadata(
+        'Issue 2FA token',
+        'Mint a short-lived two-factor authentication token. Tokens auto-expire so they cannot be reused.'
+      ),
       transferTimes: FOREVER,
       tokenIds: [{ start: '1', end: '1' }],
       ownershipTimes: FOREVER,
@@ -84,6 +89,7 @@ export function buildCustom2FA(params: Custom2FAParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: 'All',
       approvalId: 'burn',
+      ...approvalMetadata('Burn', 'Burn 2FA tokens to the burn address.'),
       transferTimes: FOREVER,
       tokenIds: [{ start: '1', end: '1' }],
       ownershipTimes: FOREVER,
@@ -99,6 +105,10 @@ export function buildCustom2FA(params: Custom2FAParams): any {
       toListId: 'All',
       initiatedByListId: 'All',
       approvalId: 'free-transfer',
+      ...approvalMetadata(
+        'Transferable',
+        'Allow holders to transfer 2FA tokens between addresses.'
+      ),
       transferTimes: FOREVER,
       tokenIds: [{ start: '1', end: '1' }],
       ownershipTimes: FOREVER,

--- a/packages/bitbadgesjs-sdk/src/core/builders/intent.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/intent.ts
@@ -14,7 +14,8 @@ import {
   durationToTimestamp,
   uniqueId,
   mintToBurnBalances,
-  buildUserApprovalMsg
+  buildUserApprovalMsg,
+  approvalMetadata
 } from './shared.js';
 
 export interface IntentParams {
@@ -37,6 +38,10 @@ export function buildIntent(params: IntentParams): any {
 
   const approval = {
     approvalId: id,
+    ...approvalMetadata(
+      'Intent',
+      'Atomic OTC swap — pay one denom and receive another in a single transfer.'
+    ),
     toListId: 'All',
     initiatedByListId: 'All',
     transferTimes: [{ start: '1', end: expirationTs }],

--- a/packages/bitbadgesjs-sdk/src/core/builders/listing.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/listing.ts
@@ -12,7 +12,8 @@ import {
   toBaseUnits,
   durationToTimestamp,
   uniqueId,
-  buildUserApprovalMsg
+  buildUserApprovalMsg,
+  approvalMetadata
 } from './shared.js';
 
 export interface ListingParams {
@@ -43,6 +44,10 @@ export function buildListing(params: ListingParams): any {
 
   const approval = {
     approvalId: id,
+    ...approvalMetadata(
+      'Listing',
+      'This approval is a conditional offer to transfer a token from this address if certain conditions are met.'
+    ),
     toListId: 'All',
     initiatedByListId: 'All',
     transferTimes: [{ start: '1', end: expirationTs }],

--- a/packages/bitbadgesjs-sdk/src/core/builders/payment-request.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/payment-request.ts
@@ -25,7 +25,8 @@ import {
   zeroMaxTransfers,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface PaymentRequestParams {
@@ -71,6 +72,10 @@ export function buildPaymentRequest(params: PaymentRequestParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: params.payer,
       approvalId: 'payment-request-pay',
+      ...approvalMetadata(
+        'Pay',
+        'Approve and pay from your wallet'
+      ),
       transferTimes: [{ start: '1', end: expirationTs }],
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,
@@ -100,6 +105,7 @@ export function buildPaymentRequest(params: PaymentRequestParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: params.payer,
       approvalId: 'payment-request-deny',
+      ...approvalMetadata('Deny', 'Reject this payment request'),
       transferTimes: [{ start: '1', end: expirationTs }],
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,

--- a/packages/bitbadgesjs-sdk/src/core/builders/payment-request.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/payment-request.ts
@@ -21,9 +21,11 @@ import {
   buildMsg,
   frozenPermissions,
   defaultBalances,
-  metadataPlaceholders,
   mintToBurnBalances,
-  zeroMaxTransfers
+  zeroMaxTransfers,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface PaymentRequestParams {
@@ -32,12 +34,15 @@ export interface PaymentRequestParams {
   payer: string; // bb1... address — the human approver/payer
   recipient: string; // bb1... address — agent/merchant receiving funds
   expiration?: string; // duration shorthand, default "30d"
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
   name?: string;
+  image?: string;
   /**
    * Free-form rationale shown to the payer at approval time. Mirrors
    * Stripe Link's ≥100 char `context` requirement — agents must justify
-   * the spend in human-readable terms. Surfaced via the off-chain
-   * metadata sidecar (collection description), not on-chain proto fields.
+   * the spend in human-readable terms. Used as the collection description
+   * (in inline mode) or appended to the auto-generated default.
    */
   context?: string;
 }
@@ -115,14 +120,24 @@ export function buildPaymentRequest(params: PaymentRequestParams): any {
     // current time vs. transferTimes[0].end.
   ];
 
+  // PaymentRequest's description has a special semantic: --context is
+  // the payer-facing rationale that the standard requires. If the
+  // caller passes --context (and didn't pass --uri), use it as the
+  // inline description verbatim; otherwise the caller MUST supply
+  // --description (or --uri) explicitly.
   const description = params.context
     ? `${params.context}\n\nPayer: ${params.payer}\nAmount: ${params.amount} ${coin.symbol}`
-    : `Payment request for ${params.amount} ${coin.symbol}`;
+    : undefined;
 
-  const { collectionMetadata, tokenMetadata, placeholders } = metadataPlaceholders(
-    params.name || 'Payment Request',
-    description
-  );
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('payment-request collectionMetadata', ['name', 'image', 'description']);
+  }
 
   return buildMsg({
     collectionApprovals,
@@ -140,8 +155,7 @@ export function buildPaymentRequest(params: PaymentRequestParams): any {
     // KEY INVERSION vs. Bounty: NO mintEscrowCoinsToTransfer. The pay
     // approval debits the payer's wallet directly via initiator routing
     // when they execute the approval — there's no pre-funded escrow.
-    collectionMetadata,
-    tokenMetadata,
-    metadataPlaceholders: placeholders
+    collectionMetadata: collectionSource,
+    tokenMetadata: [tokenMetadataEntry(FOREVER, collectionSource, 'payment request receipt')]
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/pm-buy-intent.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/pm-buy-intent.ts
@@ -12,7 +12,8 @@ import {
   toBaseUnits,
   durationToTimestamp,
   uniqueId,
-  buildUserApprovalMsg
+  buildUserApprovalMsg,
+  approvalMetadata
 } from './shared.js';
 
 export interface PmBuyIntentParams {
@@ -39,6 +40,10 @@ export function buildPmBuyIntent(params: PmBuyIntentParams): any {
 
   const approval = {
     approvalId: id,
+    ...approvalMetadata(
+      'Buy prediction tokens',
+      'Receive prediction market outcome tokens in exchange for an escrowed payment.'
+    ),
     fromListId: 'All',
     initiatedByListId: 'All',
     transferTimes: [{ start: '1', end: expirationTs }],

--- a/packages/bitbadgesjs-sdk/src/core/builders/pm-sell-intent.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/pm-sell-intent.ts
@@ -12,7 +12,8 @@ import {
   toBaseUnits,
   durationToTimestamp,
   uniqueId,
-  buildUserApprovalMsg
+  buildUserApprovalMsg,
+  approvalMetadata
 } from './shared.js';
 
 export interface PmSellIntentParams {
@@ -39,6 +40,10 @@ export function buildPmSellIntent(params: PmSellIntentParams): any {
 
   const approval = {
     approvalId: id,
+    ...approvalMetadata(
+      'Sell prediction tokens',
+      'Offer prediction market outcome tokens for sale at a fixed price.'
+    ),
     toListId: 'All',
     initiatedByListId: 'All',
     transferTimes: [{ start: '1', end: expirationTs }],

--- a/packages/bitbadgesjs-sdk/src/core/builders/prediction-market.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/prediction-market.ts
@@ -13,7 +13,8 @@ import {
   scalingBalances,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface PredictionMarketParams {
@@ -44,6 +45,10 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
   // 1. Paired Mint — mint both YES and NO by depositing USDC
   const pairedMint = {
     approvalId: `pm-mint-${mintId}`,
+    ...approvalMetadata(
+      'Deposit',
+      'Deposit to receive equal YES and NO outcome tokens'
+    ),
     fromListId: 'Mint',
     toListId: 'All',
     initiatedByListId: 'All',
@@ -79,6 +84,10 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
   // 2. Free transfer — tokens are freely transferable
   const freeTransfer = {
     approvalId: `pm-transfer-${transferId}`,
+    ...approvalMetadata(
+      'Transferable',
+      'Freely trade YES and NO tokens between any addresses'
+    ),
     fromListId: '!Mint',
     toListId: 'All',
     initiatedByListId: 'All',
@@ -92,6 +101,10 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
   // 3. Pre-Settlement Redeem — burn both YES+NO to get USDC back
   const preRedeem = {
     approvalId: `pm-redeem-${redeemId}`,
+    ...approvalMetadata(
+      'Redeem Pair',
+      'Burn equal YES and NO tokens to reclaim your deposit before settlement'
+    ),
     fromListId: '!Mint',
     toListId: BURN_ADDRESS,
     initiatedByListId: 'All',
@@ -151,10 +164,13 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
     tokenIds: any[],
     proposalId: string,
     burnAmount: string,
-    payoutAmount: string
+    payoutAmount: string,
+    metaName: string,
+    metaDescription: string
   ) {
     return {
       approvalId,
+      ...approvalMetadata(metaName, metaDescription),
       fromListId: '!Mint',
       toListId: BURN_ADDRESS,
       initiatedByListId: 'All',
@@ -201,10 +217,26 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
   }
 
   // Win: burn 1 token → 1 coin. Push: burn 2 tokens → 1 coin.
-  const settleYes = settlementApproval(`pm-settle-yes-${settleYesId}`, yesTokenIds, `pm-settle-yes-${settleYesId}`, '1', '1');
-  const settleNo = settlementApproval(`pm-settle-no-${settleNoId}`, noTokenIds, `pm-settle-no-${settleNoId}`, '1', '1');
-  const settlePushYes = settlementApproval(`pm-settle-push-yes-${settlePushYesId}`, yesTokenIds, `pm-settle-push-yes-${settlePushYesId}`, '2', '1');
-  const settlePushNo = settlementApproval(`pm-settle-push-no-${settlePushNoId}`, noTokenIds, `pm-settle-push-no-${settlePushNoId}`, '2', '1');
+  const settleYes = settlementApproval(
+    `pm-settle-yes-${settleYesId}`, yesTokenIds, `pm-settle-yes-${settleYesId}`, '1', '1',
+    'YES wins',
+    'Burn YES tokens to claim full payout after YES outcome is confirmed'
+  );
+  const settleNo = settlementApproval(
+    `pm-settle-no-${settleNoId}`, noTokenIds, `pm-settle-no-${settleNoId}`, '1', '1',
+    'NO wins',
+    'Burn NO tokens to claim full payout after NO outcome is confirmed'
+  );
+  const settlePushYes = settlementApproval(
+    `pm-settle-push-yes-${settlePushYesId}`, yesTokenIds, `pm-settle-push-yes-${settlePushYesId}`, '2', '1',
+    'Push (YES side)',
+    'Burn YES tokens to claim half payout after push (draw) outcome'
+  );
+  const settlePushNo = settlementApproval(
+    `pm-settle-push-no-${settlePushNoId}`, noTokenIds, `pm-settle-push-no-${settlePushNoId}`, '2', '1',
+    'Push (NO side)',
+    'Burn NO tokens to claim half payout after push (draw) outcome'
+  );
 
   const collectionApprovals = [pairedMint, freeTransfer, preRedeem, settleYes, settleNo, settlePushYes, settlePushNo];
 

--- a/packages/bitbadgesjs-sdk/src/core/builders/prediction-market.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/prediction-market.ts
@@ -11,12 +11,16 @@ import {
   buildAliasPath,
   frozenPermissions,
   scalingBalances,
-  singleTokenMetadata
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface PredictionMarketParams {
   verifier: string; // bb1... resolver address
   denom?: string; // payment coin, defaults to USDC (use BADGE for testnet)
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
   name?: string;
   description?: string;
   image?: string;
@@ -204,24 +208,51 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
 
   const collectionApprovals = [pairedMint, freeTransfer, preRedeem, settleYes, settleNo, settlePushYes, settlePushNo];
 
-  const yesToken = singleTokenMetadata('1', 'YES', params.description, params.image);
-  const noToken = singleTokenMetadata('2', 'NO', params.description, params.image);
-  const tokenMetadata = [yesToken.entry, noToken.entry];
-  const yesAlias = buildAliasPath('uyes', 'YES', coin.decimals, params.image, 'YES', params.description);
-  const noAlias = buildAliasPath('uno', 'NO', coin.decimals, params.image, 'NO', params.description);
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('prediction-market collectionMetadata', ['name', 'image', 'description']);
+  }
+
+  // YES/NO outcome tokens use fixed names regardless of caller --name
+  // (the standard expects these). In inline mode we serialize them
+  // with the caller's image + description.
+  const yesSource: any = params.uri
+    ? { uri: params.uri }
+    : { inlineMetadata: { name: 'YES', description: params.description as string, image: params.image as string } };
+  const noSource: any = params.uri
+    ? { uri: params.uri }
+    : { inlineMetadata: { name: 'NO', description: params.description as string, image: params.image as string } };
+
+  const yesAlias = buildAliasPath({
+    denom: 'uyes',
+    symbol: 'YES',
+    decimals: coin.decimals,
+    pathMetadata: yesSource,
+    unitMetadata: yesSource
+  });
+  const noAlias = buildAliasPath({
+    denom: 'uno',
+    symbol: 'NO',
+    decimals: coin.decimals,
+    pathMetadata: noSource,
+    unitMetadata: noSource
+  });
 
   return buildMsg({
     collectionApprovals,
     validTokenIds: [{ start: '1', end: '2' }],
     standards: ['Prediction Market'],
     collectionPermissions: frozenPermissions(),
-    tokenMetadata,
-    metadataPlaceholders: {
-      [yesToken.placeholder.uri]: yesToken.placeholder.content,
-      [noToken.placeholder.uri]: noToken.placeholder.content,
-      ...yesAlias.placeholders,
-      ...noAlias.placeholders
-    },
+    collectionMetadata: collectionSource,
+    tokenMetadata: [
+      tokenMetadataEntry([{ start: '1', end: '1' }], yesSource, 'YES token'),
+      tokenMetadataEntry([{ start: '2', end: '2' }], noSource, 'NO token')
+    ],
     invariants: {
       noCustomOwnershipTimes: true,
       maxSupplyPerId: '0',
@@ -230,6 +261,6 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
       noForcefulPostMintTransfers: true,
       disablePoolCreation: false
     },
-    aliasPathsToAdd: [yesAlias.path, noAlias.path]
+    aliasPathsToAdd: [yesAlias, noAlias]
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/product-catalog.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/product-catalog.ts
@@ -14,7 +14,8 @@ import {
   zeroAmounts,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface ProductItem {
@@ -60,6 +61,10 @@ export function buildProductCatalog(params: ProductCatalogParams): any {
 
     return {
       approvalId,
+      ...approvalMetadata(
+        'Purchase',
+        'Buy this product at the listed price.'
+      ),
       fromListId: 'Mint',
       toListId: product.burn ? BURN_ADDRESS : 'All',
       initiatedByListId: 'All',
@@ -97,6 +102,7 @@ export function buildProductCatalog(params: ProductCatalogParams): any {
   // Burn approval: anyone can burn their tokens
   const burnApproval = {
     approvalId: `product-burn-${randomId()}`,
+    ...approvalMetadata('Burn', 'Burn product token'),
     fromListId: '!Mint',
     toListId: BURN_ADDRESS,
     initiatedByListId: 'All',

--- a/packages/bitbadgesjs-sdk/src/core/builders/product-catalog.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/product-catalog.ts
@@ -9,10 +9,12 @@ import {
   toBaseUnits,
   buildMsg,
   frozenPermissions,
-  singleTokenMetadata,
   mintToBurnBalances,
   zeroMaxTransfers,
-  zeroAmounts
+  zeroAmounts,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface ProductItem {
@@ -21,12 +23,20 @@ export interface ProductItem {
   denom: string; // USDC, BADGE
   maxSupply?: number; // 0 = unlimited
   burn?: boolean; // burn on purchase
+  /** Optional pre-hosted per-product metadata URI. */
+  uri?: string;
+  description?: string;
+  image?: string;
 }
 
 export interface ProductCatalogParams {
   products: ProductItem[];
   storeAddress: string; // bb1... payment recipient
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
   name?: string;
+  description?: string;
+  image?: string;
 }
 
 export function buildProductCatalog(params: ProductCatalogParams): any {
@@ -99,28 +109,50 @@ export function buildProductCatalog(params: ProductCatalogParams): any {
 
   const collectionApprovals = [...purchaseApprovals, burnApproval];
 
-  // Per-product metadata: each product gets its own placeholder URI keyed
-  // by token id. Accumulate the sidecar entries so the auto-apply flow has
-  // full coverage.
-  const tokenMetadataAndPlaceholders = products.map((product, i) =>
-    singleTokenMetadata(String(i + 1), product.name)
-  );
-  const tokenMetadata = tokenMetadataAndPlaceholders.map((t) => t.entry);
-  const productPlaceholders: Record<string, { name: string; description: string; image: string }> = {};
-  for (const t of tokenMetadataAndPlaceholders) {
-    productPlaceholders[t.placeholder.uri] = t.placeholder.content;
+  // Per-product metadata: each product becomes one tokenMetadata entry
+  // keyed by the token id. The product itself supplies name (required);
+  // optional `--uri`/`--image`/`--description` flow per product, with
+  // the catalog-level image/description as fallback.
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('product-catalog collectionMetadata', ['name', 'image', 'description']);
+  }
+
+  const tokenMetadata = products.map((product, i) => {
+    const idStr = String(i + 1);
+    const productSource: any = product.uri
+      ? { uri: product.uri }
+      : {
+          inlineMetadata: {
+            name: product.name,
+            description: product.description || product.name,
+            image: (product.image || params.image) as string
+          }
+        };
+    return tokenMetadataEntry([{ start: idStr, end: idStr }], productSource, `product "${product.name}"`);
+  });
+
+  // Empty-products case still needs at least one tokenMetadata entry —
+  // emit a single full-range placeholder mirroring the collection.
+  if (tokenMetadata.length === 0) {
+    tokenMetadata.push(tokenMetadataEntry(FOREVER, collectionSource, 'product placeholder'));
   }
 
   return buildMsg({
     collectionApprovals,
-    validTokenIds: [{ start: '1', end: String(products.length) }],
+    validTokenIds: [{ start: '1', end: String(products.length || 1) }],
     standards: ['Products'],
     collectionPermissions: frozenPermissions(),
+    collectionMetadata: collectionSource,
     tokenMetadata,
     invariants: {
       noCustomOwnershipTimes: true,
       disablePoolCreation: true
-    },
-    metadataPlaceholders: productPlaceholders
+    }
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/quests.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/quests.ts
@@ -12,7 +12,8 @@ import {
   mintToBurnBalances,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface QuestsParams {
@@ -45,6 +46,10 @@ export function buildQuests(params: QuestsParams): any {
       toListId: 'All',
       initiatedByListId: 'All',
       approvalId: questApprovalId,
+      ...approvalMetadata(
+        'Complete This Quest!',
+        'Meet the criteria of the quest and earn your rewards.'
+      ),
       transferTimes: FOREVER,
       tokenIds: [{ start: '1', end: '1' }],
       ownershipTimes: FOREVER,
@@ -77,6 +82,7 @@ export function buildQuests(params: QuestsParams): any {
       toListId: BURN_ADDRESS,
       initiatedByListId: 'All',
       approvalId: 'burnable-approval',
+      ...approvalMetadata('Burn', 'Burn quest tokens to the burn address.'),
       transferTimes: FOREVER,
       tokenIds: [{ start: '1', end: '1' }],
       ownershipTimes: FOREVER,

--- a/packages/bitbadgesjs-sdk/src/core/builders/quests.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/quests.ts
@@ -9,14 +9,21 @@ import {
   toBaseUnits,
   buildMsg,
   baselinePermissions,
-  mintToBurnBalances
+  mintToBurnBalances,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface QuestsParams {
   reward: number; // display units per claim
   denom: string; // USDC, BADGE
   maxClaims: number;
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
   name?: string;
+  description?: string;
+  image?: string;
 }
 
 export function buildQuests(params: QuestsParams): any {
@@ -78,6 +85,16 @@ export function buildQuests(params: QuestsParams): any {
     }
   ];
 
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('quests collectionMetadata', ['name', 'image', 'description']);
+  }
+
   return buildMsg({
     collectionApprovals,
     standards: ['Quests'],
@@ -90,6 +107,8 @@ export function buildQuests(params: QuestsParams): any {
     },
     mintEscrowCoinsToTransfer: [
       { amount: String(BigInt(rewardBase) * BigInt(params.maxClaims)), denom: coin.denom }
-    ]
+    ],
+    collectionMetadata: collectionSource,
+    tokenMetadata: [tokenMetadataEntry([{ start: '1', end: '1' }], collectionSource, 'quest token')]
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/recurring-payment.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/recurring-payment.ts
@@ -14,7 +14,8 @@ import {
   parseDuration,
   durationToTimestamp,
   uniqueId,
-  buildUserApprovalMsg
+  buildUserApprovalMsg,
+  approvalMetadata
 } from './shared.js';
 
 export interface RecurringPaymentParams {
@@ -35,6 +36,10 @@ export function buildRecurringPayment(params: RecurringPaymentParams): any {
 
   const approval = {
     approvalId: id,
+    ...approvalMetadata(
+      'Recurring Approval',
+      'This approves the charge / transfer on a recurring basis.'
+    ),
     fromListId: 'Mint',
     initiatedByListId: 'All',
     transferTimes: [{ start: '1', end: expirationTs }],

--- a/packages/bitbadgesjs-sdk/src/core/builders/shared.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/shared.ts
@@ -110,76 +110,138 @@ export function uniqueId(prefix?: string): string {
 // ── Common builder helpers ───────────────────────────────────────────────────
 
 /**
- * A sidecar map of placeholder URI → off-chain metadata content. Templates
- * accumulate these and attach them to the emitted Msg as `value._meta.metadataPlaceholders`
- * so the CLI's Metadata To Upload section (and any frontend consumer)
- * knows which placeholder URIs already have content provided.
+ * Per-preset metadata field shape. Approvals are functional/text-based and
+ * MUST NOT carry an image; everything else requires name + image + description.
  */
-export type PlaceholderSidecar = Record<string, { name: string; description: string; image: string }>;
+export type MetadataPreset =
+  | 'collection'
+  | 'token'
+  | 'aliasPath'
+  | 'wrapperPath'
+  | 'addressList'
+  | 'dynamicStore'
+  | 'approval';
 
 /**
- * Build collection + default-token metadata using placeholder URIs that the
- * metadata auto-apply flow understands. Returns three things:
- *
- *   - `collectionMetadata` and `tokenMetadata` to drop into `buildMsg(...)`
- *   - `placeholders` — a sidecar map keyed by the placeholder URIs above,
- *     populated with the supplied name/description/image (or sane defaults).
- *
- * Callers should merge the returned `placeholders` into their own sidecar and
- * pass the combined map to `buildMsg({ ..., metadataPlaceholders })`, which
- * surfaces it on the emitted Msg as `value._meta.metadataPlaceholders`.
+ * Inline metadata input for the two-mode builder contract. Approvals
+ * pass `inlineMetadata: { name, description }` (no image); every other
+ * preset requires `name`, `image`, and `description`.
  */
-export function metadataPlaceholders(name: string, description?: string, image?: string) {
-  const collectionUri = 'ipfs://METADATA_COLLECTION';
-  const tokenUri = 'ipfs://METADATA_TOKEN_DEFAULT';
-  const content = {
-    name,
-    description: description || '',
-    image: image || BITBADGES_DEFAULT_IMAGE
-  };
-  return {
-    collectionMetadata: { uri: collectionUri, customData: '' },
-    tokenMetadata: [
-      { uri: tokenUri, customData: '', tokenIds: FOREVER }
-    ],
-    placeholders: {
-      [collectionUri]: { ...content },
-      [tokenUri]: { ...content }
-    } as PlaceholderSidecar
-  };
+export interface InlineMetadataInput {
+  name: string;
+  description: string;
+  /** Required for every preset except `approval`. */
+  image?: string;
+  /** Optional pass-through fields, serialized verbatim into customData. */
+  bannerImage?: string;
+  category?: string;
+  externalUrl?: string;
+  tags?: string[];
+  socials?: Record<string, string>;
+  attributes?: { type: string; name: string; value: string | number | boolean }[];
 }
 
 /**
- * Build a per-token metadata entry using a placeholder URI scoped to the
- * token id. Returns `{ entry, placeholder }`:
- *
- *   - `entry` is the object to push into `tokenMetadata: [...]`
- *   - `placeholder` is the sidecar entry the caller should merge into its
- *     accumulated PlaceholderSidecar and pass to buildMsg via
- *     `metadataPlaceholders`.
+ * Two accepted modes per metadata-bearing entity:
+ *   1. `{ uri }` — caller has already hosted the JSON; goes straight to
+ *      the on-chain `uri` field, customData stays empty.
+ *   2. `{ inlineMetadata }` — serialized to JSON and stashed in
+ *      customData; on-chain `uri` stays empty.
  */
-export function singleTokenMetadata(tokenId: string, name: string, description?: string, image?: string) {
-  const uri = `ipfs://METADATA_TOKEN_${tokenId}`;
-  return {
-    entry: {
-      uri,
-      customData: '',
-      tokenIds: [{ start: tokenId, end: tokenId }]
-    },
-    placeholder: {
-      uri,
-      content: {
-        name,
-        description: description || '',
-        image: image || BITBADGES_DEFAULT_IMAGE
-      }
+export type MetadataSource =
+  | { uri: string; inlineMetadata?: undefined }
+  | { uri?: undefined; inlineMetadata: InlineMetadataInput };
+
+/** Thrown when neither mode is satisfied for a required metadata entity. */
+export class MetadataMissingError extends Error {
+  constructor(label: string, requiredFields: string[]) {
+    super(
+      `${label}: metadata is required. Pass either { uri: "..." } or { inlineMetadata: { ${requiredFields.join(', ')} } }.`
+    );
+    this.name = 'MetadataMissingError';
+  }
+}
+
+function requiredFieldsFor(preset: MetadataPreset): string[] {
+  if (preset === 'approval') return ['name', 'description'];
+  return ['name', 'image', 'description'];
+}
+
+function validateInlineMetadata(meta: InlineMetadataInput, preset: MetadataPreset, label: string): void {
+  if (!meta.name || typeof meta.name !== 'string') {
+    throw new MetadataMissingError(label, requiredFieldsFor(preset));
+  }
+  if (!meta.description || typeof meta.description !== 'string') {
+    throw new MetadataMissingError(label, requiredFieldsFor(preset));
+  }
+  if (preset === 'approval') {
+    if (meta.image && meta.image !== '') {
+      throw new Error(`${label}: approval metadata must not include image (approvals are text-only).`);
     }
-  };
+  } else {
+    if (!meta.image || typeof meta.image !== 'string') {
+      throw new MetadataMissingError(label, requiredFieldsFor(preset));
+    }
+  }
+}
+
+/**
+ * Resolve a MetadataSource into the on-chain `(uri, customData)` pair.
+ * Throws `MetadataMissingError` when neither mode is provided. Inline
+ * mode serializes the validated metadata into customData; URI mode
+ * leaves customData empty.
+ */
+export function resolveMetadataPair(
+  source: MetadataSource | undefined,
+  preset: MetadataPreset,
+  label: string
+): { uri: string; customData: string } {
+  if (!source) throw new MetadataMissingError(label, requiredFieldsFor(preset));
+  if (source.uri !== undefined) {
+    if (typeof source.uri !== 'string' || source.uri.length === 0) {
+      throw new MetadataMissingError(label, requiredFieldsFor(preset));
+    }
+    return { uri: source.uri, customData: '' };
+  }
+  validateInlineMetadata(source.inlineMetadata, preset, label);
+  // Serialize only the known fields — drop anything caller passes that
+  // isn't part of InlineMetadataInput so customData stays predictable.
+  const { name, description, image, bannerImage, category, externalUrl, tags, socials, attributes } =
+    source.inlineMetadata;
+  const payload: Record<string, unknown> = { name, description };
+  if (preset !== 'approval' && image) payload.image = image;
+  if (bannerImage) payload.bannerImage = bannerImage;
+  if (category) payload.category = category;
+  if (externalUrl) payload.externalUrl = externalUrl;
+  if (tags) payload.tags = tags;
+  if (socials) payload.socials = socials;
+  if (attributes) payload.attributes = attributes;
+  return { uri: '', customData: JSON.stringify(payload) };
+}
+
+/**
+ * Build a per-token metadata entry. The caller supplies a token id
+ * (or range) and a metadata source; the returned entry is ready to
+ * push into `tokenMetadata: [...]`.
+ */
+export function tokenMetadataEntry(
+  tokenIds: { start: string; end: string }[] | string,
+  source: MetadataSource,
+  label?: string
+) {
+  const ids = typeof tokenIds === 'string' ? [{ start: tokenIds, end: tokenIds }] : tokenIds;
+  const display = label || (typeof tokenIds === 'string' ? `token ${tokenIds}` : 'token');
+  const { uri, customData } = resolveMetadataPair(source, 'token', display);
+  return { uri, customData, tokenIds: ids };
 }
 
 /**
  * Build a complete MsgUniversalUpdateCollection with collectionId "0" (new collection).
  * Output is wrapped in { typeUrl, value } for direct use with signing clients.
+ *
+ * Collection metadata + at least one tokenMetadata entry are REQUIRED — the
+ * builder throws `MetadataMissingError` if neither a uri nor an
+ * inlineMetadata source is provided. There is no placeholder fallback.
  */
 export function buildMsg(params: {
   collectionApprovals: any[];
@@ -188,8 +250,13 @@ export function buildMsg(params: {
   collectionPermissions?: any;
   creator?: string;
   manager?: string;
-  collectionMetadata?: any;
-  tokenMetadata?: any[];
+  /** Either pre-resolved `{uri, customData}` or a MetadataSource. Required. */
+  collectionMetadata: { uri: string; customData: string } | MetadataSource;
+  /**
+   * Pre-resolved token metadata entries (already shaped via
+   * `tokenMetadataEntry`). Required — must have at least one entry.
+   */
+  tokenMetadata: { uri: string; customData: string; tokenIds: any[] }[];
   customData?: string;
   defaultBalances?: any;
   invariants?: any;
@@ -197,20 +264,30 @@ export function buildMsg(params: {
   cosmosCoinWrapperPathsToAdd?: any[];
   mintEscrowCoinsToTransfer?: any[];
   /**
-   * Off-chain metadata sidecar the template accumulated. Attached to the
-   * output Msg as `value._meta.metadataPlaceholders`. Templates that don't have
-   * specific content should still pass an empty {} so the auto-apply flow
-   * knows to treat default placeholder URIs as NEEDED.
+   * Per-approval metadata. Map approvalId → MetadataSource. Approvals
+   * not listed here keep an empty `(uri, customData)` pair on the
+   * emitted msg — that's only valid when the approval will never need
+   * a frontend-rendered card.
    */
-  metadataPlaceholders?: PlaceholderSidecar;
+  approvalMetadata?: Record<string, MetadataSource>;
 }) {
-  // Default to placeholder URIs (not the legacy DEFAULT_METADATA_URI). The
-  // metadata auto-apply flow recognizes `ipfs://METADATA_*` and substitutes
-  // them with real uploaded URIs after the off-chain JSON is provided.
-  const collectionMetadata = params.collectionMetadata || { uri: 'ipfs://METADATA_COLLECTION', customData: '' };
-  const tokenMetadata = params.tokenMetadata || [
-    { uri: 'ipfs://METADATA_TOKEN_DEFAULT', customData: '', tokenIds: FOREVER }
-  ];
+  const collectionMetadata = isPair(params.collectionMetadata)
+    ? params.collectionMetadata
+    : resolveMetadataPair(params.collectionMetadata, 'collection', 'collectionMetadata');
+
+  if (!Array.isArray(params.tokenMetadata) || params.tokenMetadata.length === 0) {
+    throw new MetadataMissingError('tokenMetadata', ['name', 'image', 'description']);
+  }
+
+  const collectionApprovals = params.collectionApprovals.map((a: any) => {
+    const src = params.approvalMetadata?.[a.approvalId];
+    if (src) {
+      const { uri, customData } = resolveMetadataPair(src, 'approval', `approval "${a.approvalId}"`);
+      return { ...a, uri, customData };
+    }
+    if (a.uri || a.customData) return a;
+    return { ...a, uri: '', customData: '' };
+  });
 
   const msg: any = {
     typeUrl: '/tokenization.MsgUniversalUpdateCollection',
@@ -226,14 +303,11 @@ export function buildMsg(params: {
       updateCollectionMetadata: true,
       collectionMetadata,
       updateTokenMetadata: true,
-      tokenMetadata,
+      tokenMetadata: params.tokenMetadata,
       updateCustomData: true,
       customData: params.customData || '',
       updateCollectionApprovals: true,
-      collectionApprovals: params.collectionApprovals.map((a: any) => ({
-        ...a,
-        uri: a.uri || `ipfs://METADATA_APPROVAL_${a.approvalId || 'unnamed'}`
-      })),
+      collectionApprovals,
       updateStandards: true,
       standards: params.standards || [],
       updateIsArchived: false,
@@ -246,20 +320,36 @@ export function buildMsg(params: {
     }
   };
 
-  // Attach the sidecar as a per-msg `_meta` annotation on value, keyed
-  // by placeholder URIs that only live inside this msg's body. This is
-  // the single canonical location for the placeholder sidecar; every
-  // producer writes here and every consumer reads from here. There is
-  // no top-level `tx.metadataPlaceholders` copy anywhere in the code-
-  // base. Proto classes strip unknown fields on round-trip, so any
-  // place that reconstructs the msg through a Msg class must preserve
-  // `value._meta` explicitly (see core/review-normalize.ts
-  // reattachInlineMetadata).
-  if (params.metadataPlaceholders && Object.keys(params.metadataPlaceholders).length > 0) {
-    msg.value._meta = { metadataPlaceholders: params.metadataPlaceholders };
-  }
-
   return msg;
+}
+
+function isPair(v: any): v is { uri: string; customData: string } {
+  return v && typeof v === 'object' && typeof v.uri === 'string' && typeof v.customData === 'string';
+}
+
+/**
+ * Helper for builders that accept flat `name`/`description`/`image`/`uri`
+ * params (the historical CLI shape). Resolves to a MetadataSource —
+ * `{uri}` if a uri is given, `{inlineMetadata}` otherwise. Throws via
+ * resolveMetadataPair downstream when neither is satisfied.
+ */
+export function metadataFromFlat(params: {
+  uri?: string;
+  name?: string;
+  description?: string;
+  image?: string;
+}): MetadataSource | undefined {
+  if (params.uri && params.uri.length > 0) return { uri: params.uri };
+  if (params.name || params.description || params.image) {
+    return {
+      inlineMetadata: {
+        name: params.name || '',
+        description: params.description || '',
+        image: params.image
+      }
+    };
+  }
+  return undefined;
 }
 
 /**
@@ -537,27 +627,20 @@ export function sanitizeCosmosPathName(input: string, label: 'denom' | 'symbol' 
 }
 
 /**
- * Build an alias path entry for aliasPathsToAdd plus the matching metadata
- * placeholder sidecar entries for both the path-level metadata URI and the
- * denom unit's metadata URI. Returns `{ path, placeholders }`:
- *
- *   - `path` is the object to push into `aliasPathsToAdd: [...]`
- *   - `placeholders` is a PlaceholderSidecar keyed by the two URIs the
- *     path references. Callers should merge it into the accumulated
- *     sidecar passed to buildMsg via `metadataPlaceholders`.
- *
- * Image/name/description intentionally flow through the sidecar — never
- * onto the proto. The auto-apply flow on the frontend reads them from
- * `metadataPlaceholders` keyed by the path/unit metadata URI.
+ * Build an alias path entry for aliasPathsToAdd. Each path requires
+ * BOTH a path-level metadata source AND a denom-unit metadata source —
+ * they're two separate on-chain `(uri, customData)` pairs. Pass either
+ * `{ uri }` or `{ inlineMetadata: { name, image, description } }` for
+ * each (per the per-preset shape).
  */
-export function buildAliasPath(
-  denom: string,
-  symbol: string,
-  decimals: number,
-  image?: string,
-  name?: string,
-  description?: string
-) {
+export function buildAliasPath(params: {
+  denom: string;
+  symbol: string;
+  decimals: number;
+  pathMetadata: MetadataSource;
+  unitMetadata: MetadataSource;
+}) {
+  const { denom, symbol, decimals } = params;
   // Chain rule: denom unit decimals must be > 0. The chain rejects
   // `decimals: '0'` with "denom unit decimals cannot be 0". Fail fast at
   // build time so callers get a clear error instead of a chain rejection
@@ -592,45 +675,34 @@ export function buildAliasPath(
       `buildAliasPath: denom and symbol cannot be identical ("${denom}"). The chain rejects this with "duplicate denom unit symbol" because both fields are validated against the same per-tx map. Use different strings (e.g. denom="usymbol", symbol="SYMBOL").`
     );
   }
-  const pathUri = `ipfs://METADATA_ALIAS_${denom}`;
-  const unitUri = `ipfs://METADATA_ALIAS_${denom}_UNIT`;
-  const content = {
-    name: name || symbol,
-    description: description || '',
-    image: image || BITBADGES_DEFAULT_IMAGE
-  };
+  const pathPair = resolveMetadataPair(params.pathMetadata, 'aliasPath', `aliasPath "${denom}".metadata`);
+  const unitPair = resolveMetadataPair(params.unitMetadata, 'aliasPath', `aliasPath "${denom}".denomUnits[0].metadata`);
   return {
-    path: {
-      denom,
-      conversion: {
-        sideA: { amount: '1' },
-        sideB: [{ amount: '1', tokenIds: [{ start: '1', end: '1' }], ownershipTimes: FOREVER }]
-      },
-      // Path-level symbol intentionally LEFT EMPTY. The chain validates
-      // path-level symbols and denom-unit-level symbols against the SAME
-      // `symbolPaths` map per tx (validatePathSymbols in
-      // msg_server_universal_update_collection.go:673). When both are set
-      // to the same string, the second insertion fails with "duplicate
-      // denom unit symbol", even though there's only one alias path with
-      // one denom unit. Skipping the path-level entry (chain check is
-      // gated on `if pathSymbol != ""`) avoids the spurious collision
-      // while keeping the user-facing symbol on the denom unit, which is
-      // what the frontend / wallets actually display.
-      symbol: '',
-      denomUnits: [
-        {
-          decimals: String(decimals),
-          symbol,
-          isDefaultDisplay: true,
-          metadata: { uri: unitUri, customData: '' }
-        }
-      ],
-      metadata: { uri: pathUri, customData: '' }
+    denom,
+    conversion: {
+      sideA: { amount: '1' },
+      sideB: [{ amount: '1', tokenIds: [{ start: '1', end: '1' }], ownershipTimes: FOREVER }]
     },
-    placeholders: {
-      [pathUri]: { ...content },
-      [unitUri]: { ...content }
-    } as PlaceholderSidecar
+    // Path-level symbol intentionally LEFT EMPTY. The chain validates
+    // path-level symbols and denom-unit-level symbols against the SAME
+    // `symbolPaths` map per tx (validatePathSymbols in
+    // msg_server_universal_update_collection.go:673). When both are set
+    // to the same string, the second insertion fails with "duplicate
+    // denom unit symbol", even though there's only one alias path with
+    // one denom unit. Skipping the path-level entry (chain check is
+    // gated on `if pathSymbol != ""`) avoids the spurious collision
+    // while keeping the user-facing symbol on the denom unit, which is
+    // what the frontend / wallets actually display.
+    symbol: '',
+    denomUnits: [
+      {
+        decimals: String(decimals),
+        symbol,
+        isDefaultDisplay: true,
+        metadata: unitPair
+      }
+    ],
+    metadata: pathPair
   };
 }
 

--- a/packages/bitbadgesjs-sdk/src/core/builders/shared.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/shared.ts
@@ -328,6 +328,28 @@ function isPair(v: any): v is { uri: string; customData: string } {
 }
 
 /**
+ * Hardcoded inline metadata for a builder-emitted approval.
+ *
+ * Approvals are text-only (no image). Builders use this to attach a
+ * template-specific name + description to each approval so the
+ * indexer can surface meaningful details without a remote fetch.
+ *
+ * Spread directly into an approval object alongside `approvalId`:
+ *
+ *   {
+ *     approvalId: 'bounty-accept',
+ *     ...approvalMetadata('Accept bounty', 'Verifier approves...'),
+ *     ...rest
+ *   }
+ *
+ * The values are intentionally NOT user-customizable — they describe
+ * what the approval IS within the template.
+ */
+export function approvalMetadata(name: string, description: string): { customData: string } {
+  return { customData: JSON.stringify({ name, description }) };
+}
+
+/**
  * Helper for builders that accept flat `name`/`description`/`image`/`uri`
  * params (the historical CLI shape). Resolves to a MetadataSource —
  * `{uri}` if a uri is given, `{inlineMetadata}` otherwise. Throws via

--- a/packages/bitbadgesjs-sdk/src/core/builders/smart-account.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/smart-account.ts
@@ -15,7 +15,8 @@ import {
   alwaysLockedCollectionApprovalPermission,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface SmartAccountParams {
@@ -42,6 +43,10 @@ export function buildSmartAccount(params: SmartAccountParams): any {
       toListId: `!${backingAddr}`,
       initiatedByListId: 'All',
       approvalId: 'smart-account-backing',
+      ...approvalMetadata(
+        'Deposit Approval',
+        'Allows deposits by sending tokens to the backing address.'
+      ),
       transferTimes: FOREVER,
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,
@@ -60,6 +65,10 @@ export function buildSmartAccount(params: SmartAccountParams): any {
       toListId: backingAddr,
       initiatedByListId: 'All',
       approvalId: 'smart-account-unbacking',
+      ...approvalMetadata(
+        'Withdraw Approval',
+        'Allows withdrawals by receiving tokens from the backing address.'
+      ),
       transferTimes: FOREVER,
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,
@@ -78,6 +87,10 @@ export function buildSmartAccount(params: SmartAccountParams): any {
       toListId: 'All',
       initiatedByListId: 'All',
       approvalId: 'transferable-approval',
+      ...approvalMetadata(
+        'Transferable',
+        'Allow holders to transfer smart account tokens between addresses.'
+      ),
       transferTimes: FOREVER,
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,

--- a/packages/bitbadgesjs-sdk/src/core/builders/smart-account.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/smart-account.ts
@@ -12,12 +12,19 @@ import {
   generateAliasAddressForIBCBackedDenom,
   baselinePermissions,
   alwaysLockedPermission,
-  alwaysLockedCollectionApprovalPermission
+  alwaysLockedCollectionApprovalPermission,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface SmartAccountParams {
   backingCoin: string;
   symbol?: string;
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
+  name?: string;
+  description?: string;
   image?: string;
   tradable?: boolean;
   aiAgentVault?: boolean; // adds 'AI Agent Vault' standard tag
@@ -103,14 +110,30 @@ export function buildSmartAccount(params: SmartAccountParams): any {
   // the chain validator without "invalid characters" rejections.
   const cleanSymbol = sanitizeCosmosPathName(symbol, 'symbol');
   const denomStr = 'u' + cleanSymbol.toLowerCase();
-  const alias = buildAliasPath(denomStr, cleanSymbol, coin.decimals, params.image || coin.image);
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('smart-account collectionMetadata', ['name', 'image', 'description']);
+  }
+  const aliasPath = buildAliasPath({
+    denom: denomStr,
+    symbol: cleanSymbol,
+    decimals: coin.decimals,
+    pathMetadata: collectionSource,
+    unitMetadata: collectionSource
+  });
 
   return buildMsg({
     collectionApprovals,
     standards,
     invariants,
-    aliasPathsToAdd: [alias.path],
-    metadataPlaceholders: { ...alias.placeholders },
+    aliasPathsToAdd: [aliasPath],
+    collectionMetadata: collectionSource,
+    tokenMetadata: [tokenMetadataEntry(FOREVER, collectionSource, 'smart account token')],
     collectionPermissions: permissions
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/subscription.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/subscription.ts
@@ -12,7 +12,8 @@ import {
   defaultBalances,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface SubscriptionPayout {
@@ -78,6 +79,10 @@ export function buildSubscription(params: SubscriptionParams): any {
       toListId: 'All',
       initiatedByListId: 'All',
       approvalId: `subscription-tier-${tier}`,
+      ...approvalMetadata(
+        'Subscription Faucet',
+        'This is the minting faucet for subscriptions. This sets the price on the collection-level.'
+      ),
       transferTimes: FOREVER,
       tokenIds: [{ start: String(tier), end: String(tier) }],
       ownershipTimes: FOREVER,
@@ -130,6 +135,10 @@ export function buildSubscription(params: SubscriptionParams): any {
       toListId: 'All',
       initiatedByListId: 'All',
       approvalId: 'free-transfer',
+      ...approvalMetadata(
+        'Transferable',
+        'Allow holders to transfer subscription tokens between addresses.'
+      ),
       transferTimes: FOREVER,
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,

--- a/packages/bitbadgesjs-sdk/src/core/builders/subscription.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/subscription.ts
@@ -9,7 +9,10 @@ import {
   parseDuration,
   buildMsg,
   baselinePermissions,
-  defaultBalances
+  defaultBalances,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface SubscriptionPayout {
@@ -28,7 +31,11 @@ export interface SubscriptionParams {
   payouts?: SubscriptionPayout[];
   tiers?: number; // number of tiers, default 1
   transferable?: boolean; // allow post-mint P2P transfers of subscription tokens
+  /** Pre-hosted collection metadata URI. If provided, name/image/description are ignored. */
+  uri?: string;
   name?: string;
+  description?: string;
+  image?: string;
 }
 
 export function buildSubscription(params: SubscriptionParams): any {
@@ -131,6 +138,16 @@ export function buildSubscription(params: SubscriptionParams): any {
     });
   }
 
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('subscription collectionMetadata', ['name', 'image', 'description']);
+  }
+
   return buildMsg({
     collectionApprovals,
     standards: ['Subscriptions'],
@@ -142,6 +159,8 @@ export function buildSubscription(params: SubscriptionParams): any {
       noForcefulPostMintTransfers: false,
       disablePoolCreation: false
     },
-    defaultBalances: defaultBalances({ autoApproveAllIncomingTransfers: true })
+    defaultBalances: defaultBalances({ autoApproveAllIncomingTransfers: true }),
+    collectionMetadata: collectionSource,
+    tokenMetadata: [tokenMetadataEntry([{ start: '1', end: String(tiers) }], collectionSource, 'subscription token')]
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/vault.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/vault.ts
@@ -14,11 +14,16 @@ import {
   sanitizeCosmosPathName,
   ibcBackedInvariants,
   generateAliasAddressForIBCBackedDenom,
-  baselinePermissions
+  baselinePermissions,
+  tokenMetadataEntry,
+  metadataFromFlat,
+  MetadataMissingError
 } from './shared.js';
 
 export interface VaultParams {
   backingCoin: string; // USDC, BADGE, ATOM, OSMO
+  /** Pre-hosted collection metadata URI. If provided, `name`/`image`/`description` are ignored. */
+  uri?: string;
   name?: string;
   symbol?: string;
   image?: string;
@@ -126,21 +131,30 @@ export function buildVault(params: VaultParams): any {
   // Derive the denom from the (sanitized) symbol — chain enforces
   // global denom uniqueness, so a hardcoded 'uvault' would collide
   // for any user creating more than one vault on the same chain.
-  const alias = buildAliasPath(
-    'u' + symbol.toLowerCase(),
+  const collectionSource = metadataFromFlat({
+    uri: params.uri,
+    name: params.name,
+    description: params.description,
+    image: params.image
+  });
+  if (!collectionSource) {
+    throw new MetadataMissingError('vault collectionMetadata', ['name', 'image', 'description']);
+  }
+  const aliasPath = buildAliasPath({
+    denom: 'u' + symbol.toLowerCase(),
     symbol,
-    coin.decimals,
-    params.image || coin.image,
-    params.name,
-    params.description
-  );
+    decimals: coin.decimals,
+    pathMetadata: collectionSource,
+    unitMetadata: collectionSource
+  });
 
   return buildMsg({
     collectionApprovals,
     standards: ['Smart Token', 'Vault'],
     invariants,
-    aliasPathsToAdd: [alias.path],
-    metadataPlaceholders: { ...alias.placeholders },
+    aliasPathsToAdd: [aliasPath],
+    collectionMetadata: collectionSource,
+    tokenMetadata: [tokenMetadataEntry(FOREVER, collectionSource, 'vault token')],
     collectionPermissions: baselinePermissions()
   });
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/vault.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/vault.ts
@@ -17,7 +17,8 @@ import {
   baselinePermissions,
   tokenMetadataEntry,
   metadataFromFlat,
-  MetadataMissingError
+  MetadataMissingError,
+  approvalMetadata
 } from './shared.js';
 
 export interface VaultParams {
@@ -52,6 +53,10 @@ export function buildVault(params: VaultParams): any {
       toListId: `!${backingAddr}`,
       initiatedByListId: 'All',
       approvalId: 'vault-deposit',
+      ...approvalMetadata(
+        'Deposit',
+        'Open deposit — anyone can deposit backing coins to mint vault tokens.'
+      ),
       transferTimes: FOREVER,
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,
@@ -69,6 +74,10 @@ export function buildVault(params: VaultParams): any {
       toListId: backingAddr,
       initiatedByListId: 'All',
       approvalId: `vault-withdraw-${Math.random().toString(16).slice(2, 10)}`,
+      ...approvalMetadata(
+        'Withdrawal',
+        'Burn vault tokens to withdraw backing coins.'
+      ),
       transferTimes: FOREVER,
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,
@@ -112,6 +121,10 @@ export function buildVault(params: VaultParams): any {
       toListId: params.emergencyRecovery,
       initiatedByListId: params.emergencyRecovery,
       approvalId: 'vault-emergency-migration',
+      ...approvalMetadata(
+        'Emergency Migration',
+        'Emergency fund migration to a recovery address.'
+      ),
       transferTimes: FOREVER,
       tokenIds: FOREVER,
       ownershipTimes: FOREVER,


### PR DESCRIPTION
## Summary

Phase 1 of the metadata-hosting feature on the SDK side (ticket #0371). Adds `parseInlineCustomData()` so the indexer / SDK / frontend can resolve inline JSON in `customData` as off-chain metadata when `uri` is empty, and rewrites the CLI / non-AI builder path with a strict two-mode contract (URI OR inline metadata, throw on missing). The AI builder agent path is intentionally untouched (Phase 2 / #0372).

## Commits

1. `parseInlineCustomData` helper + spec — defensive parser (32 KB cap → JSON.parse → plain-object check → required-shape gate → per-field coercion → fresh `Metadata` instance). Returns null on any failure.
2. audit + verify-standards relaxation — empty-uri findings now suppressed when customData parses inline; approval metadata image check learned to peek inside inline customData and warn if image is set there.
3. core builders rewrite — drops `metadataPlaceholders()`, `singleTokenMetadata()`, and `value._meta.metadataPlaceholders` from non-AI builders. New `MetadataSource` / `MetadataMissingError` / `resolveMetadataPair` / `tokenMetadataEntry` / `metadataFromFlat` helpers. `buildMsg` requires collection + token metadata; `buildAliasPath` takes per-path + per-unit sources. Per-preset shape: collection / token / alias / wrapper / list / store all need name + image + description; approvals need name + description and reject image.
4. CLI templates — every preset now accepts `--uri` OR `--name` + `--image` + `--description` (approvals omit `--image`). No defaults. Replaced the "Metadata To Upload" auto-section with a "Resolved Metadata" section that classifies each entity as URI / INLINE / EMPTY / MIXED with a parsed inline preview.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 79 suites, 2368 tests pass (was 2346 — +22 new `parseInlineCustomData` tests)
- [x] AI builder agent path (`src/builder/agent/`, `src/builder/tools/session/setCollectionMetadata.ts`, `src/builder/tools/session/setTokenMetadata.ts`, `src/builder/tools/session/setApprovalMetadata.ts`, `src/builder/resources/masterPrompt.ts`) is byte-identical to `origin/main`
- [ ] Local CLI smoke: `bitbadges templates vault --backing-coin USDC --name "Test Vault" --description "Test" --image ipfs://abc` produces a tx with empty `uri` + JSON in `customData`
- [ ] Local CLI smoke: `bitbadges templates vault --backing-coin USDC --uri ipfs://prehosted` produces a tx with the URI set + empty `customData`
- [ ] Local CLI smoke: `bitbadges templates vault --backing-coin USDC` (no metadata flags) throws `MetadataMissingError` with a clear message

## Out of scope (Phase 2 / #0372)

AI builder agent + MCP session metadata tools + skill instructions stay on the placeholder pipeline because the frontend post-applies IPFS at submit. Those flip alongside the frontend post-apply rewrite.