### PR TITLE
sdk: re-export SIWBB types from package root

### DIFF
--- a/packages/bitbadgesjs-sdk/src/index.ts
+++ b/packages/bitbadgesjs-sdk/src/index.ts
@@ -27,3 +27,19 @@ export * from './address-converter/index.js';
 export * from './node-rest-api/index.js';
 export * from './gamm/index.js';
 export * from './signing/index.js';
+
+// Re-export SIWBB types by name so consumers (indexer's auth/siwe
+// module, frontend siwbb authorize page) can `import { ChallengeParams }
+// from 'bitbadges'` without reaching into deep subpaths.
+//
+// `OwnershipRequirements` deliberately skipped — it collides with the
+// API request class of the same name. Consumers that want the interface
+// can reference the class type, since the class implements it.
+export type {
+  AndGroup,
+  OrGroup,
+  AssetDetails,
+  AssetConditionGroup,
+  ChallengeParams,
+  VerifyChallengeOptions
+} from './blockin/index.js';


### PR DESCRIPTION
## Summary
Re-export `ChallengeParams`, `VerifyChallengeOptions`, `AssetConditionGroup`, `AndGroup`, `OrGroup`, `AssetDetails` by name from the package root so consumers can `import { ChallengeParams } from 'bitbadges'` without reaching into deep subpaths.

`OwnershipRequirements` skipped — it collides with the API request class of the same name. Consumers that want the interface can reference the class type since the class implements it.

## Why
Required for blockin-deprecation merge: indexer #157 and frontend #202 both import these types from \`'bitbadges'\`. Without this PR they only typecheck via \`bun link\` symlinks; CI/deploy breaks.

## Test plan
- [ ] \`bun run build\` clean in SDK
- [ ] Consumer typecheck passes once SDK is published + pinned (or symlinked via \`bun link bitbadges\`)
- [ ] Bump + publish so indexer + frontend can pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)