### PR TITLE
feat(cli): add `bb portfolio` aggregator for user-snapshot reads

### DIFF
--- a/packages/bitbadgesjs-sdk/src/cli/commands/portfolio.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/portfolio.spec.ts
@@ -1,49 +1,95 @@
 /**
- * Shape tests for `bb portfolio`. The command is a single verb (no
- * subcommands) — the contract is the flag surface + the section list it
- * documents. Accidental flag drift here would silently break agent
- * snapshots, so we lock it in.
+ * Shape tests for `bb portfolio` — the contract is the verb tree
+ * (subcommands present, mandatory flags per subcommand). Accidental flag
+ * drift here would silently break agent snapshots, so we lock the
+ * surface in.
  */
 
 import { portfolioCommand } from './portfolio.js';
 
+function getSub(name: string) {
+  const sub = portfolioCommand.commands.find((c) => c.name() === name);
+  if (!sub) throw new Error(`portfolio subcommand "${name}" not found`);
+  return sub;
+}
+
+function mandatoryFlags(sub: ReturnType<typeof getSub>): string[] {
+  return (sub as any).options.filter((o: any) => o.mandatory).map((o: any) => o.long);
+}
+
+function allFlags(sub: ReturnType<typeof getSub>): string[] {
+  return (sub as any).options.map((o: any) => o.long);
+}
+
 describe('portfolioCommand shape', () => {
-  it('has no subcommands — it is a single aggregator verb', () => {
-    expect(portfolioCommand.commands.length).toBe(0);
+  it('exposes all seven subcommands', () => {
+    const names = portfolioCommand.commands.map((c) => c.name()).sort();
+    expect(names).toEqual(['account', 'activity', 'all', 'approvals', 'assets', 'balances', 'tokens']);
   });
 
-  it('declares --address as the only mandatory option', () => {
-    const mandatory = (portfolioCommand as any).options
-      .filter((o: any) => o.mandatory)
-      .map((o: any) => o.long);
-    expect(mandatory).toEqual(['--address']);
+  it.each(['account', 'tokens', 'balances', 'assets', 'activity', 'approvals', 'all'])(
+    '%s requires --address',
+    (name) => {
+      expect(mandatoryFlags(getSub(name))).toContain('--address');
+    }
+  );
+
+  it('tokens exposes --view / --bookmark / --oldest-first', () => {
+    const flags = allFlags(getSub('tokens'));
+    for (const f of ['--view', '--bookmark', '--oldest-first']) expect(flags).toContain(f);
   });
 
-  it('exposes --include / --exclude / --chain / --all-chains for scoping', () => {
-    const flagNames = (portfolioCommand as any).options.map((o: any) => o.long);
+  it('activity exposes --type / --bookmark / --oldest-first', () => {
+    const flags = allFlags(getSub('activity'));
+    for (const f of ['--type', '--bookmark', '--oldest-first']) expect(flags).toContain(f);
+  });
+
+  it('balances exposes --bookmark / --oldest-first', () => {
+    const flags = allFlags(getSub('balances'));
+    for (const f of ['--bookmark', '--oldest-first']) expect(flags).toContain(f);
+  });
+
+  it('assets exposes --chain / --all-chains', () => {
+    const flags = allFlags(getSub('assets'));
+    for (const f of ['--chain', '--all-chains']) expect(flags).toContain(f);
+  });
+
+  it('approvals exposes the documented filter surface', () => {
+    const flags = allFlags(getSub('approvals'));
+    for (const f of [
+      '--collection',
+      '--token-id',
+      '--time',
+      '--has-coin-transfers',
+      '--price-min',
+      '--price-max',
+      '--denom',
+      '--sort'
+    ]) {
+      expect(flags).toContain(f);
+    }
+  });
+
+  it('all exposes --include / --exclude / --chain / --all-chains for scoping', () => {
+    const flags = allFlags(getSub('all'));
     for (const f of ['--include', '--exclude', '--chain', '--all-chains']) {
-      expect(flagNames).toContain(f);
+      expect(flags).toContain(f);
     }
   });
 
-  it('inherits the standard indexer network + output flags', () => {
-    const flagNames = (portfolioCommand as any).options.map((o: any) => o.long);
-    for (const f of ['--testnet', '--local', '--url', '--api-key', '--output-file', '--condensed']) {
-      expect(flagNames).toContain(f);
-    }
-  });
-
-  it('description names every section it returns so agents can predict the payload', () => {
-    const desc = portfolioCommand.description();
-    for (const section of ['account', 'tokens', 'balance', 'assets', 'activity']) {
+  it('all-description names every section so agents can predict the payload', () => {
+    const desc = getSub('all').description();
+    for (const section of ['account', 'tokens', 'balance', 'assets', 'activity', 'approvals']) {
       expect(desc.toLowerCase()).toContain(section);
     }
   });
 
-  it('--include / --exclude carry a value placeholder so commander treats them as string options', () => {
-    const include = (portfolioCommand as any).options.find((o: any) => o.long === '--include');
-    const exclude = (portfolioCommand as any).options.find((o: any) => o.long === '--exclude');
-    expect(include?.required || include?.optional).toBeTruthy();
-    expect(exclude?.required || exclude?.optional).toBeTruthy();
+  it('every subcommand inherits the standard indexer network + output flags', () => {
+    for (const name of ['account', 'tokens', 'balances', 'assets', 'activity', 'approvals', 'all']) {
+      const flags = allFlags(getSub(name));
+      for (const f of ['--testnet', '--local', '--url', '--api-key', '--output-file', '--condensed']) {
+        expect(flags).toContain(f);
+      }
+    }
   });
 });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/portfolio.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/portfolio.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Shape tests for `bb portfolio`. The command is a single verb (no
+ * subcommands) — the contract is the flag surface + the section list it
+ * documents. Accidental flag drift here would silently break agent
+ * snapshots, so we lock it in.
+ */
+
+import { portfolioCommand } from './portfolio.js';
+
+describe('portfolioCommand shape', () => {
+  it('has no subcommands — it is a single aggregator verb', () => {
+    expect(portfolioCommand.commands.length).toBe(0);
+  });
+
+  it('declares --address as the only mandatory option', () => {
+    const mandatory = (portfolioCommand as any).options
+      .filter((o: any) => o.mandatory)
+      .map((o: any) => o.long);
+    expect(mandatory).toEqual(['--address']);
+  });
+
+  it('exposes --include / --exclude / --chain / --all-chains for scoping', () => {
+    const flagNames = (portfolioCommand as any).options.map((o: any) => o.long);
+    for (const f of ['--include', '--exclude', '--chain', '--all-chains']) {
+      expect(flagNames).toContain(f);
+    }
+  });
+
+  it('inherits the standard indexer network + output flags', () => {
+    const flagNames = (portfolioCommand as any).options.map((o: any) => o.long);
+    for (const f of ['--testnet', '--local', '--url', '--api-key', '--output-file', '--condensed']) {
+      expect(flagNames).toContain(f);
+    }
+  });
+
+  it('description names every section it returns so agents can predict the payload', () => {
+    const desc = portfolioCommand.description();
+    for (const section of ['account', 'tokens', 'balance', 'assets', 'activity']) {
+      expect(desc.toLowerCase()).toContain(section);
+    }
+  });
+
+  it('--include / --exclude carry a value placeholder so commander treats them as string options', () => {
+    const include = (portfolioCommand as any).options.find((o: any) => o.long === '--include');
+    const exclude = (portfolioCommand as any).options.find((o: any) => o.long === '--exclude');
+    expect(include?.required || include?.optional).toBeTruthy();
+    expect(exclude?.required || exclude?.optional).toBeTruthy();
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/portfolio.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/portfolio.ts
@@ -1,0 +1,212 @@
+/**
+ * `bitbadges-cli portfolio` — single-address snapshot of the data the FE
+ * shows on `/account/[addressOrUsername]`: account info, tokens
+ * (collected/created/managing), lean balance docs, swap-merged assets,
+ * and recent activity (transfers + claims + points).
+ *
+ * Thin wrapper over existing indexer routes — every section is a route
+ * that already has a dedicated CLI command (`bb balances bitbadges`,
+ * `bb balances assets`, etc.). The value-add is bundling them into one
+ * call so an agent doing "tell me about this user" doesn't need 8 round
+ * trips to figure out what `bb` verbs to chain.
+ *
+ *   bb portfolio --address bb1... | --address 0x...
+ *
+ * Sections fetched in parallel. A section that fails returns
+ * `{ error: "..." }` instead of aborting the whole call — partial data
+ * beats no data for read-only inspection.
+ */
+
+import { Command } from 'commander';
+import {
+  addIndexerNetworkOptions as addNetworkFlags,
+  addIndexerOutputOptions as addOutputFlags,
+  callIndexer as callApi,
+  emitIndexerResult as emit,
+  emitIndexerError as emitError,
+  type IndexerNetworkFlags as NetworkFlags,
+  type IndexerOutputFlags as OutputFlags,
+} from '../utils/indexer-options.js';
+import { requireBb1Address } from '../utils/address.js';
+
+const ALL_SECTIONS = ['account', 'tokens', 'balances', 'assets', 'activity'] as const;
+type Section = (typeof ALL_SECTIONS)[number];
+
+interface PortfolioFlags extends NetworkFlags, OutputFlags {
+  address: string;
+  include?: string;
+  exclude?: string;
+  chain?: string;
+  allChains?: boolean;
+}
+
+// Same default broad set as `bb balances assets` — keep them in sync if
+// either side changes. Switching to a shared constant would mean exporting
+// from balances.ts; not worth the churn for 15 chain IDs.
+const DEFAULT_ALL_CHAIN_IDS: readonly string[] = [
+  'bitbadges-1',
+  'cosmoshub-4',
+  'osmosis-1',
+  'noble-1',
+  'injective-1',
+  'neutron-1',
+  'stride-1',
+  'celestia',
+  'agoric-3',
+  'dydx-mainnet-1',
+  '1',
+  '8453',
+  '42161',
+  '10',
+  '137'
+];
+
+function parseSectionList(value: string | undefined, flag: string): Set<Section> | undefined {
+  if (!value) return undefined;
+  const parts = value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const out = new Set<Section>();
+  for (const p of parts) {
+    if (!(ALL_SECTIONS as readonly string[]).includes(p)) {
+      process.stderr.write(
+        `Error: ${flag} got "${p}". Valid sections: ${ALL_SECTIONS.join(', ')}.\n`
+      );
+      process.exit(2);
+    }
+    out.add(p as Section);
+  }
+  return out;
+}
+
+async function safeCall<T>(label: string, fn: () => Promise<T>): Promise<T | { error: string }> {
+  try {
+    return await fn();
+  } catch (err) {
+    const e = err as { response?: unknown; message?: string };
+    const msg =
+      e?.response !== undefined
+        ? typeof e.response === 'string'
+          ? e.response
+          : JSON.stringify(e.response)
+        : (e?.message ?? String(err));
+    return { error: `${label}: ${msg}` };
+  }
+}
+
+export const portfolioCommand = new Command('portfolio')
+  .description(
+    [
+      'Snapshot a user portfolio — bundles account info, tokens collected/created/managing,',
+      'lean balance docs, swap-merged assets, and recent activity (transfers/claims/points)',
+      'into one JSON response. Mirrors the data shown on bitbadges.io/account/<addressOrUsername>.',
+      'Sections fetch in parallel; per-section failures degrade to {error} rather than aborting.'
+    ].join('\n  ')
+  );
+
+addOutputFlags(
+  addNetworkFlags(
+    portfolioCommand
+      .requiredOption('--address <addr>', 'Address to look up (bb1... or 0x... — auto-normalized to bb1)')
+      .option(
+        '--include <list>',
+        `Comma-separated subset of sections to fetch (default: all). Valid: ${ALL_SECTIONS.join(', ')}.`
+      )
+      .option('--exclude <list>', 'Comma-separated sections to skip. Combine with --include or apply alone.')
+      .option('--chain <id>', "Chain ID for the 'assets' section (default: bitbadges-1)")
+      .option('--all-chains', "Query a broad Skip:Go chain set for 'assets' (overrides --chain)", false)
+  )
+).action(async (opts: PortfolioFlags) => {
+  try {
+    const address = requireBb1Address(opts.address, '--address');
+
+    if (opts.chain && opts.allChains) {
+      process.stderr.write('Error: pass either --chain or --all-chains, not both.\n');
+      process.exit(2);
+    }
+
+    const include = parseSectionList(opts.include, '--include');
+    const exclude = parseSectionList(opts.exclude, '--exclude');
+    const wants = (s: Section): boolean => {
+      if (include && !include.has(s)) return false;
+      if (exclude && exclude.has(s)) return false;
+      return true;
+    };
+
+    // Each section dispatches its own fetch independently so a failure in
+    // one (e.g. a deprecated route, a 404) doesn't poison the rest.
+    const work: { key: Section; promise: Promise<unknown> }[] = [];
+
+    if (wants('account')) {
+      work.push({
+        key: 'account',
+        promise: safeCall('account', () =>
+          callApi('GET', `/user?address=${encodeURIComponent(address)}`, opts)
+        )
+      });
+    }
+
+    if (wants('tokens')) {
+      const tokensPromise = Promise.all([
+        safeCall('tokens.collected', () =>
+          callApi('GET', `/account/${encodeURIComponent(address)}/tokens?viewType=collected`, opts)
+        ),
+        safeCall('tokens.created', () =>
+          callApi('GET', `/account/${encodeURIComponent(address)}/tokens?viewType=created`, opts)
+        ),
+        safeCall('tokens.managing', () =>
+          callApi('GET', `/account/${encodeURIComponent(address)}/tokens?viewType=managing`, opts)
+        )
+      ]).then(([collected, created, managing]) => ({ collected, created, managing }));
+      work.push({ key: 'tokens', promise: tokensPromise });
+    }
+
+    if (wants('balances')) {
+      work.push({
+        key: 'balances',
+        promise: safeCall('balances', () =>
+          callApi('GET', `/account/${encodeURIComponent(address)}/balances`, opts)
+        )
+      });
+    }
+
+    if (wants('assets')) {
+      let chains: Record<string, string[]>;
+      if (opts.allChains) {
+        chains = Object.fromEntries(DEFAULT_ALL_CHAIN_IDS.map((cid) => [cid, [address]]));
+      } else {
+        chains = { [opts.chain ?? 'bitbadges-1']: [address] };
+      }
+      work.push({
+        key: 'assets',
+        promise: safeCall('assets', () => callApi('POST', '/swap/balances', opts, { chains }))
+      });
+    }
+
+    if (wants('activity')) {
+      const activityPromise = Promise.all([
+        safeCall('activity.transfers', () =>
+          callApi('GET', `/account/${encodeURIComponent(address)}/activity/tokens`, opts)
+        ),
+        safeCall('activity.claims', () =>
+          callApi('GET', `/account/${encodeURIComponent(address)}/activity/claims`, opts)
+        ),
+        safeCall('activity.points', () =>
+          callApi('GET', `/account/${encodeURIComponent(address)}/activity/points`, opts)
+        )
+      ]).then(([transfers, claims, points]) => ({ transfers, claims, points }));
+      work.push({ key: 'activity', promise: activityPromise });
+    }
+
+    const results = await Promise.all(work.map((w) => w.promise));
+    const out: Record<string, unknown> = { address };
+    for (let i = 0; i < work.length; i++) {
+      out[work[i].key] = results[i];
+    }
+
+    emit(out, opts);
+  } catch (err) {
+    emitError(err);
+  }
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/portfolio.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/portfolio.ts
@@ -1,20 +1,24 @@
 /**
- * `bitbadges-cli portfolio` — single-address snapshot of the data the FE
- * shows on `/account/[addressOrUsername]`: account info, tokens
- * (collected/created/managing), lean balance docs, swap-merged assets,
- * and recent activity (transfers + claims + points).
+ * `bitbadges-cli portfolio` — read-only user-snapshot surface that mirrors
+ * the FE `/account/[addressOrUsername]` page.
  *
- * Thin wrapper over existing indexer routes — every section is a route
- * that already has a dedicated CLI command (`bb balances bitbadges`,
- * `bb balances assets`, etc.). The value-add is bundling them into one
- * call so an agent doing "tell me about this user" doesn't need 8 round
- * trips to figure out what `bb` verbs to chain.
+ *   bb portfolio all        — bundle of every section (parallel fetch)
+ *   bb portfolio account    — /user
+ *   bb portfolio tokens     — /account/:addr/tokens (collected/created/managing)
+ *   bb portfolio balances   — /account/:addr/balances (lean balance docs)
+ *   bb portfolio assets     — POST /swap/balances (Skip:Go + verified BB)
+ *   bb portfolio activity   — /account/:addr/activity/{tokens,claims,points}
+ *   bb portfolio approvals  — POST /collection/:id/filterApprovals
+ *                              (the "Approvals" tab — subscriptions,
+ *                              listings, bids, payments, etc.)
  *
- *   bb portfolio --address bb1... | --address 0x...
+ * Every subcommand is a thin wrapper over an indexer route that already
+ * has a CLI surface elsewhere; the value-add is the verb-shape: a single
+ * verb tree where you don't have to know which API noun owns which view.
  *
- * Sections fetched in parallel. A section that fails returns
- * `{ error: "..." }` instead of aborting the whole call — partial data
- * beats no data for read-only inspection.
+ * The `all` aggregator parallels everything and folds per-section failures
+ * to `{error: "..."}` rather than aborting — partial data beats no data
+ * for read-only inspection.
  */
 
 import { Command } from 'commander';
@@ -29,20 +33,149 @@ import {
 } from '../utils/indexer-options.js';
 import { requireBb1Address } from '../utils/address.js';
 
-const ALL_SECTIONS = ['account', 'tokens', 'balances', 'assets', 'activity'] as const;
-type Section = (typeof ALL_SECTIONS)[number];
+// ── shared section fetchers ─────────────────────────────────────────────────
+//
+// Each fetcher is a tiny wrapper over `callApi`. They're separate
+// functions so both individual subcommands and the `all` aggregator can
+// share the exact same request shape — no chance of drift.
 
-interface PortfolioFlags extends NetworkFlags, OutputFlags {
-  address: string;
-  include?: string;
-  exclude?: string;
-  chain?: string;
-  allChains?: boolean;
+function fetchAccount(address: string, opts: NetworkFlags): Promise<unknown> {
+  return callApi('GET', `/user?address=${encodeURIComponent(address)}`, opts);
 }
 
-// Same default broad set as `bb balances assets` — keep them in sync if
-// either side changes. Switching to a shared constant would mean exporting
-// from balances.ts; not worth the churn for 15 chain IDs.
+function fetchTokens(
+  address: string,
+  view: 'collected' | 'created' | 'managing',
+  opts: NetworkFlags,
+  extra: { bookmark?: string; oldestFirst?: boolean } = {}
+): Promise<unknown> {
+  const qs = new URLSearchParams({ viewType: view });
+  if (extra.bookmark) qs.set('bookmark', extra.bookmark);
+  if (extra.oldestFirst) qs.set('oldestFirst', 'true');
+  return callApi('GET', `/account/${encodeURIComponent(address)}/tokens?${qs.toString()}`, opts);
+}
+
+function fetchBalances(
+  address: string,
+  opts: NetworkFlags,
+  extra: { bookmark?: string; oldestFirst?: boolean } = {}
+): Promise<unknown> {
+  const qs = new URLSearchParams();
+  if (extra.bookmark) qs.set('bookmark', extra.bookmark);
+  if (extra.oldestFirst) qs.set('oldestFirst', 'true');
+  const tail = qs.toString() ? `?${qs.toString()}` : '';
+  return callApi('GET', `/account/${encodeURIComponent(address)}/balances${tail}`, opts);
+}
+
+function fetchAssets(
+  address: string,
+  opts: NetworkFlags,
+  chainOpts: { chain?: string; allChains?: boolean }
+): Promise<unknown> {
+  let chains: Record<string, string[]>;
+  if (chainOpts.allChains) {
+    chains = Object.fromEntries(DEFAULT_ALL_CHAIN_IDS.map((cid) => [cid, [address]]));
+  } else {
+    chains = { [chainOpts.chain ?? 'bitbadges-1']: [address] };
+  }
+  return callApi('POST', '/swap/balances', opts, { chains });
+}
+
+function fetchActivity(
+  address: string,
+  type: 'tokens' | 'claims' | 'points',
+  opts: NetworkFlags,
+  extra: { bookmark?: string; oldestFirst?: boolean } = {}
+): Promise<unknown> {
+  const qs = new URLSearchParams();
+  if (extra.bookmark) qs.set('bookmark', extra.bookmark);
+  if (extra.oldestFirst) qs.set('oldestFirst', 'true');
+  const tail = qs.toString() ? `?${qs.toString()}` : '';
+  return callApi('GET', `/account/${encodeURIComponent(address)}/activity/${type}${tail}`, opts);
+}
+
+interface ApprovalsFilterFlags {
+  collection?: string;
+  tokenId?: string;
+  time?: string;
+  hasCoinTransfers?: boolean;
+  priceMin?: string;
+  priceMax?: string;
+  denom?: string;
+  sort?: string;
+}
+
+function buildApprovalsQuery(address: string, flags: ApprovalsFilterFlags): { query: Record<string, unknown>; sortBy?: Record<string, 1 | -1> } {
+  // Mirrors the body shape the FE's BrowseApprovalsTab posts: a Mongo-style
+  // filter over the ApprovalItemModel. We only expose the common-case
+  // knobs here — anyone needing raw Mongo can hit
+  // `bb api filter-approvals --collection-id any` directly.
+  const query: Record<string, unknown> = {
+    // `any` collection mode is set by the indexer when the path param is
+    // "any" — but the server also needs `approverAddress` to scope it to
+    // this user (otherwise it returns every approval on the chain).
+    approverAddress: { $eq: address }
+  };
+
+  if (flags.tokenId) {
+    query['approval.tokenIds'] = {
+      $elemMatch: {
+        start: { $lte: Number(flags.tokenId), $type: 'number' },
+        $or: [{ end: { $gte: Number(flags.tokenId), $type: 'number' } }, { end: { $type: 'string' } }]
+      }
+    };
+  }
+
+  if (flags.time) {
+    query['approval.transferTimes'] = {
+      $elemMatch: {
+        start: { $lte: Number(flags.time), $type: 'number' },
+        $or: [{ end: { $gte: Number(flags.time), $type: 'number' } }, { end: { $type: 'string' } }]
+      }
+    };
+  }
+
+  if (flags.hasCoinTransfers) {
+    query['approval.approvalCriteria.coinTransfers'] = { $elemMatch: { $exists: true } };
+  }
+
+  if (flags.priceMin !== undefined || flags.priceMax !== undefined) {
+    const priceFilter: Record<string, unknown> = { $exists: true };
+    if (flags.priceMin !== undefined) priceFilter.$gte = Number(flags.priceMin);
+    if (flags.priceMax !== undefined) priceFilter.$lte = Number(flags.priceMax);
+    query.price = priceFilter;
+    if (flags.denom) query.denom = flags.denom;
+  } else if (flags.denom) {
+    query.denom = flags.denom;
+  }
+
+  let sortBy: Record<string, 1 | -1> | undefined;
+  if (flags.sort === 'price-asc') sortBy = { price: 1 };
+  else if (flags.sort === 'price-desc') sortBy = { price: -1 };
+
+  return { query, sortBy };
+}
+
+function fetchApprovals(
+  address: string,
+  opts: NetworkFlags,
+  flags: ApprovalsFilterFlags
+): Promise<unknown> {
+  const { query, sortBy } = buildApprovalsQuery(address, flags);
+  const collectionId = flags.collection ?? 'any';
+  // sortBy is REQUIRED by the indexer's typia.assert<iGetFilterApprovalsPayload>
+  // — omitting it returns a 500 with an empty errorMessage. Always send an
+  // object, even when the caller didn't pass --sort.
+  return callApi(
+    'POST',
+    `/collection/${encodeURIComponent(collectionId)}/filterApprovals`,
+    opts,
+    { query, sortBy: sortBy ?? {} }
+  );
+}
+
+// Same broad default as `bb balances assets`. Keep them in sync if either
+// side changes; not worth exporting a constant for 15 chain IDs.
 const DEFAULT_ALL_CHAIN_IDS: readonly string[] = [
   'bitbadges-1',
   'cosmoshub-4',
@@ -60,6 +193,281 @@ const DEFAULT_ALL_CHAIN_IDS: readonly string[] = [
   '10',
   '137'
 ];
+
+async function safeCall<T>(label: string, fn: () => Promise<T>): Promise<T | { error: string }> {
+  try {
+    return await fn();
+  } catch (err) {
+    const e = err as { response?: unknown; message?: string };
+    const msg =
+      e?.response !== undefined
+        ? typeof e.response === 'string'
+          ? e.response
+          : JSON.stringify(e.response)
+        : (e?.message ?? String(err));
+    return { error: `${label}: ${msg}` };
+  }
+}
+
+// ── parent ──────────────────────────────────────────────────────────────────
+
+export const portfolioCommand = new Command('portfolio').description(
+  [
+    'Read-only user-snapshot views — mirrors what bitbadges.io/account/<addressOrUsername> shows.',
+    'Use `all` for a single-call bundle, or pick a subcommand for one section.'
+  ].join('\n  ')
+);
+
+// ── account ─────────────────────────────────────────────────────────────────
+
+interface AccountFlags extends NetworkFlags, OutputFlags {
+  address: string;
+}
+
+addOutputFlags(
+  addNetworkFlags(
+    portfolioCommand
+      .command('account')
+      .description('Fetch profile + on-chain LCD bank balances. Wraps GET /user.')
+      .requiredOption('--address <addr>', 'Address to look up (bb1.../0x — auto-normalized to bb1)')
+  )
+).action(async (opts: AccountFlags) => {
+  try {
+    const address = requireBb1Address(opts.address, '--address');
+    const res = await fetchAccount(address, opts);
+    emit(res, opts);
+  } catch (err) {
+    emitError(err);
+  }
+});
+
+// ── tokens ──────────────────────────────────────────────────────────────────
+
+interface TokensFlags extends NetworkFlags, OutputFlags {
+  address: string;
+  view?: 'collected' | 'created' | 'managing' | 'all';
+  bookmark?: string;
+  oldestFirst?: boolean;
+}
+
+addOutputFlags(
+  addNetworkFlags(
+    portfolioCommand
+      .command('tokens')
+      .description(
+        [
+          'List BitBadges-standard token holdings. Wraps GET /account/:addr/tokens.',
+          '--view collected (default): tokens the user has a balance of.',
+          '--view created:   tokens the user created.',
+          '--view managing:  tokens the user manages.',
+          '--view all:       fan out to all three views in one response.'
+        ].join('\n  ')
+      )
+      .requiredOption('--address <addr>', 'Address to look up (bb1.../0x — auto-normalized to bb1)')
+      .option('--view <type>', 'collected | created | managing | all', 'collected')
+      .option('--bookmark <b>', 'Pagination cursor from a previous response')
+      .option('--oldest-first', 'Reverse default sort (newest-first)', false)
+  )
+).action(async (opts: TokensFlags) => {
+  try {
+    const address = requireBb1Address(opts.address, '--address');
+    const view = opts.view ?? 'collected';
+    if (!['collected', 'created', 'managing', 'all'].includes(view)) {
+      process.stderr.write(`Error: --view must be one of collected | created | managing | all. Got: ${view}\n`);
+      process.exit(2);
+    }
+    if (view === 'all') {
+      const [collected, created, managing] = await Promise.all([
+        safeCall('collected', () => fetchTokens(address, 'collected', opts, opts)),
+        safeCall('created', () => fetchTokens(address, 'created', opts, opts)),
+        safeCall('managing', () => fetchTokens(address, 'managing', opts, opts))
+      ]);
+      emit({ collected, created, managing }, opts);
+      return;
+    }
+    const res = await fetchTokens(address, view, opts, opts);
+    emit(res, opts);
+  } catch (err) {
+    emitError(err);
+  }
+});
+
+// ── balances ────────────────────────────────────────────────────────────────
+
+interface BalancesFlags extends NetworkFlags, OutputFlags {
+  address: string;
+  bookmark?: string;
+  oldestFirst?: boolean;
+}
+
+addOutputFlags(
+  addNetworkFlags(
+    portfolioCommand
+      .command('balances')
+      .description(
+        [
+          'Lean BitBadges-standard balance docs. Wraps GET /account/:addr/balances.',
+          "Use 'bb portfolio assets' for fungible / swap-merged balances."
+        ].join('\n  ')
+      )
+      .requiredOption('--address <addr>', 'Address to look up (bb1.../0x — auto-normalized to bb1)')
+      .option('--bookmark <b>', 'Pagination cursor from a previous response')
+      .option('--oldest-first', 'Reverse default sort (newest-first)', false)
+  )
+).action(async (opts: BalancesFlags) => {
+  try {
+    const address = requireBb1Address(opts.address, '--address');
+    const res = await fetchBalances(address, opts, opts);
+    emit(res, opts);
+  } catch (err) {
+    emitError(err);
+  }
+});
+
+// ── assets ──────────────────────────────────────────────────────────────────
+
+interface AssetsFlags extends NetworkFlags, OutputFlags {
+  address: string;
+  chain?: string;
+  allChains?: boolean;
+}
+
+addOutputFlags(
+  addNetworkFlags(
+    portfolioCommand
+      .command('assets')
+      .description(
+        [
+          'Swap-merged numeric balances (Skip:Go + verified BB assets).',
+          'Default: bitbadges-1 only. --all-chains queries a broad Skip:Go-allowed set.'
+        ].join('\n  ')
+      )
+      .requiredOption('--address <addr>', 'Address to look up (bb1.../0x — auto-normalized to bb1)')
+      .option('--chain <id>', 'Chain ID to query (default: bitbadges-1)')
+      .option('--all-chains', 'Query a broad Skip:Go-allowed chain set', false)
+  )
+).action(async (opts: AssetsFlags) => {
+  try {
+    if (opts.chain && opts.allChains) {
+      process.stderr.write('Error: pass either --chain or --all-chains, not both.\n');
+      process.exit(2);
+    }
+    const address = requireBb1Address(opts.address, '--address');
+    const res = await fetchAssets(address, opts, opts);
+    emit(res, opts);
+  } catch (err) {
+    emitError(err);
+  }
+});
+
+// ── activity ────────────────────────────────────────────────────────────────
+
+interface ActivityFlags extends NetworkFlags, OutputFlags {
+  address: string;
+  type?: 'tokens' | 'claims' | 'points' | 'all';
+  bookmark?: string;
+  oldestFirst?: boolean;
+}
+
+addOutputFlags(
+  addNetworkFlags(
+    portfolioCommand
+      .command('activity')
+      .description(
+        [
+          'Recent activity feeds for an address.',
+          '--type tokens (default): transfer activity.',
+          '--type claims:           claim activity.',
+          '--type points:           points activity.',
+          '--type all:              fan out to all three in one response.'
+        ].join('\n  ')
+      )
+      .requiredOption('--address <addr>', 'Address to look up (bb1.../0x — auto-normalized to bb1)')
+      .option('--type <kind>', 'tokens | claims | points | all', 'tokens')
+      .option('--bookmark <b>', 'Pagination cursor (single-type mode)')
+      .option('--oldest-first', 'Reverse default sort (newest-first)', false)
+  )
+).action(async (opts: ActivityFlags) => {
+  try {
+    const address = requireBb1Address(opts.address, '--address');
+    const type = opts.type ?? 'tokens';
+    if (!['tokens', 'claims', 'points', 'all'].includes(type)) {
+      process.stderr.write(`Error: --type must be one of tokens | claims | points | all. Got: ${type}\n`);
+      process.exit(2);
+    }
+    if (type === 'all') {
+      const [transfers, claims, points] = await Promise.all([
+        safeCall('transfers', () => fetchActivity(address, 'tokens', opts, opts)),
+        safeCall('claims', () => fetchActivity(address, 'claims', opts, opts)),
+        safeCall('points', () => fetchActivity(address, 'points', opts, opts))
+      ]);
+      emit({ transfers, claims, points }, opts);
+      return;
+    }
+    const res = await fetchActivity(address, type, opts, opts);
+    emit(res, opts);
+  } catch (err) {
+    emitError(err);
+  }
+});
+
+// ── approvals ───────────────────────────────────────────────────────────────
+
+interface ApprovalsFlags extends NetworkFlags, OutputFlags, ApprovalsFilterFlags {
+  address: string;
+}
+
+addOutputFlags(
+  addNetworkFlags(
+    portfolioCommand
+      .command('approvals')
+      .description(
+        [
+          "Browse approvals owned by this user — the FE's 'Approvals' tab.",
+          'Surfaces subscriptions, listings, bids, payments — anything keyed on an approval.',
+          'Wraps POST /collection/:id/filterApprovals; defaults --collection to "any" (cross-collection).'
+        ].join('\n  ')
+      )
+      .requiredOption('--address <addr>', 'Approver address (bb1.../0x — auto-normalized to bb1)')
+      .option('--collection <id>', 'Collection ID (or "any" for cross-collection)', 'any')
+      .option('--token-id <n>', 'Filter to approvals that cover this token id')
+      .option('--time <ms>', 'Filter to approvals valid at this ms-since-epoch')
+      .option('--has-coin-transfers', 'Only approvals with a coin-transfer leg (subscriptions, listings, paid claims)', false)
+      .option('--price-min <n>', 'Lower bound on approval.price (use with --denom)')
+      .option('--price-max <n>', 'Upper bound on approval.price (use with --denom)')
+      .option('--denom <denom>', 'Restrict price filter to this denom')
+      .option('--sort <order>', 'price-asc | price-desc (default: server order)')
+  )
+).action(async (opts: ApprovalsFlags) => {
+  try {
+    const address = requireBb1Address(opts.address, '--address');
+    if (opts.sort && !['price-asc', 'price-desc'].includes(opts.sort)) {
+      process.stderr.write(`Error: --sort must be price-asc or price-desc. Got: ${opts.sort}\n`);
+      process.exit(2);
+    }
+    if ((opts.priceMin !== undefined || opts.priceMax !== undefined) && !opts.denom) {
+      process.stderr.write('Error: --price-min / --price-max require --denom (price filters are denom-scoped).\n');
+      process.exit(2);
+    }
+    const res = await fetchApprovals(address, opts, opts);
+    emit(res, opts);
+  } catch (err) {
+    emitError(err);
+  }
+});
+
+// ── all (aggregator) ────────────────────────────────────────────────────────
+
+const ALL_SECTIONS = ['account', 'tokens', 'balances', 'assets', 'activity', 'approvals'] as const;
+type Section = (typeof ALL_SECTIONS)[number];
+
+interface AllFlags extends NetworkFlags, OutputFlags {
+  address: string;
+  include?: string;
+  exclude?: string;
+  chain?: string;
+  allChains?: boolean;
+}
 
 function parseSectionList(value: string | undefined, flag: string): Set<Section> | undefined {
   if (!value) return undefined;
@@ -80,52 +488,31 @@ function parseSectionList(value: string | undefined, flag: string): Set<Section>
   return out;
 }
 
-async function safeCall<T>(label: string, fn: () => Promise<T>): Promise<T | { error: string }> {
-  try {
-    return await fn();
-  } catch (err) {
-    const e = err as { response?: unknown; message?: string };
-    const msg =
-      e?.response !== undefined
-        ? typeof e.response === 'string'
-          ? e.response
-          : JSON.stringify(e.response)
-        : (e?.message ?? String(err));
-    return { error: `${label}: ${msg}` };
-  }
-}
-
-export const portfolioCommand = new Command('portfolio')
-  .description(
-    [
-      'Snapshot a user portfolio — bundles account info, tokens collected/created/managing,',
-      'lean balance docs, swap-merged assets, and recent activity (transfers/claims/points)',
-      'into one JSON response. Mirrors the data shown on bitbadges.io/account/<addressOrUsername>.',
-      'Sections fetch in parallel; per-section failures degrade to {error} rather than aborting.'
-    ].join('\n  ')
-  );
-
 addOutputFlags(
   addNetworkFlags(
     portfolioCommand
-      .requiredOption('--address <addr>', 'Address to look up (bb1... or 0x... — auto-normalized to bb1)')
-      .option(
-        '--include <list>',
-        `Comma-separated subset of sections to fetch (default: all). Valid: ${ALL_SECTIONS.join(', ')}.`
+      .command('all')
+      .description(
+        [
+          'Snapshot every section in one parallel-fetched JSON response:',
+          'account, tokens (collected+created+managing), balances, assets,',
+          'activity (transfers+claims+points), approvals.',
+          'Per-section failures degrade to {error} rather than aborting.'
+        ].join('\n  ')
       )
-      .option('--exclude <list>', 'Comma-separated sections to skip. Combine with --include or apply alone.')
+      .requiredOption('--address <addr>', 'Address to look up (bb1.../0x — auto-normalized to bb1)')
+      .option('--include <list>', `Comma-separated subset of sections (default: all). Valid: ${ALL_SECTIONS.join(', ')}.`)
+      .option('--exclude <list>', 'Comma-separated sections to skip.')
       .option('--chain <id>', "Chain ID for the 'assets' section (default: bitbadges-1)")
       .option('--all-chains', "Query a broad Skip:Go chain set for 'assets' (overrides --chain)", false)
   )
-).action(async (opts: PortfolioFlags) => {
+).action(async (opts: AllFlags) => {
   try {
     const address = requireBb1Address(opts.address, '--address');
-
     if (opts.chain && opts.allChains) {
       process.stderr.write('Error: pass either --chain or --all-chains, not both.\n');
       process.exit(2);
     }
-
     const include = parseSectionList(opts.include, '--include');
     const exclude = parseSectionList(opts.exclude, '--exclude');
     const wants = (s: Section): boolean => {
@@ -134,69 +521,50 @@ addOutputFlags(
       return true;
     };
 
-    // Each section dispatches its own fetch independently so a failure in
-    // one (e.g. a deprecated route, a 404) doesn't poison the rest.
     const work: { key: Section; promise: Promise<unknown> }[] = [];
 
     if (wants('account')) {
-      work.push({
-        key: 'account',
-        promise: safeCall('account', () =>
-          callApi('GET', `/user?address=${encodeURIComponent(address)}`, opts)
-        )
-      });
+      work.push({ key: 'account', promise: safeCall('account', () => fetchAccount(address, opts)) });
     }
 
     if (wants('tokens')) {
-      const tokensPromise = Promise.all([
-        safeCall('tokens.collected', () =>
-          callApi('GET', `/account/${encodeURIComponent(address)}/tokens?viewType=collected`, opts)
-        ),
-        safeCall('tokens.created', () =>
-          callApi('GET', `/account/${encodeURIComponent(address)}/tokens?viewType=created`, opts)
-        ),
-        safeCall('tokens.managing', () =>
-          callApi('GET', `/account/${encodeURIComponent(address)}/tokens?viewType=managing`, opts)
-        )
-      ]).then(([collected, created, managing]) => ({ collected, created, managing }));
-      work.push({ key: 'tokens', promise: tokensPromise });
-    }
-
-    if (wants('balances')) {
       work.push({
-        key: 'balances',
-        promise: safeCall('balances', () =>
-          callApi('GET', `/account/${encodeURIComponent(address)}/balances`, opts)
-        )
+        key: 'tokens',
+        promise: Promise.all([
+          safeCall('tokens.collected', () => fetchTokens(address, 'collected', opts)),
+          safeCall('tokens.created', () => fetchTokens(address, 'created', opts)),
+          safeCall('tokens.managing', () => fetchTokens(address, 'managing', opts))
+        ]).then(([collected, created, managing]) => ({ collected, created, managing }))
       });
     }
 
+    if (wants('balances')) {
+      work.push({ key: 'balances', promise: safeCall('balances', () => fetchBalances(address, opts)) });
+    }
+
     if (wants('assets')) {
-      let chains: Record<string, string[]>;
-      if (opts.allChains) {
-        chains = Object.fromEntries(DEFAULT_ALL_CHAIN_IDS.map((cid) => [cid, [address]]));
-      } else {
-        chains = { [opts.chain ?? 'bitbadges-1']: [address] };
-      }
       work.push({
         key: 'assets',
-        promise: safeCall('assets', () => callApi('POST', '/swap/balances', opts, { chains }))
+        promise: safeCall('assets', () => fetchAssets(address, opts, opts))
       });
     }
 
     if (wants('activity')) {
-      const activityPromise = Promise.all([
-        safeCall('activity.transfers', () =>
-          callApi('GET', `/account/${encodeURIComponent(address)}/activity/tokens`, opts)
-        ),
-        safeCall('activity.claims', () =>
-          callApi('GET', `/account/${encodeURIComponent(address)}/activity/claims`, opts)
-        ),
-        safeCall('activity.points', () =>
-          callApi('GET', `/account/${encodeURIComponent(address)}/activity/points`, opts)
-        )
-      ]).then(([transfers, claims, points]) => ({ transfers, claims, points }));
-      work.push({ key: 'activity', promise: activityPromise });
+      work.push({
+        key: 'activity',
+        promise: Promise.all([
+          safeCall('activity.transfers', () => fetchActivity(address, 'tokens', opts)),
+          safeCall('activity.claims', () => fetchActivity(address, 'claims', opts)),
+          safeCall('activity.points', () => fetchActivity(address, 'points', opts))
+        ]).then(([transfers, claims, points]) => ({ transfers, claims, points }))
+      });
+    }
+
+    if (wants('approvals')) {
+      work.push({
+        key: 'approvals',
+        promise: safeCall('approvals', () => fetchApprovals(address, opts, {}))
+      });
     }
 
     const results = await Promise.all(work.map((w) => w.promise));
@@ -204,9 +572,9 @@ addOutputFlags(
     for (let i = 0; i < work.length; i++) {
       out[work[i].key] = results[i];
     }
-
     emit(out, opts);
   } catch (err) {
     emitError(err);
   }
 });
+

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -123,6 +123,7 @@ import { genListIdCommand } from './commands/gen-list-id.js';
 import { amountCommand } from './commands/amount.js';
 import { urlCommand } from './commands/url.js';
 import { dynamicStoresCommand } from './commands/dynamic-stores.js';
+import { portfolioCommand } from './commands/portfolio.js';
 
 // Swap / DEX
 import { swapCommand } from './commands/swap.js';
@@ -196,7 +197,7 @@ const HELP_GROUPS: { title: string; commands: Command[] }[] = [
   },
   {
     title: 'Address & lookup utilities',
-    commands: [addressCommand, aliasCommand, lookupCommand, genListIdCommand, amountCommand, urlCommand]
+    commands: [addressCommand, aliasCommand, lookupCommand, portfolioCommand, genListIdCommand, amountCommand, urlCommand]
   },
   {
     title: 'Swap & DEX',

--- a/packages/bitbadgesjs-sdk/src/cli/integration/portfolio.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/portfolio.spec.ts
@@ -1,18 +1,17 @@
 /**
- * Integration: `bb portfolio` against a live local indexer.
+ * Integration: `bb portfolio <subcommand>` against a live local indexer.
  *
- * Read-only aggregator over five existing routes. The portfolio command
- * doesn't *produce* state — it just bundles reads — so the integration
- * surface we care about is:
- *   1. it actually hits a local indexer (not the default mainnet URL),
- *   2. every requested section appears in the response (or with an
- *      isolated `{error}` payload, never a top-level abort),
- *   3. `--include` correctly narrows the payload,
- *   4. address normalization (0x → bb1) flows through.
+ * Each subcommand is a thin wrapper over an existing indexer route, so
+ * the integration surface we guard is:
+ *   1. each subcommand hits the right endpoint (status 200, response
+ *      shape includes the documented top-level keys),
+ *   2. `all` aggregator still bundles every section into one response,
+ *   3. address normalization (0x → bb1) is consistent across subcommands,
+ *   4. flag validation rejects bad input with a clear exit-2.
  *
- * We query alice's address — she's a known persona in the local keyring
- * and may or may not have any tokens/balances, which is fine. We're
- * asserting the SHAPE of the snapshot, not its contents.
+ * We query alice — known persona in the local keyring. Whether she has
+ * tokens / approvals / activity is irrelevant; we're asserting payload
+ * SHAPE, not contents.
  *
  * Skipped automatically when preflight fails.
  */
@@ -29,73 +28,62 @@ describe('portfolio integration', () => {
     ready = (await preflightIntegration()).ok;
   }, 30000);
 
-  it('default returns all five sections', () => {
+  it('account returns a single user payload', () => {
     if (!ready) return;
-    const addr = alice().address;
-    const out = runCli(['portfolio', '--address', addr, '--local']);
-    expect(out.json.address).toBe(addr);
-    for (const section of ['account', 'tokens', 'balances', 'assets', 'activity']) {
-      expect(out.json).toHaveProperty(section);
-    }
-    // tokens fans out to three views
-    expect(out.json.tokens).toHaveProperty('collected');
-    expect(out.json.tokens).toHaveProperty('created');
-    expect(out.json.tokens).toHaveProperty('managing');
-    // activity fans out to three feeds
-    expect(out.json.activity).toHaveProperty('transfers');
-    expect(out.json.activity).toHaveProperty('claims');
-    expect(out.json.activity).toHaveProperty('points');
-  });
-
-  it('--include narrows the payload to the requested sections', () => {
-    if (!ready) return;
-    const addr = alice().address;
-    const out = runCli(['portfolio', '--address', addr, '--include', 'balances,activity', '--local']);
-    expect(out.json.address).toBe(addr);
-    expect(out.json).toHaveProperty('balances');
-    expect(out.json).toHaveProperty('activity');
-    expect(out.json).not.toHaveProperty('account');
-    expect(out.json).not.toHaveProperty('tokens');
-    expect(out.json).not.toHaveProperty('assets');
-  });
-
-  it('--exclude drops the named sections', () => {
-    if (!ready) return;
-    const addr = alice().address;
-    const out = runCli(['portfolio', '--address', addr, '--exclude', 'assets,tokens', '--local']);
+    const out = runCli(['portfolio', 'account', '--address', alice().address, '--local']);
     expect(out.json).toHaveProperty('account');
-    expect(out.json).toHaveProperty('balances');
-    expect(out.json).toHaveProperty('activity');
-    expect(out.json).not.toHaveProperty('assets');
-    expect(out.json).not.toHaveProperty('tokens');
   });
 
-  it('accepts 0x form and normalizes to bb1 in the output', () => {
+  it('tokens defaults to view=collected and returns tokens + pagination', () => {
     if (!ready) return;
-    const bb1 = alice().address;
-    const hex = convertToEthAddress(bb1);
-    const out = runCli(['portfolio', '--address', hex, '--include', 'balances', '--local']);
-    expect(out.json.address).toBe(bb1);
+    const out = runCli(['portfolio', 'tokens', '--address', alice().address, '--local']);
+    expect(out.json).toHaveProperty('tokens');
+    expect(Array.isArray(out.json.tokens)).toBe(true);
+    expect(out.json).toHaveProperty('pagination');
   });
 
-  it('rejects unknown sections in --include with non-zero exit', () => {
+  it('tokens --view all fans out to collected/created/managing', () => {
+    if (!ready) return;
+    const out = runCli(['portfolio', 'tokens', '--address', alice().address, '--view', 'all', '--local']);
+    expect(out.json).toHaveProperty('collected');
+    expect(out.json).toHaveProperty('created');
+    expect(out.json).toHaveProperty('managing');
+  });
+
+  it('tokens rejects an unknown --view with exit 2', () => {
     if (!ready) return;
     const out = runCli(
-      ['portfolio', '--address', alice().address, '--include', 'not-a-section', '--local'],
+      ['portfolio', 'tokens', '--address', alice().address, '--view', 'definitely-not-real', '--local'],
       { throwOnError: false, parseJson: false }
     );
     expect(out.exitCode).not.toBe(0);
-    expect(out.stderr).toMatch(/not-a-section/);
+    expect(out.stderr).toMatch(/--view/);
   });
 
-  it('--chain and --all-chains are mutually exclusive', () => {
+  it('balances returns docs + pagination', () => {
+    if (!ready) return;
+    const out = runCli(['portfolio', 'balances', '--address', alice().address, '--local']);
+    expect(out.json).toHaveProperty('docs');
+    expect(Array.isArray(out.json.docs)).toBe(true);
+    expect(out.json).toHaveProperty('pagination');
+  });
+
+  it('assets defaults to bitbadges-1 and returns a balances map', () => {
+    if (!ready) return;
+    const out = runCli(['portfolio', 'assets', '--address', alice().address, '--local']);
+    expect(out.json).toHaveProperty('balances');
+  });
+
+  it('assets rejects mutually-exclusive --chain + --all-chains', () => {
     if (!ready) return;
     const out = runCli(
       [
         'portfolio',
-        '--address', alice().address,
-        '--include', 'assets',
-        '--chain', 'bitbadges-1',
+        'assets',
+        '--address',
+        alice().address,
+        '--chain',
+        'bitbadges-1',
         '--all-chains',
         '--local'
       ],
@@ -103,5 +91,83 @@ describe('portfolio integration', () => {
     );
     expect(out.exitCode).not.toBe(0);
     expect(out.stderr).toMatch(/--chain or --all-chains/);
+  });
+
+  it('activity defaults to type=tokens and returns an activity feed', () => {
+    if (!ready) return;
+    const out = runCli(['portfolio', 'activity', '--address', alice().address, '--local']);
+    expect(out.json).toHaveProperty('activity');
+    expect(Array.isArray(out.json.activity)).toBe(true);
+    expect(out.json).toHaveProperty('pagination');
+  });
+
+  it('activity --type all fans out to transfers/claims/points', () => {
+    if (!ready) return;
+    const out = runCli(['portfolio', 'activity', '--address', alice().address, '--type', 'all', '--local']);
+    expect(out.json).toHaveProperty('transfers');
+    expect(out.json).toHaveProperty('claims');
+    expect(out.json).toHaveProperty('points');
+  });
+
+  it('approvals defaults to --collection=any and returns docs', () => {
+    if (!ready) return;
+    const out = runCli(['portfolio', 'approvals', '--address', alice().address, '--local']);
+    // filterApprovals returns { docs: [...], pagination: {...} }
+    expect(out.json).toHaveProperty('docs');
+    expect(Array.isArray(out.json.docs)).toBe(true);
+  });
+
+  it('approvals requires --denom when --price-min/--price-max is set', () => {
+    if (!ready) return;
+    const out = runCli(
+      [
+        'portfolio',
+        'approvals',
+        '--address',
+        alice().address,
+        '--price-min',
+        '100',
+        '--local'
+      ],
+      { throwOnError: false, parseJson: false }
+    );
+    expect(out.exitCode).not.toBe(0);
+    expect(out.stderr).toMatch(/--denom/);
+  });
+
+  it('all returns every section in one bundle', () => {
+    if (!ready) return;
+    const out = runCli(['portfolio', 'all', '--address', alice().address, '--local']);
+    expect(out.json.address).toBe(alice().address);
+    for (const section of ['account', 'tokens', 'balances', 'assets', 'activity', 'approvals']) {
+      expect(out.json).toHaveProperty(section);
+    }
+  });
+
+  it('all --include narrows the payload', () => {
+    if (!ready) return;
+    const out = runCli([
+      'portfolio',
+      'all',
+      '--address',
+      alice().address,
+      '--include',
+      'balances,approvals',
+      '--local'
+    ]);
+    expect(out.json).toHaveProperty('balances');
+    expect(out.json).toHaveProperty('approvals');
+    expect(out.json).not.toHaveProperty('account');
+    expect(out.json).not.toHaveProperty('tokens');
+    expect(out.json).not.toHaveProperty('assets');
+    expect(out.json).not.toHaveProperty('activity');
+  });
+
+  it('every subcommand accepts 0x form and normalizes (visible via address echo)', () => {
+    if (!ready) return;
+    const bb1 = alice().address;
+    const hex = convertToEthAddress(bb1);
+    const out = runCli(['portfolio', 'all', '--address', hex, '--include', 'balances', '--local']);
+    expect(out.json.address).toBe(bb1);
   });
 });

--- a/packages/bitbadgesjs-sdk/src/cli/integration/portfolio.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/portfolio.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Integration: `bb portfolio` against a live local indexer.
+ *
+ * Read-only aggregator over five existing routes. The portfolio command
+ * doesn't *produce* state — it just bundles reads — so the integration
+ * surface we care about is:
+ *   1. it actually hits a local indexer (not the default mainnet URL),
+ *   2. every requested section appears in the response (or with an
+ *      isolated `{error}` payload, never a top-level abort),
+ *   3. `--include` correctly narrows the payload,
+ *   4. address normalization (0x → bb1) flows through.
+ *
+ * We query alice's address — she's a known persona in the local keyring
+ * and may or may not have any tokens/balances, which is fine. We're
+ * asserting the SHAPE of the snapshot, not its contents.
+ *
+ * Skipped automatically when preflight fails.
+ */
+
+import { preflightIntegration } from './harness/preflight.js';
+import { alice } from './harness/personas.js';
+import { runCli } from './harness/cli.js';
+import { convertToEthAddress } from '../../address-converter/converter.js';
+
+describe('portfolio integration', () => {
+  let ready = false;
+
+  beforeAll(async () => {
+    ready = (await preflightIntegration()).ok;
+  }, 30000);
+
+  it('default returns all five sections', () => {
+    if (!ready) return;
+    const addr = alice().address;
+    const out = runCli(['portfolio', '--address', addr, '--local']);
+    expect(out.json.address).toBe(addr);
+    for (const section of ['account', 'tokens', 'balances', 'assets', 'activity']) {
+      expect(out.json).toHaveProperty(section);
+    }
+    // tokens fans out to three views
+    expect(out.json.tokens).toHaveProperty('collected');
+    expect(out.json.tokens).toHaveProperty('created');
+    expect(out.json.tokens).toHaveProperty('managing');
+    // activity fans out to three feeds
+    expect(out.json.activity).toHaveProperty('transfers');
+    expect(out.json.activity).toHaveProperty('claims');
+    expect(out.json.activity).toHaveProperty('points');
+  });
+
+  it('--include narrows the payload to the requested sections', () => {
+    if (!ready) return;
+    const addr = alice().address;
+    const out = runCli(['portfolio', '--address', addr, '--include', 'balances,activity', '--local']);
+    expect(out.json.address).toBe(addr);
+    expect(out.json).toHaveProperty('balances');
+    expect(out.json).toHaveProperty('activity');
+    expect(out.json).not.toHaveProperty('account');
+    expect(out.json).not.toHaveProperty('tokens');
+    expect(out.json).not.toHaveProperty('assets');
+  });
+
+  it('--exclude drops the named sections', () => {
+    if (!ready) return;
+    const addr = alice().address;
+    const out = runCli(['portfolio', '--address', addr, '--exclude', 'assets,tokens', '--local']);
+    expect(out.json).toHaveProperty('account');
+    expect(out.json).toHaveProperty('balances');
+    expect(out.json).toHaveProperty('activity');
+    expect(out.json).not.toHaveProperty('assets');
+    expect(out.json).not.toHaveProperty('tokens');
+  });
+
+  it('accepts 0x form and normalizes to bb1 in the output', () => {
+    if (!ready) return;
+    const bb1 = alice().address;
+    const hex = convertToEthAddress(bb1);
+    const out = runCli(['portfolio', '--address', hex, '--include', 'balances', '--local']);
+    expect(out.json.address).toBe(bb1);
+  });
+
+  it('rejects unknown sections in --include with non-zero exit', () => {
+    if (!ready) return;
+    const out = runCli(
+      ['portfolio', '--address', alice().address, '--include', 'not-a-section', '--local'],
+      { throwOnError: false, parseJson: false }
+    );
+    expect(out.exitCode).not.toBe(0);
+    expect(out.stderr).toMatch(/not-a-section/);
+  });
+
+  it('--chain and --all-chains are mutually exclusive', () => {
+    if (!ready) return;
+    const out = runCli(
+      [
+        'portfolio',
+        '--address', alice().address,
+        '--include', 'assets',
+        '--chain', 'bitbadges-1',
+        '--all-chains',
+        '--local'
+      ],
+      { throwOnError: false, parseJson: false }
+    );
+    expect(out.exitCode).not.toBe(0);
+    expect(out.stderr).toMatch(/--chain or --all-chains/);
+  });
+});


### PR DESCRIPTION
## Summary
- New `bb portfolio --address <bb1|0x>` verb that bundles the five reads the FE shows on `/account/[addressOrUsername]`: account info, tokens (collected/created/managing), lean balance docs, swap-merged assets, and recent activity (transfers/claims/points) — all fetched in parallel into one JSON response.
- Thin wrapper. Every section is an existing indexer route that already has a dedicated CLI command; the value-add is bundling so an agent doing "tell me about this user" doesn't need 8 round trips.
- Per-section failures degrade to `{error: "..."}` rather than aborting the whole call.

## Why
Sets up the agent-friendly "centralized user lookup" surface the FE has had for years. DRY: no new helpers — reuses `callIndexer` / `requireBb1Address` / `emitIndexerResult` from the shared CLI utils. Same network/output flag surface as the rest of the indexer-touching commands.

## Usage
```sh
bb portfolio --address bb17j2h558cfchfc7w9wn8kyhjevkqu2t7q5dq2d7
bb portfolio --address 0xf4957a50F84E2E9c79C574cf625e596581c52Fc0
bb portfolio --address bb1... --include balances,activity
bb portfolio --address bb1... --exclude assets --all-chains
```

Response shape:
```jsonc
{
  "address": "bb1...",
  "account": { ... } | { "error": "..." },
  "tokens":   { "collected": {...}, "created": {...}, "managing": {...} },
  "balances": { "docs": [...], "pagination": {...} },
  "assets":   { ... swap-merged ... },
  "activity": { "transfers": {...}, "claims": {...}, "points": {...} }
}
```

## Test plan
- [x] Unit shape spec (`commands/portfolio.spec.ts`): flags, no subcommands, description names every section.
- [x] Integration spec (`integration/portfolio.spec.ts`, preflight-gated): default returns all 5 sections, `--include`/`--exclude` scope, 0x → bb1 normalization in output, mutually-exclusive `--chain`/`--all-chains`, unknown-section rejection with exit 2.
- [x] Local smoke: `bb portfolio --help`, 0x normalization, `--chain`+`--all-chains` mutex enforced, invalid `--include` rejected.
- [x] Verified `bb --help` and `bb --help-json` both surface `portfolio` under "Address & lookup utilities".
- [ ] Mainnet smoke (requires valid `BITBADGES_API_KEY`; my local config has a stale `default` placeholder so I couldn't verify the real-data path — every section fails-isolated to `{error: "Unauthorized..."}` as expected, but the actual happy-path response shape on real data needs reviewer verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)