### PR TITLE
docs(openapi): fix 4 broken docs.bitbadges.io URLs (#0291)

### DIFF
--- a/packages/bitbadgesjs-sdk/openapitypes-helpers/routes.yaml
+++ b/packages/bitbadgesjs-sdk/openapitypes-helpers/routes.yaml
@@ -254,9 +254,6 @@ paths:
         Scopes
         - `readProfile` - Required for private profile information like notification preferences, social connections, etc.
 
-        Couple Notes:
-        - **[Native Chain Algorithm](https://docs.bitbadges.io/for-developers/bitbadges-api/concepts/native-chain-algorithm)**
-
         Note: The `views` and corresponding fields like `tokensCollected`, etc will be blank with this simple
         GET but are provided in the response for compatibility with the SDK. To actually fetch these views, use the POST
         batch route or the individual view routes.
@@ -2823,7 +2820,7 @@ paths:
         Generates a unique code based on a seed and a zero-based index. This is used for the Codes plugin with claims.
 
         Documentation References / Tutorials:
-        - **[Codes Plugin](https://docs.bitbadges.io/for-developers/claim-builder/universal-approach-claim-codes)**
+        - **[Codes Plugin](https://docs.bitbadges.io/for-developers/claims/built-in-plugins)**
 
       tags:
         - Claims
@@ -2884,8 +2881,8 @@ paths:
         ```
 
         Documentation References / Tutorials:
-        - **[Getting Claims](https://docs.bitbadges.io/for-developers/bitbadges-api/tutorials/getting-claims)**
-        - **[Managing Claims](https://docs.bitbadges.io/for-developers/bitbadges-api/tutorials/managing-claims)**
+        - **[Claims API Reference](https://docs.bitbadges.io/for-developers/claims/api-reference)**
+        - **[Designing Claims](https://docs.bitbadges.io/for-developers/claims/designing-claims)**
 
         SDK Links:
         - **[Request Type](https://bitbadges.github.io/bitbadgesjs/interfaces/iGetClaimAttemptsPayload)**


### PR DESCRIPTION
## Summary

Fixes the four `docs.bitbadges.io` URLs in `packages/bitbadgesjs-sdk/openapitypes-helpers/routes.yaml` that still 404 today. Closes autopilot ticket #0291.

## What changed

| Before (404) | After (200) |
|---|---|
| `/for-developers/bitbadges-api/concepts/native-chain-algorithm` | *bullet dropped — no equivalent published page* |
| `/for-developers/claim-builder/universal-approach-claim-codes` | `/for-developers/claims/built-in-plugins` |
| `/for-developers/bitbadges-api/tutorials/getting-claims` | `/for-developers/claims/api-reference` |
| `/for-developers/bitbadges-api/tutorials/managing-claims` | `/for-developers/claims/designing-claims` |

The other links the ticket flagged (`/claims`, `/sign-in-with-bitbadges`, `/create-and-broadcast-txs`, `/concepts/managing-views`, `/claims/dynamic-stores`) all return 200 today thanks to Gitbook redirects + earlier doc-watch sweeps — left untouched.

## Why "Native Chain Algorithm" was dropped

The page no longer exists. The closest content is in `for-developers/concepts/accounts.md`, but that file isn't referenced in `SUMMARY.md` so Gitbook doesn't publish it (`/for-developers/concepts/accounts` also 404s). Rather than point users at unpublished content, dropped the bullet entirely. The `Couple Notes:` header that introduced it went with it since it was the only bullet.

## Test plan

- [x] `grep` confirms none of the original 9 broken-URL patterns remain in `routes.yaml`.
- [x] All 4 replacement URLs return 200 (verified via curl).
- [ ] Reviewer eyeballs the GET-account route description for sense without the dropped bullet.
- [ ] Stoplight/Swagger UI rendering still parses the YAML.

## Follow-up (out of scope)

The ticket's bonus ask — "add a CI check that runs curl against each `docs.bitbadges.io` URL in the spec and fails on 404" — would prevent this from regressing. Worth its own PR; touching `.github/workflows/` is broader than this docs swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)