### PR TITLE
sdk: re-export SIWBB types from package root

### DIFF
--- a/packages/bitbadgesjs-sdk/src/index.ts
+++ b/packages/bitbadgesjs-sdk/src/index.ts
@@ -27,3 +27,22 @@ export * from './address-converter/index.js';
 export * from './node-rest-api/index.js';
 export * from './gamm/index.js';
 export * from './signing/index.js';
+
+// Re-export SIWBB types by name so consumers (indexer's auth/siwe
+// module, frontend siwbb authorize page) can `import { ChallengeParams }
+// from 'bitbadges'` without reaching into deep subpaths.
+//
+// Skipped here to avoid collisions with already-public symbols:
+//   - `NumberType` (from `common/`)
+//   - `OwnershipRequirements` (`api-indexer/requests/blockin.ts` exports
+//     a class of the same name; consumers that want the interface can
+//     reference the class type, since the class `implements
+//     OwnershipRequirements<T>`).
+export type {
+  AndGroup,
+  OrGroup,
+  AssetDetails,
+  AssetConditionGroup,
+  ChallengeParams,
+  VerifyChallengeOptions
+} from './blockin/index.js';


### PR DESCRIPTION
## Summary
- Re-export `ChallengeParams`, `VerifyChallengeOptions`, `AssetConditionGroup`, `AndGroup`, `OrGroup`, `AssetDetails` by name from the package root (`'bitbadges'`).
- Lets consumers (indexer's new internal `auth/siwe` module, frontend siwbb authorize page) avoid deep subpath imports like `bitbadges/dist/blockin/...`.
- `OwnershipRequirements` skipped — it collides with the API request class of the same name. Consumers that want the interface can reference the class type since the class `implements OwnershipRequirements<T>`.

This is a support PR for the larger blockin-deprecation work in:
- bitbadges-indexer#TODO
- bitbadges-frontend#TODO

Tracking: backlog #0380.

## Test plan
- [ ] \`bun run build\` clean (no new symbol collisions)
- [ ] Consumer typechecks pass (indexer tsc clean, frontend tsc clean) when pulled in via \`bun link\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)