### PR TITLE
feat: add warnings to standardsConformance

### DIFF
--- a/packages/bitbadgesjs-sdk/src/api-indexer/BitBadgesCollection.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/BitBadgesCollection.ts
@@ -164,13 +164,15 @@ export interface iBitBadgesCollection<T extends NumberType> extends iCollectionD
    * indexer recomputes on each fetch rather than caching.
    *
    * The key is the standard name (e.g. "NFTMarketplace"); the value is a
-   * `{ conforms, errors? }` object where `errors` lists rule violations when
-   * `conforms` is false.
+   * `{ conforms, errors?, warnings? }` object where `errors` lists rule
+   * violations that cause `conforms` to be false, and `warnings` lists soft
+   * advisories that do not affect conformance.
    */
   standardsConformance?: {
     [standardName: string]: {
       conforms: boolean;
       errors?: string[];
+      warnings?: string[];
     };
   };
 }
@@ -235,6 +237,7 @@ export class BitBadgesCollection<T extends NumberType>
     [standardName: string]: {
       conforms: boolean;
       errors?: string[];
+      warnings?: string[];
     };
   };
 


### PR DESCRIPTION
## Summary

Extend the `standardsConformance` field on `iBitBadgesCollection` (and the mirrored `BitBadgesCollection` class property) to include an optional `warnings?: string[]` array alongside the existing `errors?: string[]`.

### Shape change

Before:
```typescript
standardsConformance?: {
  [standardName: string]: {
    conforms: boolean;
    errors?: string[];
  };
};
```

After:
```typescript
standardsConformance?: {
  [standardName: string]: {
    conforms: boolean;
    errors?: string[];
    warnings?: string[];
  };
};
```

`errors` continues to drive `conforms` (non-empty → `conforms: false`). `warnings` are soft advisories that surface in UI but do NOT flip `conforms`.

## Downstream work

- **Indexer**: needs to populate `warnings` from the validator. The current `StandardViolation` type in `packages/bitbadgesjs-sdk/src/api-indexer/verify-standards.ts` does NOT yet carry a `severity` field — every violation today is treated as an error. The indexer agent will need to either (a) add `severity: 'error' | 'warning'` to `StandardViolation` and tag each `violations.push({...})` call site, or (b) maintain a parallel allow-list of fields/standards whose violations are demoted to warnings. The shape on this PR supports both approaches.
- **Frontend**: DRY refactor of the conformance display (collapsing duplicate error/warning rendering across the collection page and review modals) depends on this shape change landing first.

## Test plan

- [x] `npm run build` in `packages/bitbadgesjs-sdk` — clean (no TS errors, no circular deps)
- [x] `npm test` — 2391/2391 passing (no behavior change, type-only extension)
- [x] `grep -n "warnings?" packages/bitbadgesjs-sdk/src/api-indexer/BitBadgesCollection.ts` — appears on both interface and class

## Notes

- No `any` introduced.
- Backwards-compatible: `warnings` is optional, so existing consumers that only read `conforms`/`errors` keep working unchanged.
- DO NOT MERGE until indexer + frontend follow-ups are queued.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>