### PR TITLE
feat(cli): auto-normalize 0x → bb1 for indexer commands

### DIFF
--- a/packages/bitbadgesjs-sdk/src/cli/commands/balances.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/balances.ts
@@ -20,6 +20,7 @@
 import { Command } from 'commander';
 import * as fs from 'node:fs';
 import { apiRequest, resolveApiKey, resolveBaseUrl } from '../utils/api-client.js';
+import { requireBb1Address } from '../utils/address.js';
 import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
 
 // ── Shared flag / output helpers (mirrors swap.ts) ─────────────────────────
@@ -213,17 +214,22 @@ addOutputFlags(
           'Default: returns ALL collection balances for the user (lean docs-only endpoint).',
           '--collection: filter to a single collection.',
           '--token: filter to a single token within --collection.',
+          'Auto-normalizes 0x → bb1 client-side; a stderr notice prints the canonical form.',
           "Does NOT include fungibles — for those, use 'bb balances ics20' or 'bb balances assets'."
         ].join('\n  ')
       )
-      .argument('<address>', 'BitBadges native address (bb1...) or any equivalent address form')
+      .argument('<address>', 'BitBadges native address (bb1...) or 0x form — auto-converted to bb1')
       .option('--collection <id>', 'Restrict to a single collection ID')
       .option('--token <n>', 'Restrict to a single token ID (requires --collection)')
       .option('--bookmark <b>', 'Pagination bookmark from a previous response (default mode only)')
       .option('--limit <n>', 'Page size for the default mode (indexer-enforced max applies)')
   )
-).action(async (address: string, opts: BitBadgesFlags) => {
+).action(async (rawAddress: string, opts: BitBadgesFlags) => {
   try {
+    // Normalize 0x → bb1 client-side so the user sees the canonical form
+    // and we fail fast on truly malformed input.
+    const address = requireBb1Address(rawAddress, '<address> argument to bb balances bitbadges');
+
     // Flag-combination validation: --token requires --collection.
     if (opts.token && !opts.collection) {
       process.stderr.write(

--- a/packages/bitbadgesjs-sdk/src/cli/commands/swap.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/swap.ts
@@ -17,6 +17,7 @@
 import { Command } from 'commander';
 import * as fs from 'node:fs';
 import { apiRequest, resolveApiKey, resolveBaseUrl } from '../utils/api-client.js';
+import { requireBb1Address } from '../utils/address.js';
 
 interface NetworkFlags {
   testnet?: boolean;
@@ -291,7 +292,10 @@ addOutputFlags(
     .description(
       'List intent-type exchange approvals. Default = global browse (active/funded only). Pass --mine <address> to scope to a single approver and include used/inactive rows.'
     )
-    .option('--mine <address>', 'Restrict to intents created by this address (also includes used/inactive)')
+    .option(
+      '--mine <address>',
+      'Restrict to intents created by this address (also includes used/inactive). Accepts bb1... or 0x... — auto-normalized to bb1.'
+    )
     .option('--pay-denom <denom>', 'Filter by the denom the intent pays out')
     .option('--receive-denom <denom>', 'Filter by the denom the intent expects to receive')
     .option('--collection-id <id>', 'Filter to a specific collection ID')
@@ -306,9 +310,10 @@ addOutputFlags(
       }
   ) => {
     try {
-      const base = opts.mine ? `/intents/${encodeURIComponent(opts.mine)}` : '/intents';
+      const mine = opts.mine ? requireBb1Address(opts.mine, '--mine') : undefined;
+      const base = mine ? `/intents/${encodeURIComponent(mine)}` : '/intents';
       const path = appendQuery(base, {
-        includeAll: opts.mine ? 'true' : undefined,
+        includeAll: mine ? 'true' : undefined,
         payDenom: opts.payDenom,
         receiveDenom: opts.receiveDenom,
         collectionId: opts.collectionId

--- a/packages/bitbadgesjs-sdk/src/cli/utils/address.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/address.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the CLI address-normalization helpers. The conversion itself
+ * is exercised by `address-converter/converter.spec.ts` — these tests
+ * focus on the CLI-side ergonomics (empty-string-on-failure, exit on
+ * malformed input, stderr normalization notice gating).
+ */
+
+import { tryBb1Address, requireBb1Address } from './address.js';
+
+// Zero-address pair — deterministic and stable across SDK versions.
+// 0x000...000 ↔ bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv.
+const ZERO_ETH = '0x0000000000000000000000000000000000000000';
+const ZERO_BB1 = 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv';
+
+describe('tryBb1Address', () => {
+  it('returns input as-is when already bb1', () => {
+    expect(tryBb1Address(ZERO_BB1)).toBe(ZERO_BB1);
+  });
+
+  it('returns empty string for nonsense input', () => {
+    expect(tryBb1Address('not-an-address')).toBe('');
+    expect(tryBb1Address('')).toBe('');
+    expect(tryBb1Address('bb1invalid')).toBe('');
+  });
+
+  it('converts a valid 0x address to bb1', () => {
+    // Pick a checksummed eth address; the converter validates checksum.
+    expect(tryBb1Address(ZERO_ETH)).toBe(ZERO_BB1);
+  });
+});
+
+describe('requireBb1Address', () => {
+  let exitSpy: jest.SpyInstance;
+  let stderrSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      throw new Error('process.exit');
+    }) as never);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.BB_QUIET;
+  });
+
+  it('returns bb1 for valid input', () => {
+    expect(requireBb1Address(ZERO_BB1, '--mine')).toBe(ZERO_BB1);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('exits with a clear error for invalid input, including the usage label', () => {
+    expect(() => requireBb1Address('garbage', '--mine')).toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const stderrCall = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderrCall).toContain('Error: invalid address "garbage" for --mine');
+    expect(stderrCall).toContain('bb1... or 0x...');
+  });
+
+  it('emits a normalization notice when input differs from output', () => {
+    requireBb1Address(ZERO_ETH, '<address>');
+    const stderrCall = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderrCall).toContain('Normalized');
+    expect(stderrCall).toContain(ZERO_ETH);
+    expect(stderrCall).toContain(ZERO_BB1);
+  });
+
+  it('suppresses the normalization notice when BB_QUIET is set', () => {
+    process.env.BB_QUIET = '1';
+    requireBb1Address(ZERO_ETH, '<address>');
+    const stderrCall = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderrCall).not.toContain('Normalized');
+  });
+
+  it('does NOT emit a normalization notice when input is already bb1', () => {
+    requireBb1Address(ZERO_BB1, '<address>');
+    const stderrCall = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderrCall).not.toContain('Normalized');
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/utils/address.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/address.ts
@@ -1,0 +1,46 @@
+/**
+ * Address-normalization helpers for the CLI. Indexer routes that key off
+ * Cosmos addresses (e.g. `/account/:address/balances`, `/intents/:address`)
+ * accept both 0x and bb1 forms server-side, but normalizing client-side
+ * gives the user a clear canonical form back and lets the CLI fail fast
+ * on truly malformed input instead of waiting for an HTTP 400.
+ */
+
+import { convertToBitBadgesAddress } from '../../address-converter/converter.js';
+
+/**
+ * Convert any supported address form (0x, bb1, bbvaloper) to its canonical
+ * bb1 form. Returns the empty string on failure — caller decides how to
+ * react. Use {@link requireBb1Address} when the failure path should exit
+ * with a formatted error.
+ */
+export function tryBb1Address(address: string): string {
+  return convertToBitBadgesAddress(address);
+}
+
+/**
+ * Convert any supported address form (0x, bb1, bbvaloper) to bb1 or exit
+ * with a CLI-friendly error.
+ *
+ * When the input is converted from 0x and stderr commentary is allowed
+ * (`BB_QUIET` not set), prints a short normalization notice so the user
+ * sees the canonical form being queried.
+ *
+ * @param address - User-supplied address (0x or bb1 or bbvaloper).
+ * @param usage   - Short label of where the address came from (e.g.
+ *                  `--mine`, `<address> argument to bb balances bitbadges`)
+ *                  — folded into the error message for context.
+ */
+export function requireBb1Address(address: string, usage: string): string {
+  const bb1 = convertToBitBadgesAddress(address);
+  if (!bb1) {
+    process.stderr.write(
+      `Error: invalid address "${address}" for ${usage}. Expected bb1... or 0x... format.\n`
+    );
+    process.exit(1);
+  }
+  if (bb1 !== address && !process.env.BB_QUIET) {
+    process.stderr.write(`Normalized ${address} → ${bb1}\n`);
+  }
+  return bb1;
+}


### PR DESCRIPTION
## Summary

`bb balances bitbadges <address>` and `bb swap intents --mine <address>` both query indexer routes that key off bb1, but accepted any input shape and let the indexer normalize server-side. This adds client-side conversion so:

- Agents/users see the canonical bb1 form being queried (helpful when a multi-chain wallet has multiple forms).
- Truly malformed input fails fast with a labeled CLI error instead of a generic indexer 400.

## Changes

- New `cli/utils/address.ts`:
  - `tryBb1Address(addr)` — pure, returns `''` on failure.
  - `requireBb1Address(addr, usage)` — exits with a clear, usage-labeled error; emits a stderr normalization notice when the canonical form differs (gated on `BB_QUIET`).
- Wired into `bb balances bitbadges <address>` and `bb swap intents --mine <address>`.
- Help text on both commands updated to advertise auto-normalization.
- 8 unit tests covering the conversion path, error path, and stderr gating.

## Test plan

- [x] `npx jest src/cli/utils/address.spec.ts` — all 8 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean, no circular deps
- [ ] Manual: `bb balances bitbadges 0x0000000000000000000000000000000000000000 --testnet` should print `Normalized 0x000… → bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv` to stderr, then JSON to stdout.
- [ ] Manual: `bb swap intents --mine garbage --testnet` should error with `Error: invalid address "garbage" for --mine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)