### PR TITLE
cli: add wallet-agnostic auth subcommand for headless Blockin sign-in

### DIFF
--- a/packages/bitbadgesjs-sdk/AI_AGENT_GUIDE.md
+++ b/packages/bitbadgesjs-sdk/AI_AGENT_GUIDE.md
@@ -461,20 +461,64 @@ console.log('Next bookmark:', activityResponse.pagination.bookmark);
 
 ### Authentication
 
-For authenticated endpoints, set an access token:
+There are three ways to authenticate against the indexer, depending on
+the surface and the scope you need.
+
+#### App-scoped: API key
+
+The default for read-mostly programmatic access. Required on every
+indexer call, but not sufficient on its own for `Full Access` routes
+(account-mutating, key-managing, signed-data-publishing endpoints).
 
 ```typescript
-// Set access token for authenticated requests
-api.setAccessToken('your-access-token');
-
-// Make authenticated request
-const accountInfo = await api.getAccount({
-  address: 'bb1abc...'
+const api = new BitBadgesAPI({
+  convertFunction: BigIntify,
+  apiKey: process.env.BITBADGES_API_KEY,
 });
+```
 
-// Clear access token
+#### User-scoped (in-process): set an access token
+
+For server code that already obtained a Blockin / SIWBB token through
+its own flow (e.g. a web backend that owns the user session):
+
+```typescript
+api.setAccessToken('your-access-token');
+const accountInfo = await api.getAccount({ address: 'bb1abc...' });
 api.unsetAccessToken();
 ```
+
+#### User-scoped (CLI / agentic): `bitbadges-cli auth`
+
+For headless agents and CLI workflows that need a `Full Access`
+session without a browser. The CLI runs the Blockin challenge → verify
+flow and stores the resulting cookie under `~/.bitbadges/auth.json`
+(mode 0600, multi-account, multi-network), then `api --with-session`
+attaches it on subsequent calls.
+
+The flow is **wallet-agnostic** — the CLI never touches a private key.
+Pair it with the chain binary's `bitbadgeschaind sign-arbitrary` for
+fully headless Cosmos signing, or paste in a signature from MetaMask /
+Keplr / a hardware wallet / a custodial signer.
+
+```bash
+# Headless three-step (chain-binary signer)
+MSG=$(bitbadges-cli auth challenge --address bb1...)
+SIG_JSON=$(bitbadgeschaind sign-arbitrary mykey "$MSG")
+bitbadges-cli auth login \
+  --address    "$(echo "$SIG_JSON" | jq -r .address)" \
+  --signature  "$(echo "$SIG_JSON" | jq -r .signature)" \
+  --public-key "$(echo "$SIG_JSON" | jq -r .pubKey)" \
+  --message    "$MSG"
+
+# Make a Full Access request
+bitbadges-cli api accounts get-account --body '{"address":"bb1..."}' --with-session
+```
+
+2FA accounts pass `--2fa <totp>` (or `--2fa-backup <code>`) to `auth
+login`. Switch active address with `auth use <addr>`; inspect with
+`auth status [--check]` and `auth whoami`. Full reference:
+<https://docs.bitbadges.io/for-developers/cli/auth-commands>.
 
 ### Error Handling
 

--- a/packages/bitbadgesjs-sdk/README.md
+++ b/packages/bitbadgesjs-sdk/README.md
@@ -64,6 +64,44 @@ The package ships three bins:
 - `bitbadges` / `bitbadges-cli` — interactive CLI helpers
 - `bitbadges-builder` — the stdio MCP server (entry point: `src/builder/index.ts`)
 
+## CLI authentication (headless / agentic)
+
+For endpoints that require a user-scoped session (anything gated by
+`Full Access` on the indexer), `bitbadges-cli auth` runs the Blockin
+challenge → verify dance and persists the resulting cookie under
+`~/.bitbadges/auth.json` (mode 0600), keyed by network + address.
+Subsequent `api` calls opt in via `--with-session`.
+
+The flow is **wallet-agnostic** — the CLI never touches a private key.
+The signature comes from any external producer: the chain binary's
+`bitbadgeschaind sign-arbitrary` (recommended for headless agents),
+MetaMask / Keplr (paste-in), a hardware wallet, a custodial signer.
+
+```bash
+# 1. Fetch a challenge (saves nonce locally for the verify step)
+bitbadges-cli auth challenge --address bb1...
+
+# 2. Sign the printed message with whatever signer you have. Headless
+#    Cosmos example using the chain binary:
+bitbadgeschaind sign-arbitrary mykey "$(bitbadges-cli auth challenge --address bb1...)"
+
+# 3. Post the signature — stores the session cookie
+bitbadges-cli auth login \
+  --address bb1... \
+  --signature <hex|base64> \
+  --public-key <b64>      # required for Cosmos addresses
+
+# 4. Make authenticated requests
+bitbadges-cli api accounts get-account --body '{"address":"bb1..."}' --with-session
+```
+
+Other subcommands: `auth status [--check]`, `auth use <addr>`,
+`auth whoami`, `auth logout [--all]`, `auth path`. 2FA accounts pass
+`--2fa <totp>` (or `--2fa-backup <code>`) to `auth login`. Multi-account
+support is built in — store as many addresses as you want, switch via
+`auth use`. Full reference:
+<https://docs.bitbadges.io/for-developers/cli/auth-commands>
+
 ## Quick Start
 
 ### 1. Initialize the API Client

--- a/packages/bitbadgesjs-sdk/src/cli/commands/api.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/api.ts
@@ -195,6 +195,7 @@ function buildRouteCommand(route: ApiRoute): Command {
       // and --as-address are explicit opt-ins to keep silent session injection
       // out of the default code path.
       let cookie: string | undefined;
+      let cookieRef: { network: 'mainnet' | 'testnet' | 'local'; address: string } | undefined;
       if (opts.asAddress || opts.withSession) {
         const { getActiveSession, getSession, formatCookieHeader } = await import('../utils/auth-store.js');
         const sessionNetwork: 'mainnet' | 'testnet' | 'local' = network ?? 'mainnet';
@@ -212,6 +213,8 @@ function buildRouteCommand(route: ApiRoute): Command {
           );
         }
         cookie = formatCookieHeader(session);
+        // Ref so apiRequest can persist the rolled Set-Cookie expiry.
+        cookieRef = { network: sessionNetwork, address: session.address };
       }
 
       // Build path params map
@@ -300,6 +303,7 @@ function buildRouteCommand(route: ApiRoute): Command {
         apiKey,
         baseUrl,
         cookie,
+        cookieRef,
       });
 
       const formatted = opts.condensed

--- a/packages/bitbadgesjs-sdk/src/cli/commands/api.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/api.ts
@@ -164,7 +164,9 @@ function buildRouteCommand(route: ApiRoute): Command {
     .option('--query <params>', 'Query string params as JSON object (e.g. \'{"bookmark":"x"}\')')
     .option('--condensed', 'Output condensed JSON (no whitespace)', false)
     .option('--dry-run', 'Show request details without sending', false)
-    .option('--output-file <path>', 'Write output to file instead of stdout');
+    .option('--output-file <path>', 'Write output to file instead of stdout')
+    .option('--with-session', 'Attach the cookie of the active address (set via `auth use`) for the resolved network', false)
+    .option('--as-address <addr>', 'Attach the cookie of the given address (overrides --with-session)');
 
   // Append rich documentation from the OpenAPI spec
   const afterHelp = buildAfterHelpText(route);
@@ -188,6 +190,29 @@ function buildRouteCommand(route: ApiRoute): Command {
         local: opts.local,
         baseUrl: opts.url,
       });
+
+      // Resolve optional session cookie. Never auto-attach; both --with-session
+      // and --as-address are explicit opt-ins to keep silent session injection
+      // out of the default code path.
+      let cookie: string | undefined;
+      if (opts.asAddress || opts.withSession) {
+        const { getActiveSession, getSession, formatCookieHeader } = await import('../utils/auth-store.js');
+        const sessionNetwork: 'mainnet' | 'testnet' | 'local' = network ?? 'mainnet';
+        const session = opts.asAddress
+          ? getSession(sessionNetwork, opts.asAddress)
+          : getActiveSession(sessionNetwork);
+        if (!session) {
+          throw new Error(
+            `No stored session for ${opts.asAddress ?? 'active address'} on ${sessionNetwork}. Run \`bitbadges-cli auth login\`.`,
+          );
+        }
+        if (Date.now() > session.expiresAt) {
+          throw new Error(
+            `Stored session for ${session.address} on ${sessionNetwork} expired at ${new Date(session.expiresAt).toISOString()}. Re-run \`bitbadges-cli auth login\`.`,
+          );
+        }
+        cookie = formatCookieHeader(session);
+      }
 
       // Build path params map
       const pathParamValues: Record<string, string> = {};
@@ -259,6 +284,7 @@ function buildRouteCommand(route: ApiRoute): Command {
           url: `${baseUrl}${resolvedPath}`,
           headers: {
             'x-api-key': apiKey ? apiKey.slice(0, 4) + '****' : '(none)',
+            ...(cookie ? { Cookie: cookie.split('=')[0] + '=****' } : {}),
             ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
           },
           body: body ?? null,
@@ -273,6 +299,7 @@ function buildRouteCommand(route: ApiRoute): Command {
         body,
         apiKey,
         baseUrl,
+        cookie,
       });
 
       const formatted = opts.condensed

--- a/packages/bitbadgesjs-sdk/src/cli/commands/auth.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auth.ts
@@ -1,0 +1,472 @@
+/**
+ * `bitbadges-cli auth` — wallet-agnostic Blockin sign-in flow against
+ * the indexer. Stores session cookies under ~/.bitbadges/auth.json,
+ * keyed by network + address. Subsequent `api --with-session` calls
+ * attach the cookie automatically.
+ *
+ * Wallet-agnostic: this command does NOT sign anything. The signature
+ * comes from any external producer (chain binary `sign-arbitrary`,
+ * MetaMask, Keplr, hardware wallet, custodial signer, ...).
+ */
+
+import * as fs from 'fs';
+import { Command } from 'commander';
+import { resolveApiKey, resolveBaseUrl } from '../utils/api-client.js';
+import {
+  AuthSession,
+  Network,
+  ParsedCookie,
+  clearPendingChallenge,
+  extractSetCookies,
+  formatCookieHeader,
+  formatCookieHeaderFromMany,
+  getActiveSession,
+  getAuthPath,
+  getPendingChallenge,
+  getSession,
+  listAllSessions,
+  pickSessionCookie,
+  removeSession,
+  setActive,
+  setPendingChallenge,
+  setSession,
+} from '../utils/auth-store.js';
+
+interface NetworkOptions {
+  testnet?: boolean;
+  local?: boolean;
+  url?: string;
+  apiKey?: string;
+}
+
+function resolveNetwork(opts: NetworkOptions): Network {
+  if (opts.testnet) return 'testnet';
+  if (opts.local) return 'local';
+  return 'mainnet';
+}
+
+function detectChain(address: string): 'Cosmos' | 'ETH' {
+  if (address.startsWith('0x')) return 'ETH';
+  if (address.startsWith('bb1')) return 'Cosmos';
+  throw new Error(`Cannot detect chain from address ${address}: must start with 'bb1' or '0x'`);
+}
+
+function readMessage(opts: { message?: string; messageFile?: string }): string | undefined {
+  if (opts.message) return opts.message;
+  if (opts.messageFile) {
+    if (opts.messageFile === '-') return fs.readFileSync(0, 'utf-8');
+    return fs.readFileSync(opts.messageFile, 'utf-8');
+  }
+  return undefined;
+}
+
+interface FetchResult {
+  status: number;
+  body: any;
+  setCookies: ParsedCookie[];
+}
+
+async function rawPost(url: string, headers: Record<string, string>, body: any): Promise<FetchResult> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+  const text = await res.text();
+  let parsed: any;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = { raw: text, status: res.status };
+  }
+  return { status: res.status, body: parsed, setCookies: extractSetCookies(res.headers) };
+}
+
+interface ChallengeResponse {
+  message: string;
+  nonce: string;
+  /** All Set-Cookie values from the response (session cookie + any LB sticky cookies). */
+  cookies: ParsedCookie[];
+}
+
+async function fetchChallenge(
+  baseUrl: string,
+  apiKey: string,
+  chain: 'Cosmos' | 'ETH',
+  address: string,
+): Promise<ChallengeResponse> {
+  const r = await rawPost(`${baseUrl}/auth/getChallenge`, { 'x-api-key': apiKey }, { chain, address });
+  if (r.status !== 200) {
+    const msg = r.body?.errorMessage || r.body?.error || `HTTP ${r.status}`;
+    throw new Error(`getChallenge failed: ${msg}`);
+  }
+  return { message: r.body.message, nonce: r.body.nonce, cookies: r.setCookies };
+}
+
+interface VerifyResult {
+  /** The new session cookie minted by /auth/verify (post-regenerate). */
+  sessionCookie: ParsedCookie;
+  /** All Set-Cookie values from /auth/verify, in order — replay these on subsequent calls in the same flow. */
+  allCookies: ParsedCookie[];
+  requires2FA: boolean;
+  twoFAMessage?: string;
+}
+
+async function postVerify(
+  baseUrl: string,
+  apiKey: string,
+  cookieHeader: string,
+  payload: { message: string; signature: string; publicKey?: string },
+): Promise<VerifyResult> {
+  const r = await rawPost(
+    `${baseUrl}/auth/verify`,
+    { 'x-api-key': apiKey, Cookie: cookieHeader },
+    payload,
+  );
+  if (r.status !== 200) {
+    const msg = r.body?.errorMessage || r.body?.error || `HTTP ${r.status}`;
+    throw new Error(`verify failed: ${msg}`);
+  }
+  const sessionCookie = pickSessionCookie(r.setCookies);
+  if (!sessionCookie) {
+    throw new Error('verify succeeded but indexer returned no session cookie — cannot persist session.');
+  }
+  return {
+    sessionCookie,
+    allCookies: r.setCookies,
+    requires2FA: !!r.body?.requires2FA,
+    twoFAMessage: r.body?.message,
+  };
+}
+
+async function complete2FA(
+  baseUrl: string,
+  apiKey: string,
+  cookieHeader: string,
+  address: string,
+  code: string,
+  isBackup: boolean,
+): Promise<{ sessionCookie: ParsedCookie | null }> {
+  const body: Record<string, string> = { address };
+  if (isBackup) body.backupCode = code;
+  else body.totpCode = code;
+
+  const r = await rawPost(`${baseUrl}/2fa/offline/verify`, { 'x-api-key': apiKey, Cookie: cookieHeader }, body);
+  if (r.status !== 200) {
+    const msg = r.body?.error || r.body?.errorMessage || `HTTP ${r.status}`;
+    throw new Error(`2FA verification failed: ${msg}`);
+  }
+  return { sessionCookie: pickSessionCookie(r.setCookies) };
+}
+
+function persistSession(args: {
+  network: Network;
+  address: string;
+  nativeAddress: string;
+  chain: 'Cosmos' | 'ETH';
+  cookie: ParsedCookie;
+  baseUrl: string;
+  setActive: boolean;
+}): AuthSession {
+  const session: AuthSession = {
+    address: args.address,
+    nativeAddress: args.nativeAddress,
+    chain: args.chain,
+    cookieName: args.cookie.name,
+    cookieValue: args.cookie.value,
+    scopes: [{ scopeName: 'Full Access' }],
+    createdAt: Date.now(),
+    expiresAt: args.cookie.expiresAt,
+    indexerUrl: args.baseUrl,
+  };
+  setSession(args.network, session);
+  if (args.setActive) setActive(args.network, args.address);
+  return session;
+}
+
+function addNetworkOptions<T extends Command>(cmd: T): T {
+  return cmd
+    .option('--testnet', 'Use testnet API', false)
+    .option('--local', 'Use local API (localhost:3001)', false)
+    .option('--url <url>', 'Custom API base URL (overrides --testnet/--local/config)')
+    .option('--api-key <key>', 'BitBadges API key (overrides BITBADGES_API_KEY env)') as T;
+}
+
+export const authCommand = new Command('auth').description(
+  'Authenticate against the BitBadges indexer (wallet-agnostic Blockin flow).',
+);
+
+// ── auth login ──────────────────────────────────────────────────────
+
+addNetworkOptions(authCommand.command('login'))
+  .description('One-shot Blockin login: fetches challenge, posts your signature, stores session cookie.')
+  .requiredOption('--address <addr>', "Native address (bb1... for Cosmos, 0x... for ETH).")
+  .requiredOption('--signature <sig>', 'Signature over the challenge message (hex or base64).')
+  .option('--public-key <b64>', 'Compressed pubkey, base64. REQUIRED for Cosmos addresses (CosmosDriver verifier needs it).')
+  .option('--message <text>', 'The exact challenge message that was signed (typically from `auth challenge`).')
+  .option('--message-file <path>', 'Read challenge message from file (use `-` for stdin).')
+  .option('--2fa <code>', '6-digit TOTP code (if account has 2FA enabled).')
+  .option('--2fa-backup <code>', 'Backup recovery code (alternative to --2fa).')
+  .action(async (opts) => {
+    const network = resolveNetwork(opts);
+    const baseUrl = resolveBaseUrl({ testnet: opts.testnet, local: opts.local, baseUrl: opts.url });
+    const apiKey = resolveApiKey(opts.apiKey, network);
+    const chain = detectChain(opts.address);
+    if (chain === 'Cosmos' && !opts.publicKey) {
+      throw new Error('--public-key is required for Cosmos signatures (CosmosDriver verifier needs it). Get it from `sign-arbitrary` output.');
+    }
+
+    let message = readMessage({ message: opts.message, messageFile: opts.messageFile });
+
+    // The /auth/verify nonce check is bound to the cookie the indexer set
+    // when it issued the challenge. Two paths to obtain that cookie:
+    //   1. A prior `auth challenge` saved a pending entry → reuse it (the
+    //      headless agentic flow: challenge → external sign → verify).
+    //   2. No pending → fetch a fresh challenge inline. Only safe when
+    //      the caller has not yet signed (i.e. `--message` not passed).
+    let cookies: ParsedCookie[];
+    const pending = getPendingChallenge(network, opts.address);
+    if (pending && (!message || pending.message.trim() === message.trim())) {
+      message = pending.message;
+      cookies = pending.cookies;
+    } else {
+      if (message && pending) {
+        process.stderr.write(
+          `Provided --message does not match the saved pending challenge for ${opts.address}; fetching a fresh challenge.\n`,
+        );
+      }
+      const fresh = await fetchChallenge(baseUrl, apiKey, chain, opts.address);
+      if (!message) {
+        message = fresh.message;
+        process.stderr.write(
+          `Auto-fetched challenge inline (no pending found). For headless flows, run \`auth challenge\` first.\n`,
+        );
+      } else if (fresh.message.trim() !== message.trim()) {
+        throw new Error(
+          'Provided --message does not match the indexer\'s current challenge. Re-fetch via `auth challenge`, sign, then `auth verify`.',
+        );
+      }
+      if (fresh.cookies.length === 0) {
+        throw new Error('getChallenge returned no Set-Cookie headers; cannot complete /auth/verify.');
+      }
+      cookies = fresh.cookies;
+    }
+
+    const verify = await postVerify(baseUrl, apiKey, formatCookieHeaderFromMany(cookies), {
+      message,
+      signature: opts.signature,
+      publicKey: opts.publicKey,
+    });
+
+    let finalCookie = verify.sessionCookie;
+    let allCookies = verify.allCookies;
+    const totp = (opts as any)['2fa'] as string | undefined;
+    const backup = (opts as any)['2faBackup'] as string | undefined;
+    if (verify.requires2FA) {
+      if (!totp && !backup) {
+        process.stderr.write(
+          `\nAccount has 2FA enabled. Re-run with --2fa <totp-code> or --2fa-backup <code>.\n`,
+        );
+        process.exit(2);
+      }
+      const stepUp = await complete2FA(
+        baseUrl,
+        apiKey,
+        formatCookieHeaderFromMany(allCookies),
+        opts.address,
+        (totp || backup)!,
+        !!backup,
+      );
+      if (stepUp.sessionCookie) finalCookie = stepUp.sessionCookie;
+    }
+
+    const session = persistSession({
+      network,
+      address: opts.address,
+      nativeAddress: opts.address,
+      chain,
+      cookie: finalCookie,
+      baseUrl,
+      setActive: true,
+    });
+    clearPendingChallenge(network, opts.address);
+
+    process.stdout.write(
+      `Logged in as ${opts.address} on ${network}. Expires ${new Date(session.expiresAt).toISOString()}.\n`,
+    );
+  });
+
+// ── auth challenge ──────────────────────────────────────────────────
+
+addNetworkOptions(authCommand.command('challenge'))
+  .description('Fetch a Blockin challenge for an address. Print the message your signer must sign.')
+  .requiredOption('--address <addr>', "Native address (bb1... or 0x...).")
+  .option('--json', 'Output {message, nonce} as JSON.', false)
+  .option('--no-save-pending', 'Do not persist the challenge cookie locally (advanced).')
+  .action(async (opts) => {
+    const network = resolveNetwork(opts);
+    const baseUrl = resolveBaseUrl({ testnet: opts.testnet, local: opts.local, baseUrl: opts.url });
+    const apiKey = resolveApiKey(opts.apiKey, network);
+    const chain = detectChain(opts.address);
+    const challenge = await fetchChallenge(baseUrl, apiKey, chain, opts.address);
+
+    if (opts.savePending !== false) {
+      // Persist the nonce cookie so a follow-up `auth login` / `auth verify`
+      // can replay it. Without this, /auth/verify hits "No sign-in request
+      // found" because each getChallenge mints a new session-bound nonce.
+      setPendingChallenge(network, opts.address, challenge.message, challenge.cookies, baseUrl);
+    }
+
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ message: challenge.message, nonce: challenge.nonce }) + '\n');
+    } else {
+      process.stdout.write(challenge.message + '\n');
+    }
+  });
+
+// ── auth verify ─────────────────────────────────────────────────────
+// Two-step counterpart to `login` for flows where signing happens
+// elsewhere. Re-fetches the challenge to get a fresh nonce cookie,
+// asserts the message the signer used matches, then posts verify.
+
+addNetworkOptions(authCommand.command('verify'))
+  .description('Complete two-step login: post a precomputed signature for a challenge.')
+  .requiredOption('--address <addr>', "Native address (bb1... or 0x...).")
+  .requiredOption('--signature <sig>', 'Signature over the challenge message.')
+  .option('--public-key <b64>', 'Compressed pubkey, base64. REQUIRED for Cosmos addresses.')
+  .option('--message <text>', 'The exact challenge message that was signed.')
+  .option('--message-file <path>', 'Read challenge message from file (use `-` for stdin).')
+  .option('--2fa <code>', '6-digit TOTP code (if 2FA enabled).')
+  .option('--2fa-backup <code>', 'Backup recovery code (alternative to --2fa).')
+  .action(async (opts) => {
+    // Same flow as `login` — kept as a separate subcommand purely for
+    // discoverability / muscle memory parity with the two-step flow.
+    await authCommand.commands.find((c) => c.name() === 'login')!.parseAsync(
+      ['login', ...rebuildArgs(opts, ['address', 'signature', 'publicKey', 'message', 'messageFile', '2fa', '2faBackup', 'testnet', 'local', 'url', 'apiKey'])],
+      { from: 'user' },
+    );
+  });
+
+function rebuildArgs(opts: Record<string, any>, keys: string[]): string[] {
+  const out: string[] = [];
+  for (const k of keys) {
+    const v = opts[k];
+    if (v === undefined || v === null || v === false) continue;
+    const flag = '--' + k.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
+    if (v === true) {
+      out.push(flag);
+    } else {
+      out.push(flag, String(v));
+    }
+  }
+  return out;
+}
+
+// ── auth status ─────────────────────────────────────────────────────
+
+addNetworkOptions(authCommand.command('status'))
+  .description('Show stored sessions and (with --check) revalidate them against the indexer.')
+  .option('--all', 'Show sessions across every network, not just the resolved one.', false)
+  .option('--check', 'Hit /api/v0/auth/status to revalidate the cookie server-side.', false)
+  .action(async (opts) => {
+    const sessions = opts.all ? listAllSessions() : (() => {
+      const network = resolveNetwork(opts);
+      const active = getActiveSession(network);
+      return active ? [{ network, session: active }] : [];
+    })();
+
+    if (sessions.length === 0) {
+      process.stdout.write('No stored sessions. Run `bitbadges-cli auth login`.\n');
+      return;
+    }
+
+    for (const { network, session } of sessions) {
+      const expiry = new Date(session.expiresAt).toISOString();
+      const status = Date.now() > session.expiresAt ? 'EXPIRED' : 'valid';
+      let serverCheck = '';
+      if (opts.check) {
+        try {
+          const r = await rawPost(
+            `${session.indexerUrl}/auth/status`,
+            { Cookie: formatCookieHeader(session) },
+            {},
+          );
+          serverCheck = r.body?.signedIn ? ' [server: signed-in]' : ' [server: NOT signed in]';
+        } catch (err: any) {
+          serverCheck = ` [server check failed: ${err.message}]`;
+        }
+      }
+      process.stdout.write(
+        `${network.padEnd(8)}  ${session.address}  ${session.chain}  expires=${expiry} (${status})${serverCheck}\n`,
+      );
+    }
+  });
+
+// ── auth logout ─────────────────────────────────────────────────────
+
+addNetworkOptions(authCommand.command('logout'))
+  .description('Sign out and remove the local session record.')
+  .option('--address <addr>', 'Address to log out (defaults to active for resolved network).')
+  .option('--all', 'Log out every stored session across all networks.', false)
+  .action(async (opts) => {
+    const targets = opts.all ? listAllSessions() : (() => {
+      const network = resolveNetwork(opts);
+      const session = opts.address ? getSession(network, opts.address) : getActiveSession(network);
+      return session ? [{ network, session }] : [];
+    })();
+
+    if (targets.length === 0) {
+      process.stdout.write('No matching session to log out.\n');
+      return;
+    }
+
+    for (const { network, session } of targets) {
+      try {
+        await rawPost(
+          `${session.indexerUrl}/auth/logout`,
+          { Cookie: formatCookieHeader(session), 'x-api-key': resolveApiKey(undefined, network) },
+          { signOutBlockin: true, signOutEmail: true },
+        );
+      } catch (err: any) {
+        process.stderr.write(`(server logout failed for ${session.address} on ${network}: ${err.message}; removing local record anyway)\n`);
+      }
+      removeSession(network, session.address);
+      process.stdout.write(`Logged out ${session.address} on ${network}.\n`);
+    }
+  });
+
+// ── auth use ────────────────────────────────────────────────────────
+
+addNetworkOptions(authCommand.command('use'))
+  .description('Set the active address for a network (used by `api --with-session`).')
+  .argument('<address>', 'Address to mark active.')
+  .action(async (address: string, opts) => {
+    const network = resolveNetwork(opts);
+    setActive(network, address);
+    process.stdout.write(`Active on ${network} is now ${address}.\n`);
+  });
+
+// ── auth whoami ─────────────────────────────────────────────────────
+
+addNetworkOptions(authCommand.command('whoami'))
+  .description('Print the active address for the resolved network.')
+  .action(async (opts) => {
+    const network = resolveNetwork(opts);
+    const session = getActiveSession(network);
+    if (!session) {
+      process.stdout.write(`No active session on ${network}. Run \`bitbadges-cli auth login\`.\n`);
+      process.exit(1);
+    }
+    process.stdout.write(
+      `${session.address} on ${network}  (chain=${session.chain}, expires=${new Date(session.expiresAt).toISOString()})\n`,
+    );
+  });
+
+// ── auth path ───────────────────────────────────────────────────────
+
+authCommand
+  .command('path')
+  .description('Print the path of the local auth store (~/.bitbadges/auth.json).')
+  .action(() => {
+    process.stdout.write(getAuthPath() + '\n');
+  });

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -4,6 +4,7 @@ import { sdkCommand } from './commands/sdk.js';
 import { createApiCommand } from './commands/api.js';
 import { configCommand } from './commands/config.js';
 import { builderCommand } from './commands/builder.js';
+import { authCommand } from './commands/auth.js';
 
 const program = new Command();
 
@@ -19,6 +20,7 @@ program.addCommand(sdkCommand);
 program.addCommand(createApiCommand());
 program.addCommand(configCommand);
 program.addCommand(builderCommand);
+program.addCommand(authCommand);
 
 // ── completion command ───────────────────────────────────────────────────────
 

--- a/packages/bitbadgesjs-sdk/src/cli/utils/api-client.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/api-client.ts
@@ -4,6 +4,12 @@
  */
 
 import { assertNetworkAvailable } from '../../signing/types.js';
+import {
+  Network,
+  extractSetCookies,
+  pickSessionCookie,
+  refreshSessionExpiry,
+} from './auth-store.js';
 import { getConfigApiKey, getConfigBaseUrl } from './config.js';
 
 export interface ApiRequestOptions {
@@ -14,6 +20,12 @@ export interface ApiRequestOptions {
   baseUrl?: string;
   /** Optional Cookie header value (e.g. "bitbadges=s%3A..."). Set via `auth login`. */
   cookie?: string;
+  /**
+   * Pointer back to the stored session so the rolled Set-Cookie expiry
+   * (express-session is `rolling: true`) gets persisted to auth.json.
+   * Leave undefined for non-session calls or one-shot cookie attaches.
+   */
+  cookieRef?: { network: Network; address: string };
 }
 
 /**
@@ -82,7 +94,7 @@ export function resolveApiKey(explicit?: string, network?: 'mainnet' | 'testnet'
  * Makes an HTTP request to the BitBadges API and returns parsed JSON.
  */
 export async function apiRequest(options: ApiRequestOptions): Promise<any> {
-  const { method, path, body, apiKey, baseUrl, cookie } = options;
+  const { method, path, body, apiKey, baseUrl, cookie, cookieRef } = options;
 
   const url = `${baseUrl}${path}`;
 
@@ -108,6 +120,19 @@ export async function apiRequest(options: ApiRequestOptions): Promise<any> {
   }
 
   const response = await fetch(url, fetchOptions);
+
+  // Indexer runs express-session with rolling: true — every authenticated
+  // response carries a fresh Set-Cookie that resets Max-Age to 7d. Capture
+  // it back to auth.json so the local expiresAt tracks reality. The SID
+  // itself is stable across rolls; only the expiry advances.
+  if (cookieRef) {
+    try {
+      const rolled = pickSessionCookie(extractSetCookies(response.headers));
+      if (rolled) refreshSessionExpiry(cookieRef.network, cookieRef.address, rolled.expiresAt);
+    } catch {
+      /* best-effort — never let a roll-write failure poison the response */
+    }
+  }
 
   const text = await response.text();
 

--- a/packages/bitbadgesjs-sdk/src/cli/utils/api-client.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/api-client.ts
@@ -12,6 +12,8 @@ export interface ApiRequestOptions {
   body?: any;
   apiKey?: string;
   baseUrl?: string;
+  /** Optional Cookie header value (e.g. "bitbadges=s%3A..."). Set via `auth login`. */
+  cookie?: string;
 }
 
 /**
@@ -80,13 +82,17 @@ export function resolveApiKey(explicit?: string, network?: 'mainnet' | 'testnet'
  * Makes an HTTP request to the BitBadges API and returns parsed JSON.
  */
 export async function apiRequest(options: ApiRequestOptions): Promise<any> {
-  const { method, path, body, apiKey, baseUrl } = options;
+  const { method, path, body, apiKey, baseUrl, cookie } = options;
 
   const url = `${baseUrl}${path}`;
 
   const headers: Record<string, string> = {
     'x-api-key': apiKey || '',
   };
+
+  if (cookie) {
+    headers['Cookie'] = cookie;
+  }
 
   if (body !== undefined) {
     headers['Content-Type'] = 'application/json';

--- a/packages/bitbadgesjs-sdk/src/cli/utils/auth-store.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/auth-store.ts
@@ -1,0 +1,301 @@
+/**
+ * Storage for BitBadges CLI auth sessions, keyed by network +
+ * address. Sister file to config.ts; lives at ~/.bitbadges/auth.json
+ * with mode 0600 since it holds replayable session cookies.
+ *
+ * Multi-network: testnet/mainnet/local cookies are independent (same
+ * address may exist on each as a separate session). Each network has
+ * its own `active` pointer so subsequent `--with-session` flags know
+ * which cookie to attach.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export type Network = 'mainnet' | 'testnet' | 'local';
+
+export interface AuthSession {
+  /** Bech32 address (bb1... — canonical BitBadges address). */
+  address: string;
+  /** Native chain address (eth = 0x..., cosmos = bb1...). May equal `address`. */
+  nativeAddress: string;
+  /** SupportedChain enum value: 'Cosmos' | 'ETH'. */
+  chain: 'Cosmos' | 'ETH';
+  /** Session cookie name (varies by env: bitbadges / bitbadges-testnet / ...). */
+  cookieName: string;
+  /** Session cookie value (the part after `name=`, before `;`). */
+  cookieValue: string;
+  /** Scopes attached to the session. v1 always Full Access. */
+  scopes: { scopeName: string }[];
+  /** Unix ms timestamp at session mint. */
+  createdAt: number;
+  /** Unix ms timestamp at expiry (parsed from cookie Max-Age/Expires; falls back to +7d). */
+  expiresAt: number;
+  /** Unix ms timestamp of last successful `auth status` revalidation. */
+  lastVerifiedAt?: number;
+  /** Indexer base URL the cookie was issued against. */
+  indexerUrl: string;
+}
+
+export interface PendingChallenge {
+  /** The Blockin challenge message the user must sign. */
+  message: string;
+  /**
+   * All cookies set by /auth/getChallenge — the session cookie carrying
+   * the nonce + any LB sticky cookies. MUST be replayed verbatim on
+   * /auth/verify or the indexer rejects with "No sign-in request found".
+   */
+  cookies: ParsedCookie[];
+  /** Unix ms when this pending challenge expires (5 min TTL by default). */
+  expiresAt: number;
+  /** Indexer base URL the challenge was issued by. */
+  indexerUrl: string;
+}
+
+interface NetworkStore {
+  active?: string;
+  sessions: Record<string, AuthSession>;
+  /** Address → in-flight challenge waiting for an external signature. */
+  pending?: Record<string, PendingChallenge>;
+}
+
+interface AuthFile {
+  version: 1;
+  networks: Partial<Record<Network, NetworkStore>>;
+}
+
+const AUTH_DIR = path.join(os.homedir(), '.bitbadges');
+const AUTH_PATH = path.join(AUTH_DIR, 'auth.json');
+
+export function getAuthPath(): string {
+  return AUTH_PATH;
+}
+
+/**
+ * Loads ~/.bitbadges/auth.json. Returns the empty shape if missing.
+ * Throws on parse error so partial corruption never silently wipes
+ * stored credentials. Auto-chmods to 0600 if found with looser perms.
+ */
+export function loadAuthStore(): AuthFile {
+  if (!fs.existsSync(AUTH_PATH)) {
+    return { version: 1, networks: {} };
+  }
+  enforceFileMode(AUTH_PATH);
+  const raw = fs.readFileSync(AUTH_PATH, 'utf-8');
+  const parsed = JSON.parse(raw) as AuthFile;
+  if (parsed.version !== 1) {
+    throw new Error(`Unsupported auth.json version ${parsed.version} at ${AUTH_PATH}`);
+  }
+  if (!parsed.networks) parsed.networks = {};
+  return parsed;
+}
+
+export function saveAuthStore(store: AuthFile): void {
+  if (!fs.existsSync(AUTH_DIR)) {
+    fs.mkdirSync(AUTH_DIR, { recursive: true, mode: 0o700 });
+  }
+  fs.writeFileSync(AUTH_PATH, JSON.stringify(store, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 });
+  enforceFileMode(AUTH_PATH);
+}
+
+function enforceFileMode(p: string): void {
+  if (process.platform === 'win32') return;
+  try {
+    const stat = fs.statSync(p);
+    const mode = stat.mode & 0o777;
+    if (mode !== 0o600) {
+      fs.chmodSync(p, 0o600);
+    }
+  } catch {
+    /* best-effort */
+  }
+}
+
+function ensureNetwork(store: AuthFile, network: Network): NetworkStore {
+  let n = store.networks[network];
+  if (!n) {
+    n = { sessions: {} };
+    store.networks[network] = n;
+  }
+  return n;
+}
+
+export function getSession(network: Network, address: string): AuthSession | undefined {
+  const store = loadAuthStore();
+  return store.networks[network]?.sessions[address];
+}
+
+export function getActiveSession(network: Network): AuthSession | undefined {
+  const store = loadAuthStore();
+  const n = store.networks[network];
+  if (!n?.active) return undefined;
+  return n.sessions[n.active];
+}
+
+export function setSession(network: Network, session: AuthSession): void {
+  const store = loadAuthStore();
+  const n = ensureNetwork(store, network);
+  n.sessions[session.address] = session;
+  if (!n.active) n.active = session.address;
+  saveAuthStore(store);
+}
+
+export function removeSession(network: Network, address: string): void {
+  const store = loadAuthStore();
+  const n = store.networks[network];
+  if (!n) return;
+  delete n.sessions[address];
+  if (n.active === address) n.active = undefined;
+  saveAuthStore(store);
+}
+
+export function setActive(network: Network, address: string): void {
+  const store = loadAuthStore();
+  const n = ensureNetwork(store, network);
+  if (!n.sessions[address]) {
+    throw new Error(`No session stored for ${address} on ${network}; run \`bitbadges-cli auth login\` first.`);
+  }
+  n.active = address;
+  saveAuthStore(store);
+}
+
+export function listSessions(network: Network): AuthSession[] {
+  const store = loadAuthStore();
+  return Object.values(store.networks[network]?.sessions ?? {});
+}
+
+export function listAllSessions(): { network: Network; session: AuthSession }[] {
+  const store = loadAuthStore();
+  const out: { network: Network; session: AuthSession }[] = [];
+  (Object.keys(store.networks) as Network[]).forEach((network) => {
+    const n = store.networks[network];
+    if (!n) return;
+    Object.values(n.sessions).forEach((session) => out.push({ network, session }));
+  });
+  return out;
+}
+
+/**
+ * Format a stored session as a Cookie header value: `name=value`.
+ * Express-session is happy without the surrounding attributes.
+ */
+export function formatCookieHeader(session: AuthSession): string {
+  return `${session.cookieName}=${session.cookieValue}`;
+}
+
+const PENDING_TTL_MS = 5 * 60 * 1000;
+
+export function setPendingChallenge(
+  network: Network,
+  address: string,
+  message: string,
+  cookies: ParsedCookie[],
+  indexerUrl: string,
+): PendingChallenge {
+  const store = loadAuthStore();
+  const n = ensureNetwork(store, network);
+  if (!n.pending) n.pending = {};
+  const pending: PendingChallenge = {
+    message,
+    cookies,
+    expiresAt: Date.now() + PENDING_TTL_MS,
+    indexerUrl,
+  };
+  n.pending[address] = pending;
+  saveAuthStore(store);
+  return pending;
+}
+
+export function getPendingChallenge(network: Network, address: string): PendingChallenge | undefined {
+  const store = loadAuthStore();
+  const p = store.networks[network]?.pending?.[address];
+  if (!p) return undefined;
+  if (Date.now() > p.expiresAt) {
+    clearPendingChallenge(network, address);
+    return undefined;
+  }
+  return p;
+}
+
+export function clearPendingChallenge(network: Network, address: string): void {
+  const store = loadAuthStore();
+  const n = store.networks[network];
+  if (!n?.pending) return;
+  delete n.pending[address];
+  saveAuthStore(store);
+}
+
+export interface ParsedCookie {
+  name: string;
+  value: string;
+  expiresAt: number;
+}
+
+/**
+ * Parse a single Set-Cookie line into name/value/expiry. Returns null
+ * if malformed.
+ */
+export function parseSetCookieLine(line: string): ParsedCookie | null {
+  const [pair, ...attrs] = line.split(';').map((s) => s.trim());
+  const eq = pair.indexOf('=');
+  if (eq < 0) return null;
+  const name = pair.slice(0, eq);
+  const value = pair.slice(eq + 1);
+
+  let expiresAt = Date.now() + 7 * 24 * 60 * 60 * 1000;
+  for (const attr of attrs) {
+    const [k, v] = attr.split('=').map((s) => s.trim());
+    const lower = k.toLowerCase();
+    if (lower === 'max-age' && v) {
+      const seconds = parseInt(v, 10);
+      if (!Number.isNaN(seconds)) expiresAt = Date.now() + seconds * 1000;
+    } else if (lower === 'expires' && v) {
+      const ts = Date.parse(v);
+      if (!Number.isNaN(ts)) expiresAt = ts;
+    }
+  }
+  return { name, value, expiresAt };
+}
+
+/**
+ * Pull ALL Set-Cookie values out of a fetch Response's headers.
+ * Uses Headers.getSetCookie() (Node 19.7+) which preserves them as
+ * separate entries; the older Headers.get('set-cookie') joins them
+ * with `, ` and is lossy when cookie attributes contain commas (e.g.
+ * Expires=Tue, 05-May-26 ...). Always prefer this helper.
+ */
+export function extractSetCookies(headers: Headers): ParsedCookie[] {
+  const raw: string[] =
+    typeof (headers as any).getSetCookie === 'function' ? (headers as any).getSetCookie() : [];
+  if (!raw.length) {
+    // Fallback: pre-19.7 Node. Best-effort split — may misparse cookies whose
+    // Expires attribute contains a comma. Worth surfacing.
+    const single = headers.get('set-cookie');
+    if (!single) return [];
+    return single
+      .split(/,(?=\s*[A-Za-z0-9_\-]+=)/) // split on `,name=` boundaries only
+      .map((s) => parseSetCookieLine(s.trim()))
+      .filter((c): c is ParsedCookie => c !== null);
+  }
+  return raw.map(parseSetCookieLine).filter((c): c is ParsedCookie => c !== null);
+}
+
+/**
+ * Pick the express-session cookie out of a Set-Cookie array. Indexer
+ * uses `bitbadges`, `bitbadges-testnet`, `bitbadges-stagenet`, or
+ * `bitbadges-dev` depending on env. Sibling cookies like
+ * `BITBADGES_ROUTE` (load-balancer stickiness) are ignored here.
+ */
+export function pickSessionCookie(cookies: ParsedCookie[]): ParsedCookie | null {
+  return cookies.find((c) => c.name.toLowerCase().startsWith('bitbadges') && c.name.toUpperCase() !== 'BITBADGES_ROUTE') ?? null;
+}
+
+/**
+ * Render a Cookie header value from multiple parsed cookies, e.g.
+ * `BITBADGES_ROUTE=...; bitbadges=s%3A...`. Order matters for some
+ * load balancers — preserve input order.
+ */
+export function formatCookieHeaderFromMany(cookies: ParsedCookie[]): string {
+  return cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+}

--- a/packages/bitbadgesjs-sdk/src/cli/utils/auth-store.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/auth-store.ts
@@ -150,6 +150,22 @@ export function removeSession(network: Network, address: string): void {
   saveAuthStore(store);
 }
 
+/**
+ * Update only the rolling expiry on a stored session. Cookie value
+ * stays put — express-session keeps the SID stable across rolls and
+ * only resets Max-Age. No-op if the session is gone (e.g. user ran
+ * `auth logout` mid-flight). Skip writes that would shorten the
+ * existing expiry — out-of-order responses shouldn't claw back time.
+ */
+export function refreshSessionExpiry(network: Network, address: string, expiresAt: number): void {
+  const store = loadAuthStore();
+  const session = store.networks[network]?.sessions[address];
+  if (!session) return;
+  if (expiresAt <= session.expiresAt) return;
+  session.expiresAt = expiresAt;
+  saveAuthStore(store);
+}
+
 export function setActive(network: Network, address: string): void {
   const store = loadAuthStore();
   const n = ensureNetwork(store, network);


### PR DESCRIPTION
## Summary

- Adds `bitbadges-cli auth {challenge,login,verify,status,logout,use,whoami,path}` — a wallet-agnostic flow that orchestrates the indexer's existing `/api/v0/auth/{getChallenge,verify,status,logout}` endpoints without ever touching keys.
- Signature comes from any external producer: `bitbadgeschaind sign-arbitrary` (BitBadges/bitbadgeschain#88), MetaMask, Keplr, custodial signer, hardware wallet — anything that can produce an ADR-36 or EIP-191 signature. Fully agentic / headless.
- `api --with-session` and `api --as-address <addr>` flags attach the stored cookie to indexer calls, unlocking `Full Access`-gated routes from the CLI.

## Why now

Today the CLI only attaches `x-api-key` (app-level scope). Routes gated by `authorizeBlockinRequest([{ scopeName: 'Full Access' }])` need a user-scoped Blockin session cookie. This adds the missing surface for agents that need to act as a specific BitBadges user.

## Critical design points

- **Wallet-agnostic.** Auth command does NOT sign anything. Caller provides `--signature` from any source.
- **Pending-challenge persistence.** `auth challenge` saves the nonce cookie to `~/.bitbadges/auth.json` so a subsequent `auth login`/`auth verify` (after external signing) can replay it. Without this, headless flows are dead on arrival — `/auth/verify`'s nonce check is bound to the cookie issued at challenge time.
- **Multi-cookie handling.** Indexer responses include both the express-session cookie AND a Cloudflare `BITBADGES_ROUTE` LB stickiness cookie. Uses `Headers.getSetCookie()` (Node 19.7+) for proper array parsing, replays both on chained calls, persists only the session cookie.
- **2FA.** `--2fa <totp>` and `--2fa-backup <code>` chain a `POST /2fa/offline/verify` call when the indexer responds with `requires2FA: true`. Without a code, exits 2 with a clear error.
- **No silent session injection.** `api` requires explicit `--with-session` or `--as-address` opt-in. Footgun avoidance.

## Storage

`~/.bitbadges/auth.json` (mode 0600) keyed by network + address:

\`\`\`jsonc
{ \"version\": 1,
  \"networks\": {
    \"mainnet\": {
      \"active\": \"bb1...\",
      \"sessions\": { \"bb1...\": { address, nativeAddress, chain, cookieName, cookieValue, scopes, createdAt, expiresAt, lastVerifiedAt, indexerUrl } },
      \"pending\": { \"bb1...\": { message, cookies, expiresAt, indexerUrl } }
    }
  }
}
\`\`\`

## Files

- NEW `packages/bitbadgesjs-sdk/src/cli/commands/auth.ts`
- NEW `packages/bitbadgesjs-sdk/src/cli/utils/auth-store.ts`
- EDIT `packages/bitbadgesjs-sdk/src/cli/commands/api.ts` — `--with-session` / `--as-address` flags
- EDIT `packages/bitbadgesjs-sdk/src/cli/utils/api-client.ts` — accept `cookie` field
- EDIT `packages/bitbadgesjs-sdk/src/cli/index.ts` — register `authCommand`

## E2E verified against mainnet

\`\`\`
$ bitbadges-cli auth challenge --address bb1... > challenge.txt
$ bitbadgeschaind sign-arbitrary smoketest --message-file challenge.txt > sig.json
$ bitbadges-cli auth login --address bb1... --signature \"\$(jq -r .signature sig.json)\" \\
                            --public-key \"\$(jq -r .pubKey sig.json)\" \\
                            --message-file challenge.txt
Logged in as bb1... on mainnet. Expires 2026-05-10T...

$ bitbadges-cli auth status --check
mainnet  bb1...  Cosmos  expires=... (valid) [server: signed-in]

$ bitbadges-cli api auth check-sign-in-status --with-session
{ \"signedIn\": true, \"scopes\": [{\"scopeName\":\"Full Access\",...}], \"address\":\"bb1...\", ... }

$ bitbadges-cli auth logout
Logged out bb1... on mainnet.
\`\`\`

## Test plan

- [ ] \`bitbadges-cli auth --help\` lists subcommands
- [ ] \`auth challenge\` → external sign → \`auth login\` → \`auth status --check\` → \`auth logout\` round-trip works
- [ ] \`api --with-session\` returns 200 + scoped data on a Full Access route
- [ ] \`api\` without \`--with-session\` does NOT auto-attach (no silent injection)
- [ ] \`auth login\` against 2FA-required account → exits 2 with clear message when \`--2fa\` not provided
- [ ] \`~/.bitbadges/auth.json\` is mode 0600

## Companion ticket

Pairs with #0373 (chain-binary signer) and blocks #0375 (browser-redirect login flow — opt-in \`--browser\` flag for users with browser-only wallets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)