### PR TITLE
sdk: mirror SIWE-conformance ChallengeParams.requestId

### DIFF
--- a/packages/bitbadgesjs-sdk/src/blockin/index.ts
+++ b/packages/bitbadgesjs-sdk/src/blockin/index.ts
@@ -53,6 +53,13 @@ export interface ChallengeParams<T extends NumberType> {
   issuedAt?: string;
   expirationDate?: string;
   notBefore?: string;
+  /**
+   * Optional EIP-4361 §3 Request ID. Lets the relying party correlate
+   * this challenge with a server-side request. SIWE-aware libraries
+   * parse `Request ID: <value>` between Not Before and Resources.
+   * Mirrors the field added to the underlying `blockin` package.
+   */
+  requestId?: string;
   resources?: string[];
   assetOwnershipRequirements?: AssetConditionGroup<T>;
 }


### PR DESCRIPTION
## Summary

Mirrors the optional `requestId` field added to the upstream `blockin` package's `ChallengeParams` (Blockin-Labs/blockin#feat/siwe-conformance) on the SDK's locally-extracted type definition. Pure type addition — no codepath changes.

Pair with the [blockin PR](https://github.com/Blockin-Labs/blockin/pulls?q=is%3Apr+head%3Afeat%2Fsiwe-conformance) for the actual EIP-4361 conformance fixes.

Refs bitbadges-autopilot#0359.

## Test plan

- [x] SDK type-check passes.
- [x] Full SDK suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)