### PR TITLE
feat(cli): browser-bridge signing — auth login --browser, sign, deploy --browser

### DIFF
--- a/packages/bitbadgesjs-sdk/package-lock.json
+++ b/packages/bitbadgesjs-sdk/package-lock.json
@@ -16,6 +16,7 @@
         "commander": "^14.0.3",
         "crypto-addr-codec": "^0.1.7",
         "ethers": "^6.13.4",
+        "open": "^10.1.0",
         "sha3": "^2.1.4",
         "typia": "^8.0.2",
         "web3-validator": "^2.0.6",
@@ -67,10 +68,14 @@
         "typescript": "~5.8.3"
       },
       "peerDependencies": {
-        "@anthropic-ai/sdk": ">=0.80.0 <1.0.0"
+        "@anthropic-ai/sdk": ">=0.80.0 <1.0.0",
+        "openai": ">=4.0.0 <6.0.0"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "openai": {
           "optional": true
         }
       }
@@ -5202,6 +5207,21 @@
         "semver": "^7.0.0"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -5884,6 +5904,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -5910,6 +5958,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -8850,6 +8910,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -8942,6 +9017,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -9226,6 +9319,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -12130,6 +12238,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -13356,6 +13482,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-async": {
@@ -15562,6 +15700,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xml": {

--- a/packages/bitbadgesjs-sdk/package.json
+++ b/packages/bitbadgesjs-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitbadges",
   "description": "BitBadges — programmable tokens on Cosmos. SDK, CLI, and builder tools for humans and agents. (Previously published as 'bitbadgesjs-sdk'.)",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "license": "MIT",
   "keywords": [
     "bitbadges",

--- a/packages/bitbadgesjs-sdk/package.json
+++ b/packages/bitbadgesjs-sdk/package.json
@@ -176,6 +176,7 @@
     "commander": "^14.0.3",
     "crypto-addr-codec": "^0.1.7",
     "ethers": "^6.13.4",
+    "open": "^10.1.0",
     "sha3": "^2.1.4",
     "typia": "^8.0.2",
     "web3-validator": "^2.0.6",

--- a/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
@@ -32,6 +32,13 @@ export interface BridgePayload {
   expectedAddress?: string;
   /** Optional chain-id hint for tx mode (mainnet/testnet/stagenet selection). */
   chainId?: string;
+  /**
+   * When true (tx mode only): the page signs the tx but does NOT broadcast.
+   * Returns the signed tx_bytes (base64) to the loopback listener so the CLI
+   * can submit/retry/batch on its own. Useful for caller-controlled
+   * broadcast (custodial signers, retry-with-backoff, parallel sequencing).
+   */
+  signOnly?: boolean;
 }
 
 export interface BridgeResult {
@@ -40,6 +47,8 @@ export interface BridgeResult {
   publicKey?: string;
   hash?: string;
   chain?: 'cosmos' | 'evm';
+  /** Sign-only mode: base64-encoded TxRaw bytes, ready to POST to /api/v0/broadcast. */
+  signedTx?: string;
   /** When set, the user cancelled or the page reported an error. */
   error?: string;
 }
@@ -244,6 +253,7 @@ export async function bridgeSign(opts: BridgeStartOptions): Promise<BridgeResult
         address: params.get('address') ?? undefined,
         publicKey: params.get('publicKey') ?? undefined,
         hash: params.get('hash') ?? undefined,
+        signedTx: params.get('signedTx') ?? undefined,
         chain: (params.get('chain') as 'cosmos' | 'evm' | null) ?? undefined,
       };
 

--- a/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
@@ -1,0 +1,264 @@
+/**
+ * Browser-bridge signing helper for the BitBadges CLI.
+ *
+ * Spins up a loopback HTTP listener on a random ephemeral port, opens the
+ * user's default browser to the BitBadges /sign page with the request
+ * encoded in the URL (or as a short code if too large), waits for the
+ * wallet to redirect back with a signature/tx hash, and returns the
+ * result.
+ *
+ * Inspired by `gh auth login --web` and `npm login --auth-type=web`:
+ *   - State nonce echoed back on every redirect for CSRF-style binding.
+ *   - 6-digit PIN displayed in the terminal AND on the /sign page so the
+ *     user can cross-verify they're looking at the page their CLI just
+ *     launched (defense against ambient phishing tabs).
+ *   - Loopback-only (`127.0.0.1`); the /sign page enforces this on its
+ *     end too. RFC 8252 §7.3 native-app loopback exception.
+ */
+
+import http from 'http';
+import { AddressInfo } from 'net';
+import crypto from 'crypto';
+
+export type BridgeMode = 'login' | 'msg' | 'tx';
+
+export interface BridgePayload {
+  /** Required for login/msg; cosmos uses txsInfo, evm uses tx. */
+  message?: string;
+  chain?: 'cosmos' | 'evm';
+  txsInfo?: Array<{ type: string; msg: object }>;
+  tx?: { to: string; value?: string; data?: string };
+  /** bb1.../0x... — the /sign page blocks signing if the connected wallet doesn't match. */
+  expectedAddress?: string;
+  /** Optional chain-id hint for tx mode (mainnet/testnet/stagenet selection). */
+  chainId?: string;
+}
+
+export interface BridgeResult {
+  signature?: string;
+  address?: string;
+  publicKey?: string;
+  hash?: string;
+  chain?: 'cosmos' | 'evm';
+  /** When set, the user cancelled or the page reported an error. */
+  error?: string;
+}
+
+export interface BridgeOptions {
+  mode: BridgeMode;
+  payload: BridgePayload;
+  baseUrl: string; // indexer base, e.g. https://api.bitbadges.io/api/v0
+  frontendUrl: string; // e.g. https://bitbadges.io
+  apiKey?: string;
+  timeoutMs?: number; // default 5min
+  /** Set to true to skip auto-launching the browser (print URL instead). */
+  noOpen?: boolean;
+}
+
+const INLINE_PAYLOAD_THRESHOLD = 2 * 1024;
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const PIN_LENGTH = 6;
+
+function randomState(): string {
+  return crypto.randomBytes(16).toString('base64url');
+}
+
+function randomPin(): string {
+  let out = '';
+  for (let i = 0; i < PIN_LENGTH; i++) {
+    out += crypto.randomInt(0, 10).toString();
+  }
+  return out;
+}
+
+function base64UrlEncodeJson(obj: unknown): string {
+  const json = JSON.stringify(obj);
+  return Buffer.from(json, 'utf8').toString('base64url');
+}
+
+async function uploadPayload(baseUrl: string, apiKey: string | undefined, payload: BridgePayload): Promise<string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) headers['x-api-key'] = apiKey;
+  const res = await fetch(`${baseUrl}/sign/payload`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ payload }),
+  });
+  const text = await res.text();
+  let body: any;
+  try { body = JSON.parse(text); } catch { body = { raw: text }; }
+  if (!res.ok || typeof body?.code !== 'string') {
+    throw new Error(`Failed to upload sign payload: ${body?.errorMessage || body?.error || `HTTP ${res.status}`}`);
+  }
+  return body.code as string;
+}
+
+function successPage(): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><title>BitBadges CLI</title></head><body style="font-family: system-ui, sans-serif; max-width: 480px; margin: 60px auto; text-align: center; padding: 0 16px;"><h2 style="color: #2a7;">Signed</h2><p>You can close this tab and return to your terminal.</p><script>setTimeout(function(){ try { window.close(); } catch(e) {} }, 1500);</script></body></html>`;
+}
+
+function errorPage(msg: string): string {
+  const safe = msg.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' } as Record<string, string>)[c]);
+  return `<!doctype html><html><head><meta charset="utf-8"><title>BitBadges CLI — error</title></head><body style="font-family: system-ui, sans-serif; max-width: 480px; margin: 60px auto; text-align: center; padding: 0 16px;"><h2 style="color: #c33;">Sign request rejected</h2><p>${safe}</p><p>You can close this tab.</p></body></html>`;
+}
+
+function gonePage(): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><title>BitBadges CLI</title></head><body style="font-family: system-ui, sans-serif; max-width: 480px; margin: 60px auto; text-align: center; padding: 0 16px;"><h2>Already received</h2><p>This sign request already returned a result. You can close this tab.</p></body></html>`;
+}
+
+/**
+ * Open the system default browser. Uses the `open` package via dynamic
+ * import (it's ESM-only). Falls back to printing the URL if anything
+ * goes wrong.
+ */
+async function tryOpen(url: string): Promise<void> {
+  try {
+    const mod = await import('open');
+    const openFn = (mod as any).default ?? (mod as any);
+    await openFn(url);
+  } catch (err: any) {
+    process.stderr.write(`(could not auto-launch browser: ${err?.message || err})\n`);
+  }
+}
+
+export interface BridgeStartOptions extends BridgeOptions {
+  /** Stream the PIN + URL to stderr before opening. Default true. */
+  printPin?: boolean;
+}
+
+export async function bridgeSign(opts: BridgeStartOptions): Promise<BridgeResult> {
+  const state = randomState();
+  const pin = randomPin();
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // Encode payload — inline base64 for small, short-code upload for large.
+  const inlineEncoded = base64UrlEncodeJson(opts.payload);
+  const useUpload = inlineEncoded.length > INLINE_PAYLOAD_THRESHOLD;
+  let payloadParam: string;
+  let payloadKind: 'inline' | 'code';
+  if (useUpload) {
+    const code = await uploadPayload(opts.baseUrl, opts.apiKey, opts.payload);
+    payloadParam = `payload=${encodeURIComponent(code)}`;
+    payloadKind = 'code';
+  } else {
+    payloadParam = `payload_inline=${encodeURIComponent(inlineEncoded)}`;
+    payloadKind = 'inline';
+  }
+
+  // Spin up loopback listener.
+  return new Promise<BridgeResult>((resolve, reject) => {
+    let resolved = false;
+    let timer: NodeJS.Timeout | undefined;
+
+    const server = http.createServer((req, res) => {
+      const reqUrl = new URL(req.url ?? '/', `http://127.0.0.1`);
+
+      // Single-shot: any subsequent request after we've resolved gets 410.
+      if (resolved) {
+        res.statusCode = 410;
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.end(gonePage());
+        return;
+      }
+
+      // Only accept the /callback path. Everything else is 404 to keep
+      // the surface tiny.
+      if (reqUrl.pathname !== '/callback') {
+        res.statusCode = 404;
+        res.end();
+        return;
+      }
+
+      const params = reqUrl.searchParams;
+      const gotState = params.get('state');
+      if (gotState !== state) {
+        res.statusCode = 403;
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.end(errorPage('State nonce did not match. The request may have come from a different CLI session.'));
+        return;
+      }
+
+      const errParam = params.get('error');
+      if (errParam) {
+        resolved = true;
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.end(errorPage(errParam));
+        cleanup();
+        resolve({ error: errParam });
+        return;
+      }
+
+      const result: BridgeResult = {
+        signature: params.get('signature') ?? undefined,
+        address: params.get('address') ?? undefined,
+        publicKey: params.get('publicKey') ?? undefined,
+        hash: params.get('hash') ?? undefined,
+        chain: (params.get('chain') as 'cosmos' | 'evm' | null) ?? undefined,
+      };
+
+      resolved = true;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.end(successPage());
+      cleanup();
+      resolve(result);
+    });
+
+    const cleanup = () => {
+      if (timer) clearTimeout(timer);
+      server.close();
+    };
+
+    server.on('error', (err) => {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        reject(err);
+      }
+    });
+
+    server.listen(0, '127.0.0.1', async () => {
+      const addr = server.address() as AddressInfo;
+      const port = addr.port;
+      const returnUrl = `http://127.0.0.1:${port}/callback`;
+      const fullUrl =
+        `${opts.frontendUrl.replace(/\/$/, '')}/sign?mode=${encodeURIComponent(opts.mode)}` +
+        `&${payloadParam}` +
+        `&return=${encodeURIComponent(returnUrl)}` +
+        `&state=${encodeURIComponent(state)}` +
+        `&pin=${encodeURIComponent(pin)}`;
+
+      if (opts.printPin !== false) {
+        process.stderr.write(`\nFirst, copy your one-time code: ${pin}\n`);
+        process.stderr.write(`Press Enter to open the browser, or paste this URL manually:\n${fullUrl}\n\n`);
+      }
+
+      timer = setTimeout(() => {
+        if (resolved) return;
+        resolved = true;
+        cleanup();
+        reject(new Error(`Sign request timed out after ${Math.round(timeoutMs / 1000)}s. Re-run the command.`));
+      }, timeoutMs);
+
+      if (!opts.noOpen) {
+        await tryOpen(fullUrl);
+      }
+    });
+
+    // payloadKind is informational — surface it in debug logs.
+    if (process.env.BITBADGES_BRIDGE_DEBUG === '1') {
+      process.stderr.write(`(bridge: payload via ${payloadKind})\n`);
+    }
+  });
+}
+
+/**
+ * Resolve the BitBadges frontend URL for a given network. Honors
+ * BITBADGES_FRONTEND_URL env override.
+ */
+export function resolveFrontendUrl(network: 'mainnet' | 'testnet' | 'local', explicit?: string): string {
+  if (explicit) return explicit;
+  if (process.env.BITBADGES_FRONTEND_URL) return process.env.BITBADGES_FRONTEND_URL;
+  if (network === 'testnet') return 'https://testnet.bitbadges.io';
+  if (network === 'local') return 'http://localhost:3000';
+  return 'https://bitbadges.io';
+}

--- a/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
@@ -97,17 +97,50 @@ async function uploadPayload(baseUrl: string, apiKey: string | undefined, payloa
   return body.code as string;
 }
 
+// Theme-aware HTML pages served by the loopback listener. Uses
+// `prefers-color-scheme` so light + dark browsers both render
+// readable text on a sensible background. No JS — no auto-close
+// (the user closes the tab themselves once they see the result).
+const PAGE_STYLES = `
+  :root { color-scheme: light dark; }
+  body {
+    font-family: system-ui, -apple-system, sans-serif;
+    max-width: 520px;
+    margin: 80px auto;
+    text-align: center;
+    padding: 0 16px;
+    background: #fff;
+    color: #111;
+  }
+  h2 { margin-bottom: 12px; }
+  p { color: #444; }
+  .ok { color: #1e8a4a; }
+  .err { color: #c2360b; }
+  .muted { color: #777; font-size: 13px; margin-top: 24px; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #15161a; color: #e8e8ec; }
+    p { color: #b8b8bf; }
+    .ok { color: #4ade80; }
+    .err { color: #f87171; }
+    .muted { color: #888; }
+  }
+`;
+
+function pageHtml(title: string, statusClass: string, statusText: string, body: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title><style>${PAGE_STYLES}</style></head><body><h2 class="${statusClass}">${statusText}</h2>${body}<p class="muted">You can close this tab.</p></body></html>`;
+}
+
 function successPage(): string {
-  return `<!doctype html><html><head><meta charset="utf-8"><title>BitBadges CLI</title></head><body style="font-family: system-ui, sans-serif; max-width: 480px; margin: 60px auto; text-align: center; padding: 0 16px;"><h2 style="color: #2a7;">Signed</h2><p>You can close this tab and return to your terminal.</p><script>setTimeout(function(){ try { window.close(); } catch(e) {} }, 1500);</script></body></html>`;
+  return pageHtml('BitBadges CLI', 'ok', 'Signed', '<p>The result was returned to the terminal that opened this tab.</p>');
 }
 
 function errorPage(msg: string): string {
   const safe = msg.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' } as Record<string, string>)[c]);
-  return `<!doctype html><html><head><meta charset="utf-8"><title>BitBadges CLI — error</title></head><body style="font-family: system-ui, sans-serif; max-width: 480px; margin: 60px auto; text-align: center; padding: 0 16px;"><h2 style="color: #c33;">Sign request rejected</h2><p>${safe}</p><p>You can close this tab.</p></body></html>`;
+  return pageHtml('BitBadges CLI — error', 'err', 'Sign request rejected', `<p>${safe}</p>`);
 }
 
 function gonePage(): string {
-  return `<!doctype html><html><head><meta charset="utf-8"><title>BitBadges CLI</title></head><body style="font-family: system-ui, sans-serif; max-width: 480px; margin: 60px auto; text-align: center; padding: 0 16px;"><h2>Already received</h2><p>This sign request already returned a result. You can close this tab.</p></body></html>`;
+  return pageHtml('BitBadges CLI', '', 'Already received', '<p>This sign request already returned a result.</p>');
 }
 
 /**

--- a/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
@@ -53,6 +53,10 @@ export interface BridgeOptions {
   timeoutMs?: number; // default 5min
   /** Set to true to skip auto-launching the browser (print URL instead). */
   noOpen?: boolean;
+  /** Pin the loopback listener port. Default: random ephemeral. Useful for SSH-forwarded dev setups. */
+  port?: number;
+  /** Hostname to embed in the return URL (default 127.0.0.1). Use 'localhost' or a custom hostname when the browser is remote and reaches the listener via tunnel. */
+  loopbackHost?: string;
 }
 
 const INLINE_PAYLOAD_THRESHOLD = 2 * 1024;
@@ -253,10 +257,12 @@ export async function bridgeSign(opts: BridgeStartOptions): Promise<BridgeResult
       }
     });
 
-    server.listen(0, '127.0.0.1', async () => {
+    const bindPort = opts.port ?? 0;
+    const loopbackHost = opts.loopbackHost ?? '127.0.0.1';
+    server.listen(bindPort, '127.0.0.1', async () => {
       const addr = server.address() as AddressInfo;
       const port = addr.port;
-      const returnUrl = `http://127.0.0.1:${port}/callback`;
+      const returnUrl = `http://${loopbackHost}:${port}/callback`;
       const fullUrl =
         `${opts.frontendUrl.replace(/\/$/, '')}/sign?mode=${encodeURIComponent(opts.mode)}` +
         `&${payloadParam}` +

--- a/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
@@ -77,11 +77,15 @@ function base64UrlEncodeJson(obj: unknown): string {
 }
 
 async function uploadPayload(baseUrl: string, apiKey: string | undefined, payload: BridgePayload): Promise<string> {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (apiKey) headers['x-api-key'] = apiKey;
+  if (!apiKey) {
+    throw new Error('Cannot upload large sign payload: no API key. Set BITBADGES_API_KEY or pass --api-key.');
+  }
   const res = await fetch(`${baseUrl}/sign/payload`, {
     method: 'POST',
-    headers,
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+    },
     body: JSON.stringify({ payload }),
   });
   const text = await res.text();

--- a/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
@@ -80,11 +80,21 @@ function base64UrlEncodeJson(obj: unknown): string {
   return Buffer.from(json, 'utf8').toString('base64url');
 }
 
+function normalizeIndexerBase(baseUrl: string): string {
+  // Some callers pass the indexer root (`http://localhost:3001`) and others
+  // pass it with the `/api/v0` suffix already attached. Normalize so the
+  // bridge always hits `<root>/api/v0/sign/payload` regardless of which
+  // shape the caller supplied.
+  const trimmed = baseUrl.replace(/\/$/, '');
+  return /\/api\/v\d+$/.test(trimmed) ? trimmed : `${trimmed}/api/v0`;
+}
+
 async function uploadPayload(baseUrl: string, apiKey: string | undefined, payload: BridgePayload): Promise<string> {
   if (!apiKey) {
     throw new Error('Cannot upload large sign payload: no API key. Set BITBADGES_API_KEY or pass --api-key.');
   }
-  const res = await fetch(`${baseUrl}/sign/payload`, {
+  const url = `${normalizeIndexerBase(baseUrl)}/sign/payload`;
+  const res = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/bitbadgesjs-sdk/src/cli/commands/auth.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auth.ts
@@ -12,6 +12,7 @@
 import * as fs from 'fs';
 import { Command } from 'commander';
 import { resolveApiKey, resolveBaseUrl } from '../utils/api-client.js';
+import { bridgeSign, resolveFrontendUrl } from '../auth/browser-bridge.js';
 import {
   AuthSession,
   Network,
@@ -201,10 +202,14 @@ export const authCommand = new Command('auth').description(
 addNetworkOptions(authCommand.command('login'))
   .description('One-shot Blockin login: fetches challenge, posts your signature, stores session cookie.')
   .requiredOption('--address <addr>', "Native address (bb1... for Cosmos, 0x... for ETH).")
-  .requiredOption('--signature <sig>', 'Signature over the challenge message (hex or base64).')
-  .option('--public-key <b64>', 'Compressed pubkey, base64. REQUIRED for Cosmos addresses (CosmosDriver verifier needs it).')
+  .option('--signature <sig>', 'Signature over the challenge message (hex or base64). Omit when using --browser.')
+  .option('--public-key <b64>', 'Compressed pubkey, base64. REQUIRED for Cosmos signatures unless --browser is set.')
   .option('--message <text>', 'The exact challenge message that was signed (typically from `auth challenge`).')
   .option('--message-file <path>', 'Read challenge message from file (use `-` for stdin).')
+  .option('--browser', 'Open the BitBadges /sign page in the default browser and use the connected wallet to sign. Mutually exclusive with --signature.')
+  .option('--frontend-url <url>', 'Override the frontend base URL used by --browser (defaults to bitbadges.io / testnet.bitbadges.io / localhost:3000 by network).')
+  .option('--no-open', 'With --browser: print the sign URL to stderr instead of auto-launching the browser.')
+  .option('--timeout <seconds>', 'With --browser: how long to wait for the wallet signature before giving up (default 300, max 1800).')
   .option('--2fa <code>', '6-digit TOTP code (if account has 2FA enabled).')
   .option('--2fa-backup <code>', 'Backup recovery code (alternative to --2fa).')
   .action(async (opts) => {
@@ -212,8 +217,15 @@ addNetworkOptions(authCommand.command('login'))
     const baseUrl = resolveBaseUrl({ testnet: opts.testnet, local: opts.local, baseUrl: opts.url });
     const apiKey = resolveApiKey(opts.apiKey, network);
     const chain = detectChain(opts.address);
-    if (chain === 'Cosmos' && !opts.publicKey) {
-      throw new Error('--public-key is required for Cosmos signatures (CosmosDriver verifier needs it). Get it from `sign-arbitrary` output.');
+
+    if (opts.browser && opts.signature) {
+      throw new Error('--browser and --signature are mutually exclusive. Pick one path.');
+    }
+    if (!opts.browser && !opts.signature) {
+      throw new Error('Either --signature <sig> or --browser is required.');
+    }
+    if (!opts.browser && chain === 'Cosmos' && !opts.publicKey) {
+      throw new Error('--public-key is required for Cosmos signatures (CosmosDriver verifier needs it). Get it from `sign-arbitrary` output, or use --browser.');
     }
 
     let message = readMessage({ message: opts.message, messageFile: opts.messageFile });
@@ -252,12 +264,44 @@ addNetworkOptions(authCommand.command('login'))
       cookies = fresh.cookies;
     }
 
+    let signatureToVerify: string = opts.signature ?? '';
+    let publicKeyToVerify: string | undefined = opts.publicKey;
+
+    if (opts.browser) {
+      if (!message) {
+        throw new Error('Internal error: missing challenge message before browser bridge.');
+      }
+      const frontendUrl = resolveFrontendUrl(network, opts.frontendUrl);
+      const requestedTimeoutSec = opts.timeout ? Math.min(1800, Math.max(60, Number(opts.timeout))) : 300;
+      process.stderr.write(`\nOpening browser to ${frontendUrl}/sign for wallet signature...\n`);
+      const result = await bridgeSign({
+        mode: 'login',
+        payload: { message, expectedAddress: opts.address, chain: chain === 'ETH' ? 'evm' : 'cosmos' },
+        baseUrl,
+        frontendUrl,
+        apiKey,
+        timeoutMs: requestedTimeoutSec * 1000,
+        noOpen: opts.open === false,
+      });
+      if (result.error) {
+        throw new Error(`Browser sign cancelled or rejected: ${result.error}`);
+      }
+      if (!result.signature) {
+        throw new Error('Browser bridge returned no signature.');
+      }
+      signatureToVerify = result.signature;
+      publicKeyToVerify = result.publicKey ?? publicKeyToVerify;
+      if (chain === 'Cosmos' && !publicKeyToVerify) {
+        throw new Error('Browser bridge did not return a publicKey for the Cosmos signature; cannot complete /auth/verify.');
+      }
+    }
+
     let verify;
     try {
       verify = await postVerify(baseUrl, apiKey, formatCookieHeaderFromMany(cookies), {
         message,
-        signature: opts.signature,
-        publicKey: opts.publicKey,
+        signature: signatureToVerify,
+        publicKey: publicKeyToVerify,
       });
     } catch (err: any) {
       // Targeted hint:" — the most common failure mode here is an

--- a/packages/bitbadgesjs-sdk/src/cli/commands/auth.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auth.ts
@@ -210,6 +210,7 @@ addNetworkOptions(authCommand.command('login'))
   .option('--frontend-url <url>', 'Override the frontend base URL used by --browser (defaults to bitbadges.io / testnet.bitbadges.io / localhost:3000 by network).')
   .option('--no-open', 'With --browser: print the sign URL to stderr instead of auto-launching the browser.')
   .option('--timeout <seconds>', 'With --browser: how long to wait for the wallet signature before giving up (default 300, max 1800).')
+  .option('--port <n>', 'With --browser: pin the loopback listener port (default: random). Use this for SSH-forwarded dev setups.')
   .option('--2fa <code>', '6-digit TOTP code (if account has 2FA enabled).')
   .option('--2fa-backup <code>', 'Backup recovery code (alternative to --2fa).')
   .action(async (opts) => {
@@ -282,6 +283,7 @@ addNetworkOptions(authCommand.command('login'))
         apiKey,
         timeoutMs: requestedTimeoutSec * 1000,
         noOpen: opts.open === false,
+        port: opts.port ? Number(opts.port) : undefined,
       });
       if (result.error) {
         throw new Error(`Browser sign cancelled or rejected: ${result.error}`);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
@@ -38,6 +38,11 @@ async function emit(
     // ephemeral burner flow, equivalent to piping the JSON output
     // into `bb cli deploy --burner`.
     deployWithBurner?: boolean;
+    deployWithBrowser?: boolean;
+    frontendUrl?: string;
+    open?: boolean;
+    timeout?: string | number;
+    expectedAddress?: string;
     fund?: 'faucet' | 'manual';
     fee?: string;
     feeDenom?: string;
@@ -253,6 +258,60 @@ async function emit(
     );
   }
 
+  // ── --deploy-with-browser ───────────────────────────────────────────────
+  // Composes build + browser-bridge broadcast in one step. Equivalent
+  // to piping the JSON output to `bb cli deploy --browser --msg-stdin
+  // --manager <addr>`. The connected wallet on /sign page signs and
+  // broadcasts; account number / sequence / gas / fees are auto-handled
+  // frontend-side by TxModal.
+  if (opts.deployWithBrowser) {
+    if (opts.deployWithBurner) {
+      process.stderr.write(
+        '\nError: --deploy-with-browser and --deploy-with-burner are mutually exclusive.\n'
+      );
+      process.exit(2);
+    }
+    const networkName = resolveNetwork(opts);
+    const apiUrl = getApiUrl(opts);
+    const apiKey = getApiKeyForNetwork(opts);
+    const { bridgeSign, resolveFrontendUrl } = await import('../auth/browser-bridge.js');
+    const frontendUrl = resolveFrontendUrl(networkName, opts.frontendUrl);
+    const expectedAddress = opts.expectedAddress ?? opts.manager ?? opts.creator;
+    const requestedTimeoutSec = opts.timeout ? Math.min(1800, Math.max(60, Number(opts.timeout))) : 300;
+    process.stderr.write(`\nOpening browser to ${frontendUrl}/sign for wallet signature + broadcast...\n`);
+    try {
+      const result = await bridgeSign({
+        mode: 'tx',
+        payload: {
+          chain: 'cosmos',
+          txsInfo: [{ type: outData.typeUrl, msg: outData.value }],
+          expectedAddress,
+        },
+        baseUrl: apiUrl,
+        frontendUrl,
+        apiKey,
+        timeoutMs: requestedTimeoutSec * 1000,
+        noOpen: opts.open === false,
+      });
+      if (result.error) {
+        process.stderr.write(`Browser broadcast cancelled or rejected: ${result.error}\n`);
+        process.exit(1);
+      }
+      const payload = {
+        success: !!result.hash,
+        path: 'browser',
+        txHash: result.hash ?? null,
+        chain: result.chain ?? 'cosmos',
+      };
+      process.stdout.write('\n' + JSON.stringify(payload, null, 2) + '\n');
+      if (!payload.success) process.exit(1);
+      return;
+    } catch (err: any) {
+      process.stderr.write(`Browser broadcast failed: ${err?.message || err}\n`);
+      process.exit(1);
+    }
+  }
+
   // ── --deploy-with-burner ────────────────────────────────────────────────
   // Composes the build + burner-deploy pipeline into one step.
   // Equivalent to piping the JSON output to `bb cli deploy --burner
@@ -368,14 +427,19 @@ const sharedOpts = (cmd: Command) => {
   // lives on --manager). Equivalent to:
   //   bb cli build <preset> ... | bb cli deploy --burner --msg-stdin --manager <addr>
   cmd.option('--deploy-with-burner', 'After building, broadcast via the throwaway burner flow (CREATE-ONLY). Requires --manager.');
-  cmd.option('--fund <mode>', 'When deploying: funding source for the burner (faucet | manual)', 'faucet');
+  cmd.option('--deploy-with-browser', 'After building, hand off to the BitBadges /sign page for wallet signature + broadcast. Pairs with your connected wallet (Keplr, MetaMask, etc.).');
+  cmd.option('--frontend-url <url>', 'With --deploy-with-browser: override the frontend base URL.');
+  cmd.option('--no-open', 'With --deploy-with-browser: print the sign URL instead of auto-launching the browser.');
+  cmd.option('--timeout <seconds>', 'With --deploy-with-browser: how long to wait for the wallet to confirm (default 300, max 1800).');
+  cmd.option('--expected-address <addr>', 'With --deploy-with-browser: bb1.../0x... that the connected wallet must match. Defaults to --manager / --creator.');
+  cmd.option('--fund <mode>', 'With --deploy-with-burner: funding source for the burner (faucet | manual)', 'faucet');
   cmd.option('--fee <amount>', 'When deploying: fee amount in base units', '0');
   cmd.option('--fee-denom <denom>', 'When deploying: fee denom', 'ubadge');
   cmd.option('--gas <number>', 'When deploying: gas limit', '400000');
-  cmd.option('--new', 'When deploying: skip the burner picker and always create a fresh wallet');
-  cmd.option('--reuse <selector>', 'When deploying: reuse a specific saved burner by address or recovery file path');
-  cmd.option('--non-interactive', 'When deploying: never prompt; on any prompt point save state and exit for later resume');
-  cmd.option('--poll-timeout <seconds>', 'When deploying: seconds to wait for funding to land before prompting/exiting', '60');
+  cmd.option('--new', 'With --deploy-with-burner: skip the burner picker and always create a fresh wallet');
+  cmd.option('--reuse <selector>', 'With --deploy-with-burner: reuse a specific saved burner by address or recovery file path');
+  cmd.option('--non-interactive', 'With --deploy-with-burner: never prompt; on any prompt point save state and exit for later resume');
+  cmd.option('--poll-timeout <seconds>', 'With --deploy-with-burner: seconds to wait for funding to land before prompting/exiting', '60');
   return cmd;
 };
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
@@ -39,6 +39,7 @@ async function emit(
     // into `bb cli deploy --burner`.
     deployWithBurner?: boolean;
     deployWithBrowser?: boolean;
+    signOnly?: boolean;
     frontendUrl?: string;
     open?: boolean;
     timeout?: string | number;
@@ -286,6 +287,7 @@ async function emit(
           chain: 'cosmos',
           txsInfo: [{ type: outData.typeUrl, msg: outData.value }],
           expectedAddress,
+          signOnly: !!opts.signOnly,
         },
         baseUrl: apiUrl,
         frontendUrl,
@@ -297,12 +299,21 @@ async function emit(
         process.stderr.write(`Browser broadcast cancelled or rejected: ${result.error}\n`);
         process.exit(1);
       }
-      const payload = {
-        success: !!result.hash,
-        path: 'browser',
-        txHash: result.hash ?? null,
-        chain: result.chain ?? 'cosmos',
-      };
+      const payload: any = opts.signOnly
+        ? {
+            success: !!result.signedTx,
+            path: 'browser',
+            mode: 'sign-only',
+            signedTx: result.signedTx ?? null,
+            chain: result.chain ?? 'cosmos',
+          }
+        : {
+            success: !!result.hash,
+            path: 'browser',
+            mode: 'sign-and-broadcast',
+            txHash: result.hash ?? null,
+            chain: result.chain ?? 'cosmos',
+          };
       process.stdout.write('\n' + JSON.stringify(payload, null, 2) + '\n');
       if (!payload.success) process.exit(1);
       return;
@@ -428,6 +439,7 @@ const sharedOpts = (cmd: Command) => {
   //   bb cli build <preset> ... | bb cli deploy --burner --msg-stdin --manager <addr>
   cmd.option('--deploy-with-burner', 'After building, broadcast via the throwaway burner flow (CREATE-ONLY). Requires --manager.');
   cmd.option('--deploy-with-browser', 'After building, hand off to the BitBadges /sign page for wallet signature + broadcast. Pairs with your connected wallet (Keplr, MetaMask, etc.).');
+  cmd.option('--sign-only', 'With --deploy-with-browser: have the wallet sign but not broadcast — returns the signed tx bytes for caller-controlled broadcast.');
   cmd.option('--frontend-url <url>', 'With --deploy-with-browser: override the frontend base URL.');
   cmd.option('--no-open', 'With --deploy-with-browser: print the sign URL instead of auto-launching the browser.');
   cmd.option('--timeout <seconds>', 'With --deploy-with-browser: how long to wait for the wallet to confirm (default 300, max 1800).');

--- a/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
@@ -171,6 +171,7 @@ export const deployCommand = new Command('deploy')
   .option('--timeout <seconds>', 'With --browser: how long to wait for the wallet to confirm (default 300, max 1800).')
   .option('--port <n>', 'With --browser: pin the loopback listener port (default: random). Use this for SSH-forwarded dev setups.')
   .option('--expected-address <addr>', 'With --browser: bb1.../0x... that the connected wallet must match. Defaults to --manager.')
+  .option('--sign-only', 'With --browser: have the wallet SIGN the tx but not broadcast. Returns the signed tx bytes to the CLI so the caller can broadcast on its own (retry, batch, custodial submit). Result lands in stdout JSON as `signedTx`.')
   .option('--msg-file <path>', 'Read msg JSON from a file')
   .option('--msg-stdin', 'Read msg JSON from stdin')
   .option('--manager <address>', 'Address that will own the created collection (bb1...). Required for --burner; recommended for --browser.')
@@ -307,6 +308,7 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
           chain: 'cosmos',
           txsInfo: [{ type: msg.typeUrl, msg: msg.value }],
           expectedAddress,
+          signOnly: !!opts.signOnly,
         },
         baseUrl: apiUrl,
         frontendUrl,
@@ -319,12 +321,21 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
         process.stderr.write(`Browser broadcast cancelled or rejected: ${result.error}\n`);
         process.exit(1);
       }
-      const payload = {
-        success: !!result.hash,
-        path: 'browser',
-        txHash: result.hash ?? null,
-        chain: result.chain ?? 'cosmos',
-      };
+      const payload: any = opts.signOnly
+        ? {
+            success: !!result.signedTx,
+            path: 'browser',
+            mode: 'sign-only',
+            signedTx: result.signedTx ?? null,
+            chain: result.chain ?? 'cosmos',
+          }
+        : {
+            success: !!result.hash,
+            path: 'browser',
+            mode: 'sign-and-broadcast',
+            txHash: result.hash ?? null,
+            chain: result.chain ?? 'cosmos',
+          };
       process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
       process.exit(payload.success ? 0 : 1);
     } catch (err: any) {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
@@ -169,6 +169,7 @@ export const deployCommand = new Command('deploy')
   .option('--frontend-url <url>', 'With --browser: override the frontend base URL (defaults vary by network).')
   .option('--no-open', 'With --browser: print the sign URL to stderr instead of auto-launching the browser.')
   .option('--timeout <seconds>', 'With --browser: how long to wait for the wallet to confirm (default 300, max 1800).')
+  .option('--port <n>', 'With --browser: pin the loopback listener port (default: random). Use this for SSH-forwarded dev setups.')
   .option('--expected-address <addr>', 'With --browser: bb1.../0x... that the connected wallet must match. Defaults to --manager.')
   .option('--msg-file <path>', 'Read msg JSON from a file')
   .option('--msg-stdin', 'Read msg JSON from stdin')
@@ -312,6 +313,7 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
         apiKey,
         timeoutMs: requestedTimeoutSec * 1000,
         noOpen: opts.open === false,
+        port: opts.port ? Number(opts.port) : undefined,
       });
       if (result.error) {
         process.stderr.write(`Browser broadcast cancelled or rejected: ${result.error}\n`);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
@@ -156,28 +156,50 @@ RELATED
 
 export const deployCommand = new Command('deploy')
   .description(LONG_DESCRIPTION)
-  .summary('Broadcast a create-collection msg. Today: --burner is the only supported path.')
+  .summary('Broadcast a msg. Pick one path: --burner (throwaway signer) or --browser (your wallet via /sign handoff).')
   .usage(' ')
   .argument('[input]', 'Msg JSON file path, "-" for stdin, or inline JSON')
-  // Required path flag. Only `--burner` is implemented today; the flag
-  // is required-explicit to leave room for future paths (`--from <key>`
-  // for chain-binary signing, `--api-broadcast` for posting a pre-signed
-  // tx) without making any of them the silent default.
-  .requiredOption('--burner', 'Use the throwaway burner-wallet path. Currently the only supported deploy path.')
+  // Path selection. Exactly one of --burner / --browser must be set;
+  // the action handler enforces this. Leaves room for future paths
+  // (`--from <key>` for chain-binary signing, `--api-broadcast` for
+  // posting a pre-signed tx) without making any of them the silent
+  // default.
+  .option('--burner', 'Use the throwaway burner-wallet path (CREATE-ONLY). Requires --manager.')
+  .option('--browser', 'Hand off to the BitBadges /sign page in the browser; sign with your connected wallet (Keplr / MetaMask / etc.).')
+  .option('--frontend-url <url>', 'With --browser: override the frontend base URL (defaults vary by network).')
+  .option('--no-open', 'With --browser: print the sign URL to stderr instead of auto-launching the browser.')
+  .option('--timeout <seconds>', 'With --browser: how long to wait for the wallet to confirm (default 300, max 1800).')
+  .option('--expected-address <addr>', 'With --browser: bb1.../0x... that the connected wallet must match. Defaults to --manager.')
   .option('--msg-file <path>', 'Read msg JSON from a file')
   .option('--msg-stdin', 'Read msg JSON from stdin')
-  .requiredOption('--manager <address>', 'Address that will own the created collection (bb1...). Required — refuses to create orphaned collections.')
-  .option('--fund <mode>', 'Funding source for the burner: faucet | manual', 'faucet')
+  .option('--manager <address>', 'Address that will own the created collection (bb1...). Required for --burner; recommended for --browser.')
+  .option('--fund <mode>', 'With --burner: funding source for the burner (faucet | manual)', 'faucet')
   .option('--fee <amount>', 'Fee amount in base units (e.g. "0" or "5000")', '0')
   .option('--fee-denom <denom>', 'Fee denom', 'ubadge')
   .option('--gas <number>', 'Gas limit', '400000')
-  .option('--new', 'Skip the picker and always create a fresh burner')
-  .option('--reuse <selector>', 'Reuse a specific saved burner by address or recovery file path')
-  .option('--non-interactive', 'Never prompt; on any prompt point, save state and exit for later resume. Also forced when stdout is not a TTY.')
-  .option('--poll-timeout <seconds>', 'Seconds to wait for funding to land before prompting/exiting', '60')
-  .option('--dry-run', 'Simulate the tx and print expected gas + balance changes; never broadcast. No wallet is generated, no funding is requested.');
+  .option('--new', 'With --burner: skip the picker and always create a fresh burner')
+  .option('--reuse <selector>', 'With --burner: reuse a specific saved burner by address or recovery file path')
+  .option('--non-interactive', 'With --burner: never prompt; on any prompt point, save state and exit for later resume. Also forced when stdout is not a TTY.')
+  .option('--poll-timeout <seconds>', 'With --burner: seconds to wait for funding to land before prompting/exiting', '60')
+  .option('--dry-run', 'Simulate the tx and print expected gas + balance changes; never broadcast.');
 addNetworkOptions(deployCommand);
 deployCommand.action(async (input: string | undefined, opts: any) => {
+  // 0. Path selection — exactly one of --burner / --browser.
+  const useBurner = Boolean(opts.burner);
+  const useBrowser = Boolean(opts.browser);
+  if (useBurner && useBrowser) {
+    process.stderr.write('Error: --burner and --browser are mutually exclusive.\n');
+    process.exit(2);
+  }
+  if (!useBurner && !useBrowser && !opts.dryRun) {
+    process.stderr.write('Error: pick a deploy path — --burner (throwaway signer) or --browser (your connected wallet via /sign).\n');
+    process.exit(2);
+  }
+  if (useBurner && !opts.manager) {
+    process.stderr.write('Error: --burner requires --manager <bb1...>. The burner is a throwaway signer; the manager captures lasting collection ownership.\n');
+    process.exit(2);
+  }
+
   // 1. Resolve network + endpoints
   const networkName = resolveNetwork(opts);
   // The CLI's `mainnet | local | testnet` types line up 1:1 with the
@@ -187,7 +209,7 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
   const nodeUrl = opts.nodeUrl || NETWORK_CONFIGS[network].nodeUrl;
   const apiKey = getApiKeyForNetwork(opts);
 
-  if (opts.fund === 'faucet' && !apiKey && network !== 'local') {
+  if (useBurner && opts.fund === 'faucet' && !apiKey && network !== 'local') {
     process.stderr.write(
       'Warning: --fund faucet requires an API key on non-local networks. Set BITBADGES_API_KEY or `bitbadges-cli config set apiKey <key>`.\n'
     );
@@ -260,6 +282,51 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
       process.exit(0);
     } catch (err: any) {
       process.stderr.write(`Dry-run simulate failed: ${err?.message || err}\n`);
+      process.exit(1);
+    }
+  }
+
+  // 2.7 --browser short-circuit: hand off to the BitBadges /sign page,
+  // let the user's connected wallet sign and broadcast, capture the tx
+  // hash on the loopback listener. Frontend-side TxModal handles
+  // account number / sequence / gas / fees auto-fetch from the indexer.
+  if (useBrowser) {
+    if (msg && msg.value && opts.manager && !msg.value.manager) {
+      msg.value.manager = opts.manager;
+    }
+    const { bridgeSign, resolveFrontendUrl } = await import('../auth/browser-bridge.js');
+    const frontendUrl = resolveFrontendUrl(networkName, opts.frontendUrl);
+    const expectedAddress = opts.expectedAddress ?? opts.manager;
+    const requestedTimeoutSec = opts.timeout ? Math.min(1800, Math.max(60, Number(opts.timeout))) : 300;
+    process.stderr.write(`\nOpening browser to ${frontendUrl}/sign for wallet signature + broadcast...\n`);
+    try {
+      const result = await bridgeSign({
+        mode: 'tx',
+        payload: {
+          chain: 'cosmos',
+          txsInfo: [{ type: msg.typeUrl, msg: msg.value }],
+          expectedAddress,
+        },
+        baseUrl: apiUrl,
+        frontendUrl,
+        apiKey,
+        timeoutMs: requestedTimeoutSec * 1000,
+        noOpen: opts.open === false,
+      });
+      if (result.error) {
+        process.stderr.write(`Browser broadcast cancelled or rejected: ${result.error}\n`);
+        process.exit(1);
+      }
+      const payload = {
+        success: !!result.hash,
+        path: 'browser',
+        txHash: result.hash ?? null,
+        chain: result.chain ?? 'cosmos',
+      };
+      process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+      process.exit(payload.success ? 0 : 1);
+    } catch (err: any) {
+      process.stderr.write(`Browser broadcast failed: ${err?.message || err}\n`);
       process.exit(1);
     }
   }

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-pub-key.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-pub-key.ts
@@ -1,0 +1,284 @@
+/**
+ * `bitbadges-cli gen-pub-key` — derive the base64-encoded compressed
+ * secp256k1 public key for a Cosmos address.
+ *
+ * Resolution order:
+ *   1. Indexer's account record (`/api/v0/users` → `account.publicKey`).
+ *      Populated whenever the address has signed in or transacted.
+ *   2. Chain LCD (`/cosmos/auth/v1beta1/accounts/<addr>`).
+ *      Populated whenever the address has broadcast a tx onchain.
+ *   3. ECDSA signature recovery (only if the account has neither).
+ *      User signs a small fixed message offline; the CLI iterates the
+ *      4 secp256k1 recovery candidates and picks the one whose derived
+ *      bb1 address matches `--address`. Never asks for a private key
+ *      or mnemonic.
+ *
+ * Use cases:
+ *   - Plug into `gen-tx-payload --no-fetch --public-key <b64>` for
+ *     air-gapped flows where the indexer isn't reachable.
+ *   - Pre-flight a brand-new account that hasn't broadcast any tx yet
+ *     (the indexer will return an empty publicKey for fresh accounts).
+ *   - Print the bb1 + 0x form of an address from a single source of
+ *     truth.
+ *
+ * EVM N/A: EVM signing doesn't carry a separate Cosmos pubkey in
+ * AuthInfo — the secp256k1 key is recovered per-tx from the EVM tx's
+ * own signature.
+ */
+
+import { Command } from 'commander';
+import { addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
+import { NETWORK_CONFIGS } from '../../signing/types.js';
+import { convertToBitBadgesAddress, convertToEthAddress, cosmosAddressFromPublicKey } from '../../address-converter/converter.js';
+
+/**
+ * Canonical message used for the recovery flow. Distinct from any
+ * Blockin / SIWBB challenge so a user signing this CANNOT have their
+ * signature replayed against `/auth/verify`. Stable across versions —
+ * the CLI on the recovery side reconstructs the exact ADR-36 envelope
+ * from this string.
+ */
+const PUBKEY_DERIVATION_MESSAGE =
+  'BitBadges public key derivation. This signature is used only to derive your public key for offline signing. No transaction is being created or authorized, no session is being granted, and this signature has no validity outside this CLI flow.';
+
+function normalizeIndexerBase(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/$/, '');
+  return /\/api\/v\d+$/.test(trimmed) ? trimmed : `${trimmed}/api/v0`;
+}
+
+interface LookupResult {
+  found?: string;
+  /** True when the source replied "no pubkey on file"; false when the source is unreachable. */
+  reachable: boolean;
+  warning?: string;
+}
+
+async function lookupViaIndexer(baseUrl: string, apiKey: string | undefined, address: string): Promise<LookupResult> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) headers['x-api-key'] = apiKey;
+  try {
+    const res = await fetch(`${normalizeIndexerBase(baseUrl)}/users`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ accountsToFetch: [{ address }] }),
+    });
+    if (!res.ok) {
+      return { reachable: false, warning: `indexer responded ${res.status} (${baseUrl})` };
+    }
+    const body = await res.json();
+    const acct = (body?.accounts ?? [])[0];
+    const key = acct?.publicKey?.key ?? acct?.publicKey;
+    if (typeof key === 'string' && key.length > 0) return { found: key, reachable: true };
+    return { reachable: true };
+  } catch (err: any) {
+    return { reachable: false, warning: `indexer unreachable: ${err?.message || err}` };
+  }
+}
+
+async function lookupViaChainLCD(nodeUrl: string, address: string): Promise<LookupResult> {
+  try {
+    const res = await fetch(`${nodeUrl.replace(/\/$/, '')}/cosmos/auth/v1beta1/accounts/${encodeURIComponent(address)}`);
+    if (!res.ok) {
+      return { reachable: false, warning: `chain LCD responded ${res.status} (${nodeUrl})` };
+    }
+    const body = await res.json();
+    // Account shape varies by chain — the BitBadges chain wraps in BaseAccount.
+    // Common paths:
+    //   account.pub_key.key                          (cosmos-sdk vanilla)
+    //   account.base_account.pub_key.key             (vesting / module accts)
+    //   account.value.public_key.key                 (legacy)
+    const candidates: any[] = [
+      body?.account?.pub_key?.key,
+      body?.account?.base_account?.pub_key?.key,
+      body?.account?.value?.public_key?.key,
+      body?.account?.public_key?.key,
+    ];
+    for (const c of candidates) {
+      if (typeof c === 'string' && c.length > 0) return { found: c, reachable: true };
+    }
+    return { reachable: true };
+  } catch (err: any) {
+    return { reachable: false, warning: `chain LCD unreachable: ${err?.message || err}` };
+  }
+}
+
+/**
+ * Reconstruct the ADR-36 amino sign-doc bytes the wallet signed.
+ *
+ * Keplr's `signArbitrary(chainId, address, data)` constructs:
+ *   {
+ *     chain_id: "",
+ *     account_number: "0",
+ *     sequence: "0",
+ *     fee: { gas: "0", amount: [] },
+ *     msgs: [{ type: "sign/MsgSignData", value: { signer, data: <base64-of-data> } }],
+ *     memo: "",
+ *   }
+ * Then JSON-canonicalizes (alphabetically sorted keys, no whitespace),
+ * UTF-8 encodes, sha256s, and signs the digest. We replay the same.
+ */
+function buildAdr36SignBytes(signer: string, message: string): Uint8Array {
+  const dataBase64 = Buffer.from(message, 'utf8').toString('base64');
+  const signDoc = {
+    account_number: '0',
+    chain_id: '',
+    fee: { amount: [], gas: '0' },
+    memo: '',
+    msgs: [
+      {
+        type: 'sign/MsgSignData',
+        value: { data: dataBase64, signer },
+      },
+    ],
+    sequence: '0',
+  };
+  const canonical = canonicalizeJson(signDoc);
+  return Buffer.from(canonical, 'utf8');
+}
+
+function canonicalizeJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalizeJson).join(',') + ']';
+  const keys = Object.keys(value as object).sort();
+  return '{' + keys.map((k) => JSON.stringify(k) + ':' + canonicalizeJson((value as any)[k])).join(',') + '}';
+}
+
+async function recoverPubKey(message: string, signatureBase64: string, expectedAddress: string): Promise<string> {
+  const signBytes = buildAdr36SignBytes(expectedAddress, message);
+  const { createHash } = await import('crypto');
+  const digest = createHash('sha256').update(signBytes).digest();
+
+  const sigBytes = Buffer.from(signatureBase64, 'base64');
+  if (sigBytes.length !== 64) {
+    throw new Error(`Expected 64-byte signature (R || S), got ${sigBytes.length} bytes. Cosmos ADR-36 sigs do not include a recovery byte.`);
+  }
+  const r = '0x' + sigBytes.subarray(0, 32).toString('hex');
+  const s = '0x' + sigBytes.subarray(32, 64).toString('hex');
+
+  // ethers v6 — Signature.from accepts {r, s, v}; v ∈ {27, 28} for valid recoveries.
+  // SigningKey.recoverPublicKey returns 0x04-prefixed uncompressed (65 bytes).
+  // SigningKey.computePublicKey(uncompressed, true) returns the 33-byte compressed form.
+  const ethers = await import('ethers');
+
+  for (const v of [27, 28]) {
+    try {
+      const sig = ethers.Signature.from({ r, s, v });
+      const uncompressed = ethers.SigningKey.recoverPublicKey(digest, sig); // 0x04...
+      const compressed = ethers.SigningKey.computePublicKey(uncompressed, true); // 0x02.../0x03...
+      const compressedHex = compressed.startsWith('0x') ? compressed.slice(2) : compressed;
+      const derivedBb1 = cosmosAddressFromPublicKey(compressedHex);
+      if (derivedBb1 === expectedAddress) {
+        return Buffer.from(compressedHex, 'hex').toString('base64');
+      }
+    } catch {
+      // Some recovery IDs produce invalid points; skip.
+    }
+  }
+
+  throw new Error(
+    `Could not recover a public key matching ${expectedAddress} from the supplied signature. ` +
+      'Verify (a) the signature is base64-encoded, (b) the address is the one that produced the signature, and (c) you signed the canonical message exactly as printed.'
+  );
+}
+
+export const genPubKeyCommand = new Command('gen-pub-key')
+  .description('Derive a Cosmos public key from a bb1 address (or recover via signature for fresh accounts).')
+  .summary('Cosmos pub key from address — indexer / chain lookup, recovery as fallback.')
+  .requiredOption('--address <addr>', 'Cosmos bb1 address (or 0x... — will be converted). EVM-only addresses N/A: EVM signing recovers the pubkey per-tx.')
+  .option('--signature <b64>', 'Skip lookups and recover from this signature. Pair with --message if not signing the canonical CLI message.')
+  .option('--message <text>', 'Custom message that was signed. Defaults to the canonical CLI derivation message printed by --print-message.')
+  .option('--print-message', 'Print the canonical message your wallet should sign for the recovery flow, then exit.')
+  .option('--no-lookup', 'Skip the indexer + chain LCD lookups; force the signature-recovery path.');
+addNetworkOptions(genPubKeyCommand);
+genPubKeyCommand.action(async (opts) => {
+  // --print-message: tell the user exactly what to sign.
+  if (opts.printMessage) {
+    process.stdout.write(PUBKEY_DERIVATION_MESSAGE + '\n');
+    return;
+  }
+
+  // Normalize address. 0x... → bb1; bb1... → bb1; anything else → error.
+  let address: string;
+  try {
+    address = convertToBitBadgesAddress(String(opts.address));
+    if (!address) throw new Error('not a valid address');
+  } catch (err: any) {
+    process.stderr.write(`Invalid --address: ${err?.message || err}\n`);
+    process.exit(2);
+  }
+
+  const networkName = resolveNetwork(opts);
+  const baseUrl = getApiUrl(opts);
+  const apiKey = getApiKeyForNetwork(opts);
+  const nodeUrl = (opts as any).nodeUrl || NETWORK_CONFIGS[networkName].nodeUrl;
+
+  // 1. Lookup paths (skipped if --no-lookup or --signature was passed).
+  let pubKey: string | undefined;
+  let source: 'indexer' | 'chain' | 'signature' | undefined;
+  const warnings: string[] = [];
+
+  if (opts.lookup !== false && !opts.signature) {
+    const indexerRes = await lookupViaIndexer(baseUrl, apiKey, address);
+    if (indexerRes.found) {
+      pubKey = indexerRes.found;
+      source = 'indexer';
+    } else if (indexerRes.warning) {
+      warnings.push(indexerRes.warning);
+    }
+    if (!pubKey) {
+      const chainRes = await lookupViaChainLCD(nodeUrl, address);
+      if (chainRes.found) {
+        pubKey = chainRes.found;
+        source = 'chain';
+      } else if (chainRes.warning) {
+        warnings.push(chainRes.warning);
+      }
+    }
+  }
+
+  // 2. Signature recovery fallback.
+  if (!pubKey) {
+    if (!opts.signature) {
+      const warnSection = warnings.length > 0
+        ? `Lookup warnings:\n${warnings.map((w) => `  - ${w}`).join('\n')}\n\n`
+        : '';
+      process.stderr.write(
+        `Public key not found in the indexer (${baseUrl}) or chain LCD (${nodeUrl}).\n` +
+          'This typically means the address has never broadcast a tx or signed in.\n\n' +
+          warnSection +
+          'To derive the pub key offline:\n' +
+          '  1. Sign this exact message with your wallet (Keplr signArbitrary, hardware wallet, or any ADR-36-capable signer):\n\n' +
+          `    ${PUBKEY_DERIVATION_MESSAGE}\n\n` +
+          '  2. Re-run with the resulting base64 signature:\n' +
+          `     bitbadges-cli gen-pub-key --address ${address} --signature <base64>\n\n` +
+          '  Print the message verbatim with: bitbadges-cli gen-pub-key --print-message\n'
+      );
+      process.exit(2);
+    }
+    const message = String(opts.message ?? PUBKEY_DERIVATION_MESSAGE);
+    try {
+      pubKey = await recoverPubKey(message, String(opts.signature), address);
+      source = 'signature';
+    } catch (err: any) {
+      process.stderr.write(`${err?.message || err}\n`);
+      process.exit(1);
+    }
+  }
+
+  // 3. Compute address forms for output convenience.
+  let bb1Address = '';
+  let ethAddress = '';
+  try {
+    bb1Address = address;
+    ethAddress = convertToEthAddress(address);
+  } catch {
+    // Some addresses (e.g. derived from non-secp256k1 keys) don't have a stable EVM form. Best effort.
+  }
+
+  process.stdout.write(JSON.stringify({
+    pubKey,
+    bb1Address,
+    ethAddress,
+    source,
+  }, null, 2) + '\n');
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
@@ -105,8 +105,9 @@ export const genTxPayloadCommand = new Command('gen-tx-payload')
   .argument('[input]', 'Msg JSON file path, "-" for stdin, or inline JSON. Accepts a single {typeUrl, value} or an array.')
   .option('--msg-file <path>', 'Read msg JSON from a file')
   .option('--msg-stdin', 'Read msg JSON from stdin')
-  .requiredOption('--from <address>', 'Signer address (bb1.../0x...). Used to fetch account info and select payload shape. If 0x... is supplied, the bb1-equivalent is auto-derived for the Cosmos sender and EVM payload is also generated.')
-  .option('--evm-from <0x...>', 'Generate EVM payload for this address in addition to the Cosmos sender. Use when you want both signDirect AND evmTx outputs.')
+  .requiredOption('--from <address>', 'Signer address (bb1.../0x...). Used to fetch account info and select payload shape. With 0x... → emits evmTx (and signDirect if a public key is on chain). With bb1... → emits signDirect; add --with-evm-tx to also emit evmTx.')
+  .option('--evm-from <0x...>', 'Use this EVM address for the evmTx payload alongside a bb1 sender. Implies --with-evm-tx.')
+  .option('--with-evm-tx', 'Force-emit the evmTx precompile call alongside the Cosmos payloads. Useful when --from is bb1 and you also want a ready-to-send EVM tx.')
   .option('--public-key <b64>', 'Base64 compressed pubkey. Required if not fetched from indexer (--no-fetch) or if account is not yet onchain.')
   .option('--account-number <n>', 'Override account number (skip indexer round-trip for this field)')
   .option('--sequence <n>', 'Override sequence (skip indexer round-trip for this field)')
@@ -129,12 +130,27 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
 
   // Resolve sender / EVM address. The user passes one address via --from;
   // we derive the other when an EVM payload is wanted (--from is 0x... OR
-  // --evm-from is set explicitly).
+  // --evm-from is set explicitly OR --with-evm-tx is set with a bb1 --from).
   const fromIsEvm = String(opts.from).startsWith('0x');
   const senderAddress: string = fromIsEvm
     ? evmToCosmosAddress(opts.from, 'bb')
     : opts.from;
-  const evmAddress: string | undefined = opts.evmFrom ?? (fromIsEvm ? opts.from : undefined);
+  // EVM address resolution:
+  //  - explicit --evm-from wins
+  //  - else if --from is 0x..., use that
+  //  - else if --with-evm-tx is set, derive from bb1 sender via cosmosToEthAddress (best-effort; user can override)
+  let evmAddress: string | undefined = opts.evmFrom ?? (fromIsEvm ? opts.from : undefined);
+  if (!evmAddress && opts.withEvmTx) {
+    // bb1 → 0x derivation. The SDK's converter handles this.
+    try {
+      const { convertToEthAddress } = await import('../../address-converter/converter.js');
+      evmAddress = convertToEthAddress(senderAddress);
+    } catch (err: any) {
+      process.stderr.write(`Failed to derive EVM address from ${senderAddress}: ${err?.message || err}\n`);
+      process.stderr.write('Pass --evm-from 0x... explicitly.\n');
+      process.exit(2);
+    }
+  }
 
   const networkName = resolveNetwork(opts);
   const baseUrl = getApiUrl(opts);
@@ -153,10 +169,10 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
         const info = await fetchAccountInfo(baseUrl, apiKey, senderAddress);
         if (accountNumber === undefined) accountNumber = info.accountNumber;
         if (sequence === undefined) sequence = info.sequence;
-        if (!publicKey) publicKey = info.publicKey;
+        if (!publicKey && info.publicKey) publicKey = info.publicKey;
       } catch (err: any) {
         process.stderr.write(`Indexer fetch failed: ${err?.message || err}\n`);
-        process.stderr.write('If running offline, pass --no-fetch with --account-number, --sequence, and --public-key.\n');
+        process.stderr.write('If running offline, pass --no-fetch with --account-number and --sequence (and --public-key if you want Cosmos sign payloads).\n');
         process.exit(1);
       }
     }
@@ -166,8 +182,21 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
     process.stderr.write('Missing --account-number / --sequence. Re-run without --no-fetch, or supply both flags.\n');
     process.exit(2);
   }
-  if (!publicKey) {
-    process.stderr.write('Missing public key. Pass --public-key <b64>, or omit --no-fetch so the indexer can supply it (account must be seen onchain first).\n');
+
+  // publicKey is required for Cosmos sign payloads (signDirect, legacyAmino).
+  // It's NOT required if only evmTx is wanted — i.e. when --from is 0x...
+  // and there's no public key on file yet (Privy-only sign-in). In that
+  // case, drop the cosmos sender so createTransactionPayload only emits
+  // evmTx — the EVM tx is self-signing (no separate pubkey for the
+  // Cosmos AuthInfo).
+  const wantCosmosPayloads = !!publicKey;
+  if (!wantCosmosPayloads && !evmAddress) {
+    process.stderr.write(
+      'No public key available for ' + senderAddress + ' and no EVM address provided. ' +
+      'Either:\n' +
+      '  • Pass --public-key <b64> (for Cosmos signDirect/legacyAmino), or\n' +
+      '  • Use an EVM address via --from 0x... or --evm-from 0x... (emits evmTx only).\n'
+    );
     process.exit(2);
   }
 
@@ -195,12 +224,16 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
   try {
     payload = createTransactionPayload(
       {
-        sender: {
-          address: senderAddress,
-          sequence: sequence,
-          accountNumber: accountNumber,
-          publicKey: publicKey,
-        },
+        ...(wantCosmosPayloads
+          ? {
+              sender: {
+                address: senderAddress,
+                sequence: sequence,
+                accountNumber: accountNumber,
+                publicKey: publicKey!,
+              },
+            }
+          : {}),
         fee: { amount: fee, denom, gas },
         memo,
         chainIdOverride: chainId,
@@ -215,32 +248,53 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
 
   // Serialize the proto TxBody / AuthInfo to base64 so the JSON output is
   // self-contained. signBytes is already a string. evmTx is plain JSON.
-  const envelope = {
-    chain: evmAddress ? (senderAddress ? 'cosmos+evm' : 'evm') : 'cosmos',
+  const envelope: any = {
+    chain: evmAddress ? (wantCosmosPayloads ? 'cosmos+evm' : 'evm') : 'cosmos',
     chainId,
-    sender: { address: senderAddress, accountNumber: String(accountNumber), sequence: String(sequence), publicKey },
-    ...(evmAddress ? { evmAddress } : {}),
     fee: { amount: fee, denom, gas },
     memo,
     messages: messagesInput,
-    signDirect: {
+  };
+  if (wantCosmosPayloads) {
+    envelope.sender = { address: senderAddress, accountNumber: String(accountNumber), sequence: String(sequence), publicKey };
+    envelope.signDirect = {
       bodyBytes: bytesToBase64(payload.signDirect.body.toBinary()),
       authInfoBytes: bytesToBase64(payload.signDirect.authInfo.toBinary()),
       signBytes: payload.signDirect.signBytes,
-    },
-    legacyAmino: {
+    };
+    envelope.legacyAmino = {
       bodyBytes: bytesToBase64(payload.legacyAmino.body.toBinary()),
       authInfoBytes: bytesToBase64(payload.legacyAmino.authInfo.toBinary()),
       signBytes: payload.legacyAmino.signBytes,
-    },
-    ...(payload.evmTx ? { evmTx: payload.evmTx } : {}),
-    instructions: [
-      'signDirect.signBytes is what you sign for SIGN_MODE_DIRECT (Cosmos default).',
-      'legacyAmino.signBytes is what hardware wallets sign for SIGN_MODE_AMINO.',
-      'evmTx is a precompile call ready for ethers/viem: `signer.sendTransaction({to, data, value})`.',
-      'Once signed: rebuild a TxRaw {bodyBytes, authInfoBytes, [signature]} and POST to /api/v0/broadcast.',
-    ],
-  };
+    };
+  }
+  if (evmAddress) {
+    envelope.evmAddress = evmAddress;
+  }
+  if (payload.evmTx) {
+    // Augment the precompile call with everything an external EVM signer
+    // (ethers/viem/hardware) needs to construct an EIP-1559 tx without
+    // re-fetching anything: chainId, recommended gasLimit, and a hint
+    // string for the precompile function.
+    envelope.evmTx = {
+      ...payload.evmTx,
+      chainId: NETWORK_CONFIGS[networkName].evmChainId,
+      gasLimit: gas,
+    };
+  }
+  // Broadcast endpoint hint so callers don't have to know our routes.
+  envelope.broadcastEndpoint = `${normalizeIndexerBase(baseUrl)}/broadcast`;
+  envelope.instructions = [
+    ...(wantCosmosPayloads ? [
+      'Cosmos signing — pick one mode:',
+      '  SIGN_MODE_DIRECT: sign signDirect.signBytes; assemble TxRaw{bodyBytes, authInfoBytes, [signature]} and POST to broadcastEndpoint.',
+      '  SIGN_MODE_AMINO:  sign legacyAmino.signBytes (for hardware wallets that already speak amino).',
+    ] : []),
+    ...(payload.evmTx ? [
+      'EVM signing — build an EIP-1559 tx with: { chainId: evmTx.chainId, to: evmTx.to, data: evmTx.data, value: evmTx.value, gasLimit: evmTx.gasLimit }, sign with your EVM key, send via any RPC.',
+    ] : []),
+    'Need a tx-bytes-only flow without managing TxRaw assembly? Use `bitbadges-cli deploy --browser --sign-only` instead — that hands the wallet the signing UI and returns ready-to-broadcast bytes.',
+  ];
 
   process.stdout.write(JSON.stringify(envelope, null, 2) + '\n');
 });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
@@ -1,0 +1,211 @@
+/**
+ * `bitbadges-cli gen-tx-payload` — produce a fully-populated, signable
+ * tx payload from a built msg JSON. Output is pipable into any external
+ * signer (custom EVM wallet, ethers/viem, hardware wallet, custodial
+ * signer) that isn't the chain binary or the browser-bridge.
+ *
+ * The CLI's "third signing destination": #0373 covers chain-binary,
+ * #0375 covers browser wallets, this covers programmatic / agentic
+ * signers that want the SignDoc bytes precomputed.
+ *
+ * Pulls account number + sequence from the indexer based on --from
+ * (unless --no-fetch is set), builds the TxBody / AuthInfo / SignDoc
+ * with the supplied fee + gas, and emits a JSON envelope with both
+ * SIGN_MODE_DIRECT and SIGN_MODE_AMINO sign-bytes plus raw protobuf
+ * components.
+ */
+
+import * as fs from 'fs';
+import { Command } from 'commander';
+import { addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
+import {
+  createBodyWithMultipleMessages,
+  createFee,
+  createSignerInfo,
+  createAuthInfo,
+  createSignDoc,
+  createStdSignDigestFromProto,
+  SIGN_DIRECT,
+  LEGACY_AMINO,
+} from '../../transactions/messages/transaction.js';
+import { NETWORK_CONFIGS } from '../../signing/types.js';
+
+interface MsgEntry {
+  typeUrl: string;
+  value: Record<string, unknown>;
+}
+
+function readMsgInput(opts: { input?: string; msgFile?: string; msgStdin?: boolean }): MsgEntry | MsgEntry[] {
+  let raw: string;
+  if (opts.msgStdin) {
+    raw = fs.readFileSync(0, 'utf-8');
+  } else if (opts.msgFile) {
+    raw = fs.readFileSync(opts.msgFile, 'utf-8');
+  } else if (opts.input) {
+    if (opts.input === '-') raw = fs.readFileSync(0, 'utf-8');
+    else if (opts.input.startsWith('{') || opts.input.startsWith('[')) raw = opts.input;
+    else raw = fs.readFileSync(opts.input, 'utf-8');
+  } else if (!process.stdin.isTTY) {
+    raw = fs.readFileSync(0, 'utf-8');
+  } else {
+    throw new Error('No msg input. Pass a positional file/-, --msg-file, --msg-stdin, or pipe via stdin.');
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed;
+  } catch (err: any) {
+    throw new Error(`Failed to parse msg JSON: ${err?.message || err}`);
+  }
+}
+
+function normalizeMessages(input: unknown): MsgEntry[] {
+  const arr = Array.isArray(input) ? input : [input];
+  for (const m of arr) {
+    if (!m || typeof m !== 'object' || typeof (m as any).typeUrl !== 'string' || !(m as any).value) {
+      throw new Error('Each message must be `{typeUrl: string, value: object}`. Received: ' + JSON.stringify(m));
+    }
+  }
+  return arr as MsgEntry[];
+}
+
+interface FetchedAccountInfo {
+  accountNumber: number;
+  sequence: number;
+  publicKey?: string;
+}
+
+async function fetchAccountInfo(baseUrl: string, apiKey: string | undefined, address: string): Promise<FetchedAccountInfo> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) headers['x-api-key'] = apiKey;
+  const res = await fetch(`${baseUrl}/users`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ accountsToFetch: [{ address }] }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch account info for ${address}: HTTP ${res.status} ${await res.text()}`);
+  }
+  const body = await res.json();
+  const acct = (body?.accounts ?? [])[0];
+  if (!acct) {
+    throw new Error(`Indexer returned no account for ${address}. Has it been seen onchain yet?`);
+  }
+  return {
+    accountNumber: Number(acct.accountNumber ?? 0),
+    sequence: Number(acct.sequence ?? 0),
+    publicKey: acct.publicKey?.key ?? acct.publicKey,
+  };
+}
+
+function bytesToBase64(b: Uint8Array): string {
+  return Buffer.from(b).toString('base64');
+}
+
+export const genTxPayloadCommand = new Command('gen-tx-payload')
+  .description('Build a fully-populated signable tx payload from a msg JSON. Pipe into any external signer.')
+  .summary('Convert msg JSON → SignDoc bytes ready for an external signer.')
+  .argument('[input]', 'Msg JSON file path, "-" for stdin, or inline JSON. Accepts a single {typeUrl, value} or an array.')
+  .option('--msg-file <path>', 'Read msg JSON from a file')
+  .option('--msg-stdin', 'Read msg JSON from stdin')
+  .requiredOption('--from <address>', 'Signer address. Determines chain (bb1.../0x...) and is used to fetch account number + sequence.')
+  .option('--public-key <b64>', 'Base64 compressed pubkey. Required if not fetched from indexer (--no-fetch) or if account is not yet onchain.')
+  .option('--account-number <n>', 'Override account number (skip indexer round-trip for this field)')
+  .option('--sequence <n>', 'Override sequence (skip indexer round-trip for this field)')
+  .option('--chain-id <id>', 'Chain ID (default per network: bitbadges_50024-1 mainnet, bitbadges_50025-1 testnet, bitbadges_50026-1 stagenet)')
+  .option('--memo <text>', 'Optional tx memo', '')
+  .option('--fee <amount>', 'Fee amount in base units', '0')
+  .option('--fee-denom <denom>', 'Fee denom', 'ubadge')
+  .option('--gas <number>', 'Gas limit', '400000')
+  .option('--no-fetch', 'Skip the indexer account-info round-trip; require --account-number and --sequence via flags. Useful for offline / air-gapped flows.');
+addNetworkOptions(genTxPayloadCommand);
+genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => {
+  let messagesInput: MsgEntry[];
+  try {
+    const raw = readMsgInput({ input: positional, msgFile: opts.msgFile, msgStdin: opts.msgStdin });
+    messagesInput = normalizeMessages(raw);
+  } catch (err: any) {
+    process.stderr.write(`${err?.message || err}\n`);
+    process.exit(2);
+  }
+
+  const networkName = resolveNetwork(opts);
+  const baseUrl = getApiUrl(opts);
+  const apiKey = getApiKeyForNetwork(opts);
+  const chainId = opts.chainId ?? NETWORK_CONFIGS[networkName].cosmosChainId;
+
+  // Account number + sequence — either fetched or provided.
+  let accountNumber: number | undefined = opts.accountNumber !== undefined ? Number(opts.accountNumber) : undefined;
+  let sequence: number | undefined = opts.sequence !== undefined ? Number(opts.sequence) : undefined;
+  let publicKey: string | undefined = opts.publicKey;
+
+  if (opts.fetch !== false) {
+    if (accountNumber === undefined || sequence === undefined || !publicKey) {
+      try {
+        const info = await fetchAccountInfo(baseUrl, apiKey, opts.from);
+        if (accountNumber === undefined) accountNumber = info.accountNumber;
+        if (sequence === undefined) sequence = info.sequence;
+        if (!publicKey) publicKey = info.publicKey;
+      } catch (err: any) {
+        process.stderr.write(`Indexer fetch failed: ${err?.message || err}\n`);
+        process.stderr.write('If running offline, pass --no-fetch with --account-number, --sequence, and --public-key.\n');
+        process.exit(1);
+      }
+    }
+  }
+
+  if (accountNumber === undefined || sequence === undefined) {
+    process.stderr.write('Missing --account-number / --sequence. Re-run without --no-fetch, or supply both flags.\n');
+    process.exit(2);
+  }
+  if (!publicKey) {
+    process.stderr.write('Missing public key. Pass --public-key <b64>, or omit --no-fetch so the indexer can supply it (account must be seen onchain first).\n');
+    process.exit(2);
+  }
+
+  // Build all the bytes the external signer might need.
+  const fee = String(opts.fee ?? '0');
+  const denom = String(opts.feeDenom ?? 'ubadge');
+  const gas = Number(opts.gas ?? 400000);
+  const memo = String(opts.memo ?? '');
+
+  const body = createBodyWithMultipleMessages(messagesInput, memo);
+  const feeMessage = createFee(fee, denom, gas);
+  const pubKeyBytes = new Uint8Array(Buffer.from(publicKey, 'base64'));
+
+  const directSignerInfo = createSignerInfo(pubKeyBytes, sequence, SIGN_DIRECT);
+  const directAuthInfo = createAuthInfo(directSignerInfo, feeMessage);
+  const directSignDoc = createSignDoc(body.toBinary(), directAuthInfo.toBinary(), chainId, accountNumber);
+
+  const aminoSignerInfo = createSignerInfo(pubKeyBytes, sequence, LEGACY_AMINO);
+  const aminoAuthInfo = createAuthInfo(aminoSignerInfo, feeMessage);
+  const aminoSignBytes = createStdSignDigestFromProto(messagesInput, memo, fee, denom, gas, sequence, accountNumber, chainId);
+
+  const envelope = {
+    chain: opts.from.startsWith('0x') ? 'evm' : 'cosmos',
+    chainId,
+    from: opts.from,
+    accountNumber: String(accountNumber),
+    sequence: String(sequence),
+    publicKey,
+    fee: { amount: fee, denom, gas: String(gas) },
+    memo,
+    messages: messagesInput,
+    bodyBytes: bytesToBase64(body.toBinary()),
+    authInfo: {
+      direct: bytesToBase64(directAuthInfo.toBinary()),
+      amino: bytesToBase64(aminoAuthInfo.toBinary()),
+    },
+    signBytes: {
+      // SIGN_MODE_DIRECT: protobuf-encoded SignDoc. Sign these bytes.
+      direct: bytesToBase64(directSignDoc.toBinary()),
+      // SIGN_MODE_AMINO: stable JSON-canonical digest. For hardware wallets.
+      amino: aminoSignBytes,
+    },
+    instructions: {
+      direct: 'Sign signBytes.direct with your private key (secp256k1 over keccak256(bytes)). Submit the signature back via `bitbadges-cli api broadcast-tx` or POST /api/v0/broadcast with txBytes built from createTxRaw(bodyBytes, authInfo.direct, [signature]).',
+      amino: 'Sign signBytes.amino with your private key (legacy amino path, useful for hardware wallets that already support cosmos amino signing).',
+    },
+  };
+
+  process.stdout.write(JSON.stringify(envelope, null, 2) + '\n');
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
@@ -18,16 +18,6 @@
 import * as fs from 'fs';
 import { Command } from 'commander';
 import { addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
-import {
-  createBodyWithMultipleMessages,
-  createFee,
-  createSignerInfo,
-  createAuthInfo,
-  createSignDoc,
-  createStdSignDigestFromProto,
-  SIGN_DIRECT,
-  LEGACY_AMINO,
-} from '../../transactions/messages/transaction.js';
 import { NETWORK_CONFIGS } from '../../signing/types.js';
 
 interface MsgEntry {
@@ -74,10 +64,15 @@ interface FetchedAccountInfo {
   publicKey?: string;
 }
 
+function normalizeIndexerBase(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/$/, '');
+  return /\/api\/v\d+$/.test(trimmed) ? trimmed : `${trimmed}/api/v0`;
+}
+
 async function fetchAccountInfo(baseUrl: string, apiKey: string | undefined, address: string): Promise<FetchedAccountInfo> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (apiKey) headers['x-api-key'] = apiKey;
-  const res = await fetch(`${baseUrl}/users`, {
+  const res = await fetch(`${normalizeIndexerBase(baseUrl)}/users`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ accountsToFetch: [{ address }] }),
@@ -95,10 +90,6 @@ async function fetchAccountInfo(baseUrl: string, apiKey: string | undefined, add
     sequence: Number(acct.sequence ?? 0),
     publicKey: acct.publicKey?.key ?? acct.publicKey,
   };
-}
-
-function bytesToBase64(b: Uint8Array): string {
-  return Buffer.from(b).toString('base64');
 }
 
 export const genTxPayloadCommand = new Command('gen-tx-payload')
@@ -162,23 +153,18 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
     process.exit(2);
   }
 
-  // Build all the bytes the external signer might need.
+  // Build the metadata envelope an external signer needs. The CLI does NOT
+  // proto-encode the messages here — that requires the per-message-type
+  // SDK class which is heavy to plumb. Instead the caller is expected to
+  // handle its own proto encoding (ethers/viem for EVM-wrapped, cosmjs
+  // Registry for Cosmos, etc.) using the canonical message JSON we emit.
+  // What we DO populate is the fiddly state-fetching part: account number,
+  // sequence, public key, chain id, fee, memo — the things you'd otherwise
+  // have to hit the indexer / chain LCD for separately.
   const fee = String(opts.fee ?? '0');
   const denom = String(opts.feeDenom ?? 'ubadge');
   const gas = Number(opts.gas ?? 400000);
   const memo = String(opts.memo ?? '');
-
-  const body = createBodyWithMultipleMessages(messagesInput, memo);
-  const feeMessage = createFee(fee, denom, gas);
-  const pubKeyBytes = new Uint8Array(Buffer.from(publicKey, 'base64'));
-
-  const directSignerInfo = createSignerInfo(pubKeyBytes, sequence, SIGN_DIRECT);
-  const directAuthInfo = createAuthInfo(directSignerInfo, feeMessage);
-  const directSignDoc = createSignDoc(body.toBinary(), directAuthInfo.toBinary(), chainId, accountNumber);
-
-  const aminoSignerInfo = createSignerInfo(pubKeyBytes, sequence, LEGACY_AMINO);
-  const aminoAuthInfo = createAuthInfo(aminoSignerInfo, feeMessage);
-  const aminoSignBytes = createStdSignDigestFromProto(messagesInput, memo, fee, denom, gas, sequence, accountNumber, chainId);
 
   const envelope = {
     chain: opts.from.startsWith('0x') ? 'evm' : 'cosmos',
@@ -190,21 +176,16 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
     fee: { amount: fee, denom, gas: String(gas) },
     memo,
     messages: messagesInput,
-    bodyBytes: bytesToBase64(body.toBinary()),
-    authInfo: {
-      direct: bytesToBase64(directAuthInfo.toBinary()),
-      amino: bytesToBase64(aminoAuthInfo.toBinary()),
-    },
-    signBytes: {
-      // SIGN_MODE_DIRECT: protobuf-encoded SignDoc. Sign these bytes.
-      direct: bytesToBase64(directSignDoc.toBinary()),
-      // SIGN_MODE_AMINO: stable JSON-canonical digest. For hardware wallets.
-      amino: aminoSignBytes,
-    },
-    instructions: {
-      direct: 'Sign signBytes.direct with your private key (secp256k1 over keccak256(bytes)). Submit the signature back via `bitbadges-cli api broadcast-tx` or POST /api/v0/broadcast with txBytes built from createTxRaw(bodyBytes, authInfo.direct, [signature]).',
-      amino: 'Sign signBytes.amino with your private key (legacy amino path, useful for hardware wallets that already support cosmos amino signing).',
-    },
+    instructions: [
+      'This envelope contains the per-account state needed to construct a Cosmos SignDoc.',
+      'The CLI has fetched accountNumber, sequence, publicKey, and chainId for you.',
+      'To sign and broadcast:',
+      '  1. Build a Cosmos TxBody from `messages` (use the cosmjs Registry that matches each typeUrl).',
+      '  2. Build AuthInfo from `publicKey`, `sequence`, and `fee`.',
+      '  3. Build SignDoc from bodyBytes + authInfoBytes + chainId + accountNumber.',
+      '  4. Sign SignDoc.toBinary() with your private key (secp256k1).',
+      '  5. POST a TxRaw {bodyBytes, authInfoBytes, [signature]} to the chain or BitBadges /api/v0/broadcast.',
+    ],
   };
 
   process.stdout.write(JSON.stringify(envelope, null, 2) + '\n');

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
@@ -4,21 +4,25 @@
  * signer (custom EVM wallet, ethers/viem, hardware wallet, custodial
  * signer) that isn't the chain binary or the browser-bridge.
  *
- * The CLI's "third signing destination": #0373 covers chain-binary,
- * #0375 covers browser wallets, this covers programmatic / agentic
- * signers that want the SignDoc bytes precomputed.
+ * Output mirrors the SDK's `createTransactionPayload()` return shape:
+ *   - signDirect.{bodyBytes, authInfoBytes, signBytes}     (Cosmos SIGN_MODE_DIRECT)
+ *   - legacyAmino.{bodyBytes, authInfoBytes, signBytes}    (Cosmos SIGN_MODE_AMINO, hardware-wallet friendly)
+ *   - evmTx.{to, data, value, functionName}                (EVM precompile call, ready for ethers/viem)
  *
- * Pulls account number + sequence from the indexer based on --from
- * (unless --no-fetch is set), builds the TxBody / AuthInfo / SignDoc
- * with the supplied fee + gas, and emits a JSON envelope with both
- * SIGN_MODE_DIRECT and SIGN_MODE_AMINO sign-bytes plus raw protobuf
- * components.
+ * Cosmos payloads require `--from <bb1...>` plus the public key (auto-
+ * fetched from the indexer when the account has been seen onchain).
+ * EVM payload is generated when `--evm-from <0x...>` is set, OR when
+ * `--from` is itself a 0x-address (in which case the bb1-equivalent is
+ * auto-derived for the Cosmos sender).
  */
 
 import * as fs from 'fs';
 import { Command } from 'commander';
 import { addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
 import { NETWORK_CONFIGS } from '../../signing/types.js';
+import { createTransactionPayload } from '../../transactions/messages/base.js';
+import { encodeTokenizationMsgFromJson, supportedTokenizationTypeUrls } from '../../transactions/messages/bitbadges/tokenization/fromJson.js';
+import { evmToCosmosAddress } from '../../transactions/precompile/helpers.js';
 
 interface MsgEntry {
   typeUrl: string;
@@ -41,8 +45,7 @@ function readMsgInput(opts: { input?: string; msgFile?: string; msgStdin?: boole
     throw new Error('No msg input. Pass a positional file/-, --msg-file, --msg-stdin, or pipe via stdin.');
   }
   try {
-    const parsed = JSON.parse(raw);
-    return parsed;
+    return JSON.parse(raw);
   } catch (err: any) {
     throw new Error(`Failed to parse msg JSON: ${err?.message || err}`);
   }
@@ -92,22 +95,27 @@ async function fetchAccountInfo(baseUrl: string, apiKey: string | undefined, add
   };
 }
 
+function bytesToBase64(b: Uint8Array): string {
+  return Buffer.from(b).toString('base64');
+}
+
 export const genTxPayloadCommand = new Command('gen-tx-payload')
   .description('Build a fully-populated signable tx payload from a msg JSON. Pipe into any external signer.')
-  .summary('Convert msg JSON → SignDoc bytes ready for an external signer.')
+  .summary('Convert msg JSON → SignDoc / EVM tx ready for an external signer.')
   .argument('[input]', 'Msg JSON file path, "-" for stdin, or inline JSON. Accepts a single {typeUrl, value} or an array.')
   .option('--msg-file <path>', 'Read msg JSON from a file')
   .option('--msg-stdin', 'Read msg JSON from stdin')
-  .requiredOption('--from <address>', 'Signer address. Determines chain (bb1.../0x...) and is used to fetch account number + sequence.')
+  .requiredOption('--from <address>', 'Signer address (bb1.../0x...). Used to fetch account info and select payload shape. If 0x... is supplied, the bb1-equivalent is auto-derived for the Cosmos sender and EVM payload is also generated.')
+  .option('--evm-from <0x...>', 'Generate EVM payload for this address in addition to the Cosmos sender. Use when you want both signDirect AND evmTx outputs.')
   .option('--public-key <b64>', 'Base64 compressed pubkey. Required if not fetched from indexer (--no-fetch) or if account is not yet onchain.')
   .option('--account-number <n>', 'Override account number (skip indexer round-trip for this field)')
   .option('--sequence <n>', 'Override sequence (skip indexer round-trip for this field)')
-  .option('--chain-id <id>', 'Chain ID (default per network: bitbadges_50024-1 mainnet, bitbadges_50025-1 testnet, bitbadges_50026-1 stagenet)')
+  .option('--chain-id <id>', 'Cosmos chain ID override (default per network: bitbadges-1 / etc)')
   .option('--memo <text>', 'Optional tx memo', '')
   .option('--fee <amount>', 'Fee amount in base units', '0')
   .option('--fee-denom <denom>', 'Fee denom', 'ubadge')
   .option('--gas <number>', 'Gas limit', '400000')
-  .option('--no-fetch', 'Skip the indexer account-info round-trip; require --account-number and --sequence via flags. Useful for offline / air-gapped flows.');
+  .option('--no-fetch', 'Skip the indexer account-info round-trip; require --account-number, --sequence, and --public-key via flags. Useful for offline / air-gapped flows.');
 addNetworkOptions(genTxPayloadCommand);
 genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => {
   let messagesInput: MsgEntry[];
@@ -119,12 +127,22 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
     process.exit(2);
   }
 
+  // Resolve sender / EVM address. The user passes one address via --from;
+  // we derive the other when an EVM payload is wanted (--from is 0x... OR
+  // --evm-from is set explicitly).
+  const fromIsEvm = String(opts.from).startsWith('0x');
+  const senderAddress: string = fromIsEvm
+    ? evmToCosmosAddress(opts.from, 'bb')
+    : opts.from;
+  const evmAddress: string | undefined = opts.evmFrom ?? (fromIsEvm ? opts.from : undefined);
+
   const networkName = resolveNetwork(opts);
   const baseUrl = getApiUrl(opts);
   const apiKey = getApiKeyForNetwork(opts);
   const chainId = opts.chainId ?? NETWORK_CONFIGS[networkName].cosmosChainId;
 
-  // Account number + sequence — either fetched or provided.
+  // Account number + sequence — either fetched or provided. Always keyed by
+  // the bb1 sender, even when the user passed --from 0x...
   let accountNumber: number | undefined = opts.accountNumber !== undefined ? Number(opts.accountNumber) : undefined;
   let sequence: number | undefined = opts.sequence !== undefined ? Number(opts.sequence) : undefined;
   let publicKey: string | undefined = opts.publicKey;
@@ -132,7 +150,7 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
   if (opts.fetch !== false) {
     if (accountNumber === undefined || sequence === undefined || !publicKey) {
       try {
-        const info = await fetchAccountInfo(baseUrl, apiKey, opts.from);
+        const info = await fetchAccountInfo(baseUrl, apiKey, senderAddress);
         if (accountNumber === undefined) accountNumber = info.accountNumber;
         if (sequence === undefined) sequence = info.sequence;
         if (!publicKey) publicKey = info.publicKey;
@@ -153,38 +171,74 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
     process.exit(2);
   }
 
-  // Build the metadata envelope an external signer needs. The CLI does NOT
-  // proto-encode the messages here — that requires the per-message-type
-  // SDK class which is heavy to plumb. Instead the caller is expected to
-  // handle its own proto encoding (ethers/viem for EVM-wrapped, cosmjs
-  // Registry for Cosmos, etc.) using the canonical message JSON we emit.
-  // What we DO populate is the fiddly state-fetching part: account number,
-  // sequence, public key, chain id, fee, memo — the things you'd otherwise
-  // have to hit the indexer / chain LCD for separately.
+  // Convert each {typeUrl, value} JSON into a proto Message via the SDK's
+  // tokenization JSON dispatcher. Non-tokenization typeUrls are out of
+  // scope for this command — the agent should proto-encode them itself.
+  let protoMessages;
+  try {
+    protoMessages = messagesInput.map((m) => encodeTokenizationMsgFromJson(m));
+  } catch (err: any) {
+    process.stderr.write(`Failed to encode message: ${err?.message || err}\n`);
+    process.stderr.write(`Supported typeUrls: ${supportedTokenizationTypeUrls().join(', ')}\n`);
+    process.exit(2);
+  }
+
+  // Hand the proto messages to createTransactionPayload — the same SDK
+  // function the dashboard's TxModal uses. Returns signDirect +
+  // legacyAmino (when sender is set) and evmTx (when evmAddress is set).
   const fee = String(opts.fee ?? '0');
   const denom = String(opts.feeDenom ?? 'ubadge');
-  const gas = Number(opts.gas ?? 400000);
+  const gas = String(opts.gas ?? 400000);
   const memo = String(opts.memo ?? '');
 
+  let payload;
+  try {
+    payload = createTransactionPayload(
+      {
+        sender: {
+          address: senderAddress,
+          sequence: sequence,
+          accountNumber: accountNumber,
+          publicKey: publicKey,
+        },
+        fee: { amount: fee, denom, gas },
+        memo,
+        chainIdOverride: chainId,
+        ...(evmAddress ? { evmAddress } : {}),
+      },
+      protoMessages
+    );
+  } catch (err: any) {
+    process.stderr.write(`createTransactionPayload failed: ${err?.message || err}\n`);
+    process.exit(1);
+  }
+
+  // Serialize the proto TxBody / AuthInfo to base64 so the JSON output is
+  // self-contained. signBytes is already a string. evmTx is plain JSON.
   const envelope = {
-    chain: opts.from.startsWith('0x') ? 'evm' : 'cosmos',
+    chain: evmAddress ? (senderAddress ? 'cosmos+evm' : 'evm') : 'cosmos',
     chainId,
-    from: opts.from,
-    accountNumber: String(accountNumber),
-    sequence: String(sequence),
-    publicKey,
-    fee: { amount: fee, denom, gas: String(gas) },
+    sender: { address: senderAddress, accountNumber: String(accountNumber), sequence: String(sequence), publicKey },
+    ...(evmAddress ? { evmAddress } : {}),
+    fee: { amount: fee, denom, gas },
     memo,
     messages: messagesInput,
+    signDirect: {
+      bodyBytes: bytesToBase64(payload.signDirect.body.toBinary()),
+      authInfoBytes: bytesToBase64(payload.signDirect.authInfo.toBinary()),
+      signBytes: payload.signDirect.signBytes,
+    },
+    legacyAmino: {
+      bodyBytes: bytesToBase64(payload.legacyAmino.body.toBinary()),
+      authInfoBytes: bytesToBase64(payload.legacyAmino.authInfo.toBinary()),
+      signBytes: payload.legacyAmino.signBytes,
+    },
+    ...(payload.evmTx ? { evmTx: payload.evmTx } : {}),
     instructions: [
-      'This envelope contains the per-account state needed to construct a Cosmos SignDoc.',
-      'The CLI has fetched accountNumber, sequence, publicKey, and chainId for you.',
-      'To sign and broadcast:',
-      '  1. Build a Cosmos TxBody from `messages` (use the cosmjs Registry that matches each typeUrl).',
-      '  2. Build AuthInfo from `publicKey`, `sequence`, and `fee`.',
-      '  3. Build SignDoc from bodyBytes + authInfoBytes + chainId + accountNumber.',
-      '  4. Sign SignDoc.toBinary() with your private key (secp256k1).',
-      '  5. POST a TxRaw {bodyBytes, authInfoBytes, [signature]} to the chain or BitBadges /api/v0/broadcast.',
+      'signDirect.signBytes is what you sign for SIGN_MODE_DIRECT (Cosmos default).',
+      'legacyAmino.signBytes is what hardware wallets sign for SIGN_MODE_AMINO.',
+      'evmTx is a precompile call ready for ethers/viem: `signer.sendTransaction({to, data, value})`.',
+      'Once signed: rebuild a TxRaw {bodyBytes, authInfoBytes, [signature]} and POST to /api/v0/broadcast.',
     ],
   };
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/sign-with-browser.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/sign-with-browser.ts
@@ -1,5 +1,5 @@
 /**
- * `bitbadges-cli sign --browser <message-or-file>` — hand an arbitrary
+ * `bitbadges-cli sign-with-browser <message-or-file>` — hand an arbitrary
  * message off to the user's browser wallet (Keplr / MetaMask / etc.) for
  * signature, then return the signature + address as JSON on stdout.
  *
@@ -29,19 +29,18 @@ function readMessage(opts: { message?: string; messageFile?: string; positional?
   throw new Error('No message provided. Pass --message <text>, --message-file <path>, a positional arg, or pipe via stdin.');
 }
 
-export const signCommand = new Command('sign')
+export const signWithBrowserCommand = new Command('sign-with-browser')
   .description('Hand an arbitrary message to a browser wallet for signature, return signature + address.')
   .summary('Browser-bridge personal sign for any message.')
   .argument('[input]', 'Inline message, "-" for stdin, or "@path" for a file')
   .option('--message <text>', 'The message to sign (inline)')
   .option('--message-file <path>', 'Read message from file ("-" for stdin)')
-  .requiredOption('--browser', 'Required: this command only supports the browser-bridge path today.')
   .option('--expected-address <addr>', 'Require the connected wallet to match this address (bb1... / 0x...).')
   .option('--frontend-url <url>', 'Override the frontend base URL.')
   .option('--no-open', 'Print the sign URL instead of auto-launching the browser.')
   .option('--timeout <seconds>', 'How long to wait for the wallet (default 300, max 1800).');
-addNetworkOptions(signCommand);
-signCommand.action(async (positional: string | undefined, opts: any) => {
+addNetworkOptions(signWithBrowserCommand);
+signWithBrowserCommand.action(async (positional: string | undefined, opts: any) => {
   let message: string;
   try {
     message = readMessage({ message: opts.message, messageFile: opts.messageFile, positional });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/sign-with-browser.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/sign-with-browser.ts
@@ -38,7 +38,8 @@ export const signWithBrowserCommand = new Command('sign-with-browser')
   .option('--expected-address <addr>', 'Require the connected wallet to match this address (bb1... / 0x...).')
   .option('--frontend-url <url>', 'Override the frontend base URL.')
   .option('--no-open', 'Print the sign URL instead of auto-launching the browser.')
-  .option('--timeout <seconds>', 'How long to wait for the wallet (default 300, max 1800).');
+  .option('--timeout <seconds>', 'How long to wait for the wallet (default 300, max 1800).')
+  .option('--port <n>', 'Pin the loopback listener port (default: random ephemeral). Use this when your browser is on a different machine and you need a stable SSH port-forward.');
 addNetworkOptions(signWithBrowserCommand);
 signWithBrowserCommand.action(async (positional: string | undefined, opts: any) => {
   let message: string;
@@ -66,6 +67,7 @@ signWithBrowserCommand.action(async (positional: string | undefined, opts: any) 
       apiKey,
       timeoutMs: requestedTimeoutSec * 1000,
       noOpen: opts.open === false,
+      port: opts.port ? Number(opts.port) : undefined,
     });
     if (result.error) {
       process.stderr.write(`Sign cancelled or rejected: ${result.error}\n`);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/sign.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/sign.ts
@@ -1,0 +1,89 @@
+/**
+ * `bitbadges-cli sign --browser <message-or-file>` — hand an arbitrary
+ * message off to the user's browser wallet (Keplr / MetaMask / etc.) for
+ * signature, then return the signature + address as JSON on stdout.
+ *
+ * Pairs with #0375. Use cases: piping a Blockin challenge into a third-
+ * party signer, signing arbitrary attestation messages from an agent,
+ * etc. This command does NOT touch /auth/verify or persist a session —
+ * use `auth login --browser` for that.
+ */
+
+import * as fs from 'fs';
+import { Command } from 'commander';
+import { addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
+import { bridgeSign, resolveFrontendUrl } from '../auth/browser-bridge.js';
+
+function readMessage(opts: { message?: string; messageFile?: string; positional?: string }): string {
+  if (opts.message) return opts.message;
+  if (opts.messageFile) {
+    if (opts.messageFile === '-') return fs.readFileSync(0, 'utf-8');
+    return fs.readFileSync(opts.messageFile, 'utf-8');
+  }
+  if (opts.positional) {
+    if (opts.positional === '-') return fs.readFileSync(0, 'utf-8');
+    if (opts.positional.startsWith('@')) return fs.readFileSync(opts.positional.slice(1), 'utf-8');
+    return opts.positional;
+  }
+  if (!process.stdin.isTTY) return fs.readFileSync(0, 'utf-8');
+  throw new Error('No message provided. Pass --message <text>, --message-file <path>, a positional arg, or pipe via stdin.');
+}
+
+export const signCommand = new Command('sign')
+  .description('Hand an arbitrary message to a browser wallet for signature, return signature + address.')
+  .summary('Browser-bridge personal sign for any message.')
+  .argument('[input]', 'Inline message, "-" for stdin, or "@path" for a file')
+  .option('--message <text>', 'The message to sign (inline)')
+  .option('--message-file <path>', 'Read message from file ("-" for stdin)')
+  .requiredOption('--browser', 'Required: this command only supports the browser-bridge path today.')
+  .option('--expected-address <addr>', 'Require the connected wallet to match this address (bb1... / 0x...).')
+  .option('--frontend-url <url>', 'Override the frontend base URL.')
+  .option('--no-open', 'Print the sign URL instead of auto-launching the browser.')
+  .option('--timeout <seconds>', 'How long to wait for the wallet (default 300, max 1800).');
+addNetworkOptions(signCommand);
+signCommand.action(async (positional: string | undefined, opts: any) => {
+  let message: string;
+  try {
+    message = readMessage({ message: opts.message, messageFile: opts.messageFile, positional });
+  } catch (err: any) {
+    process.stderr.write(`${err?.message || err}\n`);
+    process.exit(2);
+  }
+
+  const networkName = resolveNetwork(opts);
+  const baseUrl = getApiUrl(opts);
+  const apiKey = getApiKeyForNetwork(opts);
+  const frontendUrl = resolveFrontendUrl(networkName, opts.frontendUrl);
+  const requestedTimeoutSec = opts.timeout ? Math.min(1800, Math.max(60, Number(opts.timeout))) : 300;
+
+  process.stderr.write(`\nOpening browser to ${frontendUrl}/sign for wallet signature...\n`);
+
+  try {
+    const result = await bridgeSign({
+      mode: 'msg',
+      payload: { message, expectedAddress: opts.expectedAddress },
+      baseUrl,
+      frontendUrl,
+      apiKey,
+      timeoutMs: requestedTimeoutSec * 1000,
+      noOpen: opts.open === false,
+    });
+    if (result.error) {
+      process.stderr.write(`Sign cancelled or rejected: ${result.error}\n`);
+      process.exit(1);
+    }
+    if (!result.signature) {
+      process.stderr.write('Browser bridge returned no signature.\n');
+      process.exit(1);
+    }
+    process.stdout.write(JSON.stringify({
+      signature: result.signature,
+      address: result.address,
+      publicKey: result.publicKey,
+      chain: result.chain,
+    }, null, 2) + '\n');
+  } catch (err: any) {
+    process.stderr.write(`Browser sign failed: ${err?.message || err}\n`);
+    process.exit(1);
+  }
+});

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -11,6 +11,7 @@ import { simulateCommand } from './commands/simulate.js';
 import { previewCommand } from './commands/preview.js';
 import { deployCommand } from './commands/deploy.js';
 import { txCommand } from './commands/tx.js';
+import { signCommand } from './commands/sign.js';
 
 // Indexer access
 import { createApiCommand } from './commands/api.js';
@@ -74,7 +75,7 @@ const HELP_GROUPS: { title: string; commands: Command[] }[] = [
   },
   {
     title: 'Indexer access',
-    commands: [createApiCommand(), authCommand]
+    commands: [createApiCommand(), authCommand, signCommand]
   },
   {
     title: 'Local state',

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -13,6 +13,7 @@ import { deployCommand } from './commands/deploy.js';
 import { txCommand } from './commands/tx.js';
 import { signWithBrowserCommand } from './commands/sign-with-browser.js';
 import { genTxPayloadCommand } from './commands/gen-tx-payload.js';
+import { genPubKeyCommand } from './commands/gen-pub-key.js';
 
 // Indexer access
 import { createApiCommand } from './commands/api.js';
@@ -76,7 +77,7 @@ const HELP_GROUPS: { title: string; commands: Command[] }[] = [
   },
   {
     title: 'Indexer access',
-    commands: [createApiCommand(), authCommand, signWithBrowserCommand]
+    commands: [createApiCommand(), authCommand, signWithBrowserCommand, genPubKeyCommand]
   },
   {
     title: 'Local state',

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -11,7 +11,8 @@ import { simulateCommand } from './commands/simulate.js';
 import { previewCommand } from './commands/preview.js';
 import { deployCommand } from './commands/deploy.js';
 import { txCommand } from './commands/tx.js';
-import { signCommand } from './commands/sign.js';
+import { signWithBrowserCommand } from './commands/sign-with-browser.js';
+import { genTxPayloadCommand } from './commands/gen-tx-payload.js';
 
 // Indexer access
 import { createApiCommand } from './commands/api.js';
@@ -71,11 +72,11 @@ if (process.argv.includes('--quiet')) {
 const HELP_GROUPS: { title: string; commands: Command[] }[] = [
   {
     title: 'Build & ship a transaction',
-    commands: [buildCommand, toolsCommand, toolCommand, checkCommand, explainCommand, simulateCommand, previewCommand, deployCommand, txCommand]
+    commands: [buildCommand, toolsCommand, toolCommand, checkCommand, explainCommand, simulateCommand, previewCommand, genTxPayloadCommand, deployCommand, txCommand]
   },
   {
     title: 'Indexer access',
-    commands: [createApiCommand(), authCommand, signCommand]
+    commands: [createApiCommand(), authCommand, signWithBrowserCommand]
   },
   {
     title: 'Local state',


### PR DESCRIPTION
## Summary

Adds a wallet-handoff path so users with browser-only wallets (Keplr, MetaMask, Phantom, WalletConnect) can sign from the CLI without exporting keys or running a chain binary. Same UX pattern as `gh auth login --web` / `npm login --auth-type=web`:

1. CLI spins up a loopback listener on a random ephemeral port.
2. Opens default browser to `bitbadges.io/sign?mode=...&payload_inline=<base64>&return=http://127.0.0.1:PORT&state=<nonce>&pin=<6-digit>`.
3. User cross-verifies the PIN (CLI shows it in stderr; page renders it large).
4. Wallet signs; page redirects to loopback with the signature/tx hash.
5. CLI captures result, validates `state`, completes flow.

## New surface

**Helper:** `src/cli/auth/browser-bridge.ts` — `bridgeSign({ mode, payload, ... })` does all the loopback + browser-open + state-validation plumbing. Three modes: `login` (Blockin signature for /auth/verify), `msg` (arbitrary personal-sign), `tx` (Cosmos multi-msg-in-one-TxBody, single signature). Adds the `open` npm dep (^10.1.0) for cross-platform browser launch.

**Commands:**
- `bitbadges-cli auth login --browser` — wires `bridgeSign(mode=login)` into the existing #0374 auth flow. Signature replaces `--signature`; cookies from the inline `getChallenge` are replayed on `/auth/verify`. Persisted session shape unchanged.
- `bitbadges-cli sign --browser <message>` — new top-level command. Returns `{signature, address, publicKey}` as JSON.
- `bitbadges-cli deploy --browser` — parallel to `deploy --burner`. Hands off the msg JSON to `/sign?mode=tx`, gets back a tx hash. Frontend's TxModal handles account number / sequence / gas / fee auto-fetch — none of that has to be replicated CLI-side.
- `bitbadges-cli build <preset> --deploy-with-browser` — composes build + bridge, parallel to `--deploy-with-burner`.

## Security UX

- **6-digit PIN cross-verification.** Defense against ambient phishing tabs / browser confusion. CLI shows e.g. `987654` in stderr; `/sign` page renders the same number prominently. User confirms before clicking sign.
- **Signer-binding check.** `expectedAddress` is propagated to the page. If the connected wallet's address (bb1-converted) doesn't match, the page disables the sign button and explains.
- **State nonce.** Non-matching `state` → 403 + reject (page) + ignored (listener).
- **Loopback-only return.** Page enforces `^http://(127\.0\.0\.1|localhost)(:\d+)?(/.*)?$`. RFC 8252 §7.3.
- **Single-shot listener.** Subsequent callbacks get 410.

## Out of scope

- No AI-builder / dashboard UI integration. The terminal is the UI; the browser is purely the signer.
- Single tx per request. Cosmos multi-msg-in-one-TxBody is supported (one signature). EVM = single tx; multi-tx flows = multiple round-trips.
- No 2FA changes — `auth login --browser` errors out asking for `--2fa <code>` if the account requires it (same behavior as the existing flow).

## Pairs with

- Autopilot ticket #0375 (design)
- bitbadges-indexer#156 (sign/payload short-code service)
- bitbadges-frontend#194 (/sign page)

PRs are sequential — this one needs the indexer + frontend deployed before the bridge actually works against prod, but `auth login --local --browser` works today against a local indexer + frontend.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (full SDK build, no circular deps)
- [x] `node dist/cjs/cli/index.js --help` — `sign` appears in Indexer access group
- [x] `node dist/cjs/cli/index.js deploy --help` — `--browser` flag present
- [ ] Manual e2e (post-deploy of indexer + frontend PRs):
  - [ ] `auth login --browser --address bb1...` opens browser, signs with Keplr, returns to terminal with valid Full Access session
  - [ ] `sign --browser "hello world"` opens browser, signs, prints JSON
  - [ ] `deploy --browser --manager bb1... --msg-file collection.json` opens browser, broadcasts via wallet, prints tx hash
  - [ ] `build vault --name X --image Y --description Z --manager bb1... --deploy-with-browser` composes build + bridge end-to-end
  - [ ] Phishing test: `state` mismatch → 403; `return=https://evil.com` → page rejects

🤖 Generated with [Claude Code](https://claude.com/claude-code)