### PR TITLE
feat(sdk): re-export placeholder-art generator from package root

### DIFF
--- a/packages/bitbadgesjs-sdk/package.json
+++ b/packages/bitbadgesjs-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitbadges",
   "description": "BitBadges — programmable tokens on Cosmos. SDK, CLI, and builder tools for humans and agents. (Previously published as 'bitbadgesjs-sdk'.)",
-  "version": "0.37.2",
+  "version": "0.37.3",
   "license": "MIT",
   "keywords": [
     "bitbadges",

--- a/packages/bitbadgesjs-sdk/src/index.ts
+++ b/packages/bitbadgesjs-sdk/src/index.ts
@@ -43,3 +43,24 @@ export type {
   ChallengeParams,
   VerifyChallengeOptions
 } from './blockin/index.js';
+
+// Placeholder-art generator — deterministic SVG data URIs for use as
+// image fields anywhere a consumer wants an "intentional placeholder"
+// without an IPFS roundtrip. Used by the AI Builder and the frontend
+// ImageSelect's "Generate" affordance.
+export {
+  generatePlaceholderArt,
+  hashSeed,
+  deriveSymbol,
+  resolveStyle,
+  PALETTES,
+  pickPalette,
+  GLYPH_NAMES
+} from './builder/generators/placeholder-art/index.js';
+export type {
+  GeneratePlaceholderArtInput,
+  GeneratePlaceholderArtResult,
+  PlaceholderArtStyle,
+  PlaceholderArtVibe,
+  Palette
+} from './builder/generators/placeholder-art/index.js';


### PR DESCRIPTION
## Summary
- Surfaces `generatePlaceholderArt` (and its types/helpers — `PALETTES`, `pickPalette`, `GLYPH_NAMES`, `hashSeed`, `deriveSymbol`, `resolveStyle`, plus `Palette`, `GeneratePlaceholderArtInput/Result`, `PlaceholderArtStyle`, `PlaceholderArtVibe`) on the public SDK entry.
- No behavior change — pure named re-export from `builder/generators/placeholder-art/index.js`.
- Unblocks the frontend `ImageSelect` "Generate Placeholder" affordance (companion PR in `bitbadges-frontend`).

## Test plan
- [x] `npm run build` passes (tsc + tsc-esm + alias + fixup + madge)
- [x] No circular dependency warnings
- [ ] Pair-test with the frontend PR via `bun link` to confirm `import { generatePlaceholderArt } from 'bitbadges'` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)