### PR TITLE
sdk: export tracing primitives (#0343 follow-up)

### DIFF
--- a/packages/bitbadgesjs-sdk/package.json
+++ b/packages/bitbadgesjs-sdk/package.json
@@ -61,6 +61,10 @@
     "./builder/internals": {
       "import": "./dist/esm/builder/agent/internals.js",
       "require": "./dist/cjs/builder/agent/internals.js"
+    },
+    "./builder/tracing": {
+      "import": "./dist/esm/builder/tracing/index.js",
+      "require": "./dist/cjs/builder/tracing/index.js"
     }
   },
   "bin": {
@@ -93,6 +97,9 @@
       ],
       "builder/internals": [
         "./dist/esm/builder/agent/internals.d.ts"
+      ],
+      "builder/tracing": [
+        "./dist/esm/builder/tracing/index.d.ts"
       ]
     }
   },

--- a/packages/bitbadgesjs-sdk/src/builder/agent/index.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/agent/index.ts
@@ -54,6 +54,22 @@ export {
 export { getProvider, AnthropicProvider, OpenAIProvider, SUPPORTED_PROVIDERS } from './providers/index.js';
 export type { LLMProvider, ProviderName } from './providers/index.js';
 
+// Observability — TraceEmitter abstraction passed via the `tracer`
+// option on BitBadgesBuilderAgent. Vendor adapters (LangFuse / OTEL)
+// ship as separate packages; SDK core ships only NoopEmitter (default,
+// zero overhead) + InMemoryEmitter (tests + reference impl).
+export {
+  NoopEmitter,
+  InMemoryEmitter,
+  type TraceEmitter,
+  type Span,
+  type SpanAttributes,
+  type SpanId,
+  type SpanStatus,
+  type TraceId,
+  type SpanRecord
+} from '../tracing/index.js';
+
 export type {
   // Options
   BitBadgesBuilderAgentOptions,


### PR DESCRIPTION
## Summary

Follow-up to #200. The tracing module shipped under
`src/builder/tracing/` but wasn't reachable from any package
export — `import { TraceEmitter } from 'bitbadges/...'` failed.

Two paths added:

- **`bitbadges/builder/agent`** — re-exports `NoopEmitter`,
  `InMemoryEmitter`, and the type interfaces alongside
  `BitBadgesBuilderAgent`. One import for "everything to build
  with the agent."
- **`bitbadges/builder/tracing`** — dedicated entry for consumers
  that only want the abstraction (e.g. an indexer
  `SessionLogEmitter` that implements `TraceEmitter` without
  pulling in the full agent).

Both wire through the existing dual cjs/esm `exports` map + the
parallel `typesVersions` map.

Unblocks the indexer `SessionLogEmitter` (#0343 PR 2).

## Test plan

- [x] `npm run build` passes
- [x] No circular deps
- [x] `import { NoopEmitter, type TraceEmitter } from 'bitbadges/builder/agent'` resolves
- [x] `import { NoopEmitter, type TraceEmitter } from 'bitbadges/builder/tracing'` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)