### PR TITLE
feat(cli): envelope rollout (#0398) + build review/warnings/metadata in JSON

### DIFF
--- a/packages/bitbadgesjs-sdk/src/builder/sdk/coinRegistry.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/sdk/coinRegistry.spec.ts
@@ -31,10 +31,11 @@ describe('coinRegistry', () => {
   });
 
   describe('buildSymbolToTokenInfoMap', () => {
-    it('only includes IBC-denom entries (not native ubadge/badges:*)', () => {
+    it('includes every coin in MAINNET_COINS_REGISTRY (native + chain-internal + IBC)', () => {
       const map = buildSymbolToTokenInfoMap();
-      for (const token of map.values()) {
-        expect(token.ibcDenom.startsWith('ibc/')).toBe(true);
+      const symbols = Array.from(map.keys());
+      for (const required of ['BADGE', 'CHAOS', 'USDC', 'ATOM', 'OSMO']) {
+        expect(symbols).toContain(required);
       }
     });
 
@@ -44,11 +45,18 @@ describe('coinRegistry', () => {
       expect(a).toBe(b);
     });
 
-    it('each entry has a well-formed bb1 backing address', () => {
+    it('every IBC entry has a well-formed bb1 backing address; native + chain-internal entries omit it', () => {
       const map = buildSymbolToTokenInfoMap();
       for (const token of map.values()) {
-        expect(token.backingAddress).toMatch(/^bb1/);
-        expect(token.backingAddress.length).toBeGreaterThan(10);
+        if (token.ibcDenom.startsWith('ibc/')) {
+          expect(token.backingAddress).toMatch(/^bb1/);
+          expect(token.backingAddress!.length).toBeGreaterThan(10);
+        } else {
+          // Native (BADGE @ ubadge) and chain-internal (CHAOS @
+          // badges:49:chaosnet) denoms are queryable but can't have a
+          // backing alias — the wrapper flow only applies to IBC sources.
+          expect(token.backingAddress).toBeUndefined();
+        }
       }
     });
   });
@@ -89,6 +97,23 @@ describe('coinRegistry', () => {
 
     it('returns null for an empty query (no symbol, no ibc/ prefix)', () => {
       expect(lookupTokenInfo('')).toBeNull();
+    });
+
+    it('finds native BADGE (ubadge) and reports no backingAddress', () => {
+      const badge = lookupTokenInfo('BADGE');
+      expect(badge).not.toBeNull();
+      expect(badge!.symbol).toBe('BADGE');
+      expect(badge!.ibcDenom).toBe('ubadge');
+      expect(badge!.decimals).toBe('9');
+      expect(badge!.backingAddress).toBeUndefined();
+    });
+
+    it('finds chain-internal CHAOS (badges:49:chaosnet) and reports no backingAddress', () => {
+      const chaos = lookupTokenInfo('CHAOS');
+      expect(chaos).not.toBeNull();
+      expect(chaos!.symbol).toBe('CHAOS');
+      expect(chaos!.ibcDenom).toBe('badges:49:chaosnet');
+      expect(chaos!.backingAddress).toBeUndefined();
     });
   });
 

--- a/packages/bitbadgesjs-sdk/src/builder/sdk/coinRegistry.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/sdk/coinRegistry.ts
@@ -18,13 +18,24 @@ export interface CoinDetails {
 }
 
 /**
- * Token info with pre-generated backing address
+ * Token info exposed by `lookup_token_info` and `getAllTokens`.
+ *
+ * `ibcDenom` is misnamed for historical reasons — it holds the *primary*
+ * denom for the token (e.g. `ubadge`, `badges:49:chaosnet`, `ibc/...`),
+ * not just IBC denoms. We keep the name to avoid breaking the
+ * agent-facing contract; consumers should treat it as "the canonical
+ * denom string for this symbol."
+ *
+ * `backingAddress` is only set when the denom is IBC-backed — that's
+ * the Smart Token wrapping path's prerequisite. Native chain coins
+ * (BADGE) and chain-internal denoms (CHAOS at badges:49:chaosnet) leave
+ * it undefined.
  */
 export interface TokenInfo {
   symbol: string;
   ibcDenom: string;
   decimals: string;
-  backingAddress: string;
+  backingAddress?: string;
   displayName: string;
 }
 
@@ -85,25 +96,37 @@ export function buildSymbolToTokenInfoMap(): Map<string, TokenInfo> {
 
   const symbolMap = new Map<string, TokenInfo>();
 
+  // Every coin in the registry is queryable. We used to filter to IBC
+  // denoms only — that was historically scoped to the Smart Token
+  // backing path — but agents reasonably ask `lookup_token_info BADGE`
+  // for decimals / denom resolution and need a useful answer. Compute
+  // `backingAddress` only for IBC entries (since the alias generator
+  // expects an `ibc/...` denom); leave it undefined for native (BADGE)
+  // and chain-internal (CHAOS at `badges:49:chaosnet`) denoms.
   Object.entries(MAINNET_COINS_REGISTRY).forEach(([baseDenom, coinDetails]) => {
-    // Only include IBC denoms for Smart Token backing
+    const symbol = coinDetails.symbol.toUpperCase();
+    if (symbolMap.has(symbol)) return;
+
+    let backingAddress: string | undefined;
     if (baseDenom.startsWith('ibc/')) {
-      const symbol = coinDetails.symbol.toUpperCase();
-      if (!symbolMap.has(symbol)) {
-        try {
-          const backingAddress = generateAliasAddressForIBCBackedDenom(baseDenom);
-          symbolMap.set(symbol, {
-            symbol,
-            ibcDenom: baseDenom,
-            decimals: coinDetails.decimals,
-            backingAddress,
-            displayName: coinDetails.label
-          });
-        } catch (error) {
-          console.warn(`Failed to generate backing address for ${baseDenom}:`, error);
-        }
+      try {
+        backingAddress = generateAliasAddressForIBCBackedDenom(baseDenom);
+      } catch (error) {
+        console.warn(`Failed to generate backing address for ${baseDenom}:`, error);
+        // Skip IBC denoms that can't generate an alias — these are
+        // unusable for Smart Token backing AND we don't want to surface
+        // them without the canonical address.
+        return;
       }
     }
+
+    symbolMap.set(symbol, {
+      symbol,
+      ibcDenom: baseDenom,
+      decimals: coinDetails.decimals,
+      ...(backingAddress ? { backingAddress } : {}),
+      displayName: coinDetails.label
+    });
   });
 
   symbolToTokenInfoCache = symbolMap;

--- a/packages/bitbadgesjs-sdk/src/builder/tools/utilities/lookupTokenInfo.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/tools/utilities/lookupTokenInfo.spec.ts
@@ -84,7 +84,8 @@ describe('handleLookupTokenInfo', () => {
       const denom = 'ibc/0123456789ABCDEF';
       const res = handleLookupTokenInfo({ query: denom });
       expect(res.success).toBe(true);
-      expect(res.tokenInfo!.backingAddress.length).toBeGreaterThan(4);
+      expect(res.tokenInfo!.backingAddress).toBeDefined();
+      expect(res.tokenInfo!.backingAddress!.length).toBeGreaterThan(4);
     });
   });
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/address.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/address.ts
@@ -1,38 +1,45 @@
 import { Command } from 'commander';
+import { addOutputOptions, emit, emitError } from '../utils/envelope.js';
 
 export const addressCommand = new Command('address').description('Address conversion and validation utilities.');
 
-addressCommand
-  .command('convert <address>')
-  .description('Convert an address between bb1 and 0x formats. Auto-detects target direction from the input if --to is omitted.')
-  .option('--to <format>', 'Target format: bb1 or 0x. Default: opposite of the input.')
-  .action(async (address: string, opts: { to?: string }) => {
-    const { convertToBitBadgesAddress, convertToEthAddress } = await import('../../address-converter/converter.js');
+addOutputOptions(
+  addressCommand
+    .command('convert <address>')
+    .description('Convert an address between bb1 and 0x formats. Auto-detects target direction from the input if --to is omitted.')
+    .option('--to <format>', 'Target format: bb1 or 0x. Default: opposite of the input.')
+).action(async (address: string, opts: { to?: string; condensed?: boolean; outputFile?: string }) => {
+  const { convertToBitBadgesAddress, convertToEthAddress } = await import('../../address-converter/converter.js');
 
-    const to = opts.to ?? (address.startsWith('0x') ? 'bb1' : address.startsWith('bb') ? '0x' : '');
-    if (to !== 'bb1' && to !== '0x') {
-      console.error(`Could not infer target format from "${address}". Pass --to bb1 or --to 0x.`);
-      process.exit(2);
-    }
+  const to = opts.to ?? (address.startsWith('0x') ? 'bb1' : address.startsWith('bb') ? '0x' : '');
+  if (to !== 'bb1' && to !== '0x') {
+    emitError(new Error(`Could not infer target format from "${address}". Pass --to bb1 or --to 0x.`), {
+      code: 'invalid_target',
+      exitCode: 2
+    });
+  }
 
-    const result = to === 'bb1' ? convertToBitBadgesAddress(address) : convertToEthAddress(address);
-    if (!result) {
-      console.error(`Could not convert "${address}". Verify it is a well-formed bb1.../0x... address.`);
-      process.exit(2);
-    }
-    console.log(result);
-  });
+  const result = to === 'bb1' ? convertToBitBadgesAddress(address) : convertToEthAddress(address);
+  if (!result) {
+    emitError(new Error(`Could not convert "${address}". Verify it is a well-formed bb1.../0x... address.`), {
+      code: 'invalid_address',
+      exitCode: 2
+    });
+  }
+  emit({ result, source: address, target: to }, opts);
+});
 
-addressCommand
-  .command('validate <address>')
-  .description('Validate an address and detect its chain. Exits 0 when valid, 2 when invalid — so scripts can branch on exit code.')
-  .action(async (address: string) => {
-    const { isAddressValid, getChainForAddress } = await import('../../address-converter/converter.js');
+addOutputOptions(
+  addressCommand
+    .command('validate <address>')
+    .description('Validate an address and detect its chain. Exits 0 when valid, 2 when invalid — so scripts can branch on exit code.')
+).action(async (address: string, opts: { condensed?: boolean; outputFile?: string }) => {
+  const { isAddressValid, getChainForAddress } = await import('../../address-converter/converter.js');
 
-    const valid = isAddressValid(address);
-    const chain = getChainForAddress(address);
-    const chainLabel = chain === 'Cosmos' ? 'BitBadges' : chain === 'ETH' ? 'Ethereum' : 'Unknown';
+  const valid = isAddressValid(address);
+  const chain = getChainForAddress(address);
+  const chainLabel = chain === 'Cosmos' ? 'BitBadges' : chain === 'ETH' ? 'Ethereum' : 'Unknown';
 
-    console.log(JSON.stringify({ valid, chain: chainLabel, address }, null, 2));
-    if (!valid) process.exit(2);
-  });
+  emit({ valid, chain: chainLabel, address }, opts);
+  if (!valid) process.exit(2);
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/alias.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/alias.ts
@@ -1,29 +1,35 @@
 import { Command } from 'commander';
+import { addOutputOptions, emit } from '../utils/envelope.js';
 
 export const aliasCommand = new Command('alias').description('Generate protocol-derived alias addresses.');
 
-aliasCommand
-  .command('for-ibc-backing <ibcDenom>')
-  .description('Generate backing address for an IBC-backed smart token (uses BackedPathGenerationPrefix)')
-  .action(async (ibcDenom: string) => {
-    const { generateAliasAddressForIBCBackedDenom } = await import('../../core/aliases.js');
-    console.log(generateAliasAddressForIBCBackedDenom(ibcDenom));
-  });
+addOutputOptions(
+  aliasCommand
+    .command('for-ibc-backing <ibcDenom>')
+    .description('Generate backing address for an IBC-backed smart token (uses BackedPathGenerationPrefix)')
+).action(async (ibcDenom: string, opts: { condensed?: boolean; outputFile?: string }) => {
+  const { generateAliasAddressForIBCBackedDenom } = await import('../../core/aliases.js');
+  const address = generateAliasAddressForIBCBackedDenom(ibcDenom);
+  emit({ address, kind: 'ibc-backing', source: ibcDenom }, opts);
+});
 
-aliasCommand
-  .command('for-wrapper <denom>')
-  .description('Generate wrapper path address for a cosmos coin wrapper (uses DenomGenerationPrefix)')
-  .action(async (denom: string) => {
-    const { generateAliasAddressForDenom } = await import('../../core/aliases.js');
-    console.log(generateAliasAddressForDenom(denom));
-  });
+addOutputOptions(
+  aliasCommand
+    .command('for-wrapper <denom>')
+    .description('Generate wrapper path address for a cosmos coin wrapper (uses DenomGenerationPrefix)')
+).action(async (denom: string, opts: { condensed?: boolean; outputFile?: string }) => {
+  const { generateAliasAddressForDenom } = await import('../../core/aliases.js');
+  const address = generateAliasAddressForDenom(denom);
+  emit({ address, kind: 'wrapper', source: denom }, opts);
+});
 
-aliasCommand
-  .command('for-mint-escrow <collectionId>')
-  .description('Generate mint escrow address for a collection (where to send quest reward funds, etc.)')
-  .action(async (collectionId: string) => {
-    const { getAliasDerivationKeysForCollection, generateAlias } = await import('../../core/aliases.js');
-    const derivationKeys = getAliasDerivationKeysForCollection(collectionId);
-    const address = generateAlias('badges', derivationKeys);
-    console.log(address);
-  });
+addOutputOptions(
+  aliasCommand
+    .command('for-mint-escrow <collectionId>')
+    .description('Generate mint escrow address for a collection (where to send quest reward funds, etc.)')
+).action(async (collectionId: string, opts: { condensed?: boolean; outputFile?: string }) => {
+  const { getAliasDerivationKeysForCollection, generateAlias } = await import('../../core/aliases.js');
+  const derivationKeys = getAliasDerivationKeysForCollection(collectionId);
+  const address = generateAlias('badges', derivationKeys);
+  emit({ address, kind: 'mint-escrow', source: collectionId }, opts);
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/api.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/api.spec.ts
@@ -45,10 +45,10 @@ describe('createApiCommand shape', () => {
     expect(all.commands.length).toBeGreaterThan(50);
   });
 
-  it('exposes --search + --format flags at the top level', () => {
+  it('exposes --search at the top level (envelope is always JSON post-#0398)', () => {
     const api = createApiCommand();
     const longs = (api.options as any[]).map((o) => o.long);
-    expect(longs).toEqual(expect.arrayContaining(['--search', '--format']));
+    expect(longs).toEqual(expect.arrayContaining(['--search']));
   });
 
   it('group commands carry a "<n> routes" suffix in their description', () => {
@@ -74,7 +74,7 @@ describe('api --search', () => {
     };
   };
 
-  it('returns no-match message when keyword has no hits', async () => {
+  it('returns an empty matches array when keyword has no hits', async () => {
     const api = createApiCommand();
     const cap = captureStdout();
     try {
@@ -85,23 +85,26 @@ describe('api --search', () => {
     } finally {
       cap.restore();
     }
-    expect(cap.out()).toMatch(/No routes match/);
+    const env = JSON.parse(cap.out().trim());
+    expect(env.ok).toBe(true);
+    expect(env.data.matches).toEqual([]);
   });
 
-  it('--format json emits an array of route metadata', async () => {
+  it('--search emits an envelope with route metadata in data.matches', async () => {
     const api = createApiCommand();
     const cap = captureStdout();
     try {
-      await api.parseAsync(['--search', 'account', '--format', 'json'], {
+      await api.parseAsync(['--search', 'account'], {
         from: 'user',
       });
     } finally {
       cap.restore();
     }
-    const parsed = JSON.parse(cap.out().trim());
-    expect(Array.isArray(parsed)).toBe(true);
-    expect(parsed.length).toBeGreaterThan(0);
-    for (const m of parsed) {
+    const env = JSON.parse(cap.out().trim());
+    expect(env.ok).toBe(true);
+    expect(Array.isArray(env.data.matches)).toBe(true);
+    expect(env.data.matches.length).toBeGreaterThan(0);
+    for (const m of env.data.matches) {
       expect(m).toEqual(
         expect.objectContaining({
           name: expect.any(String),

--- a/packages/bitbadgesjs-sdk/src/cli/commands/api.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/api.ts
@@ -25,6 +25,7 @@ import {
   addIndexerNetworkOptions,
   addIndexerOutputOptions,
 } from '../utils/indexer-options.js';
+import { emit, emitError } from '../utils/envelope.js';
 import { ROUTES, TAG_DESCRIPTIONS, type ApiRoute } from './api-routes.js';
 
 // ---------------------------------------------------------------------------
@@ -191,22 +192,23 @@ function buildRouteCommand(route: ApiRoute): Command {
     // Agents get a deterministic shape they can consume; full JSONSchema
     // generation can land alongside the OpenAPI pipeline upgrade.
     if (opts.schema) {
-      const schemaPayload = {
-        name: route.name,
-        method: route.method,
-        path: route.path,
-        description: route.description,
-        pathParams: route.pathParams,
-        hasBody: route.hasBody,
-        sdkLinks: route.sdkLinks ?? null,
-        queryParams: route.queryParams ?? [],
-        bodyFields: route.bodyFields ?? [],
-        requestSchema: route.requestSchema ?? null,
-        responseSchema: route.responseSchema ?? null,
-        example: route.example ?? null
-      };
-      const out = opts.condensed ? JSON.stringify(schemaPayload) : JSON.stringify(schemaPayload, null, 2);
-      process.stdout.write(out + '\n');
+      emit(
+        {
+          name: route.name,
+          method: route.method,
+          path: route.path,
+          description: route.description,
+          pathParams: route.pathParams,
+          hasBody: route.hasBody,
+          sdkLinks: route.sdkLinks ?? null,
+          queryParams: route.queryParams ?? [],
+          bodyFields: route.bodyFields ?? [],
+          requestSchema: route.requestSchema ?? null,
+          responseSchema: route.responseSchema ?? null,
+          example: route.example ?? null
+        },
+        opts
+      );
       return;
     }
 
@@ -323,17 +325,19 @@ function buildRouteCommand(route: ApiRoute): Command {
 
       // Dry-run: show request details and exit
       if (opts.dryRun) {
-        const dryOutput = {
-          method: route.method,
-          url: `${baseUrl}${resolvedPath}`,
-          headers: {
-            'x-api-key': apiKey ? apiKey.slice(0, 4) + '****' : '(none)',
-            ...(cookie ? { Cookie: cookie.split('=')[0] + '=****' } : {}),
-            ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+        emit(
+          {
+            method: route.method,
+            url: `${baseUrl}${resolvedPath}`,
+            headers: {
+              'x-api-key': apiKey ? apiKey.slice(0, 4) + '****' : '(none)',
+              ...(cookie ? { Cookie: cookie.split('=')[0] + '=****' } : {}),
+              ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+            },
+            body: body ?? null,
           },
-          body: body ?? null,
-        };
-        process.stdout.write(JSON.stringify(dryOutput, null, 2) + '\n');
+          opts
+        );
         return;
       }
 
@@ -347,30 +351,9 @@ function buildRouteCommand(route: ApiRoute): Command {
         cookieRef,
       });
 
-      const formatted = opts.condensed
-        ? JSON.stringify(result)
-        : JSON.stringify(result, null, 2);
-
-      if (opts.outputFile) {
-        fs.writeFileSync(opts.outputFile, formatted + '\n', 'utf-8');
-        process.stderr.write(`Written to ${opts.outputFile}\n`);
-      } else {
-        process.stdout.write(formatted + '\n');
-      }
+      emit(result, opts);
     } catch (err: any) {
-      // If the error has a response body, print it
-      if (err.response) {
-        process.stderr.write(JSON.stringify(err.response, null, 2) + '\n');
-      } else {
-        process.stderr.write(`Error: ${err.message}\n`);
-      }
-      // Surface the targeted auth hint surfaced by api-client.ts for
-      // 401/403 paths. Keeps the on-error UX one line longer than the
-      // raw response body, but cuts the agent's retry-loop in half.
-      if (err.hint) {
-        process.stderr.write(`Hint: ${err.hint}\n`);
-      }
-      process.exitCode = 1;
+      emitError(err, { exitCode: 1 });
     }
   });
 
@@ -395,8 +378,7 @@ export function createApiCommand(): Command {
   // of the `api` command's raw-passthrough contract.
   api
     .option('--search <kw>', 'Search routes by keyword (matches name, path, tag, description). Case-insensitive substring.')
-    .option('--format <fmt>', 'Output format for --search: json | text', 'text')
-    .action((opts: { search?: string; format?: string }) => {
+    .action((opts: { search?: string }) => {
       if (!opts.search) {
         api.outputHelp();
         return;
@@ -412,21 +394,7 @@ export function createApiCommand(): Command {
         tag: r.tag,
         description: r.description
       }));
-      if (opts.format === 'json') {
-        process.stdout.write(JSON.stringify(matches, null, 2) + '\n');
-        return;
-      }
-      if (matches.length === 0) {
-        process.stdout.write(`No routes match "${opts.search}".\n`);
-        return;
-      }
-      const nameW = Math.max(...matches.map((m) => m.name.length));
-      const methodW = Math.max(...matches.map((m) => m.method.length));
-      for (const m of matches) {
-        process.stdout.write(
-          `${m.name.padEnd(nameW)}  ${m.method.padEnd(methodW)}  ${m.path}\n      ${m.description}\n\n`
-        );
-      }
+      emit({ search: opts.search, matches });
     });
 
   // Create tag-based group commands

--- a/packages/bitbadgesjs-sdk/src/cli/commands/auth.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auth.spec.ts
@@ -43,14 +43,14 @@ describe('authCommand shape', () => {
     );
   });
 
-  it('challenge requires --address and exposes --json + --no-save-pending', () => {
+  it('challenge requires --address and exposes --no-save-pending (envelope is always JSON post-#0398)', () => {
     const challenge = authCommand.commands.find((c) => c.name() === 'challenge')!;
     const requiredLongs = (challenge.options as any[])
       .filter((o) => o.required)
       .map((o) => o.long);
     expect(requiredLongs).toContain('--address');
     const longs = (challenge.options as any[]).map((o) => o.long);
-    expect(longs).toEqual(expect.arrayContaining(['--json', '--no-save-pending']));
+    expect(longs).toEqual(expect.arrayContaining(['--no-save-pending']));
   });
 
   it('use takes <address>', () => {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/auth.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auth.ts
@@ -305,17 +305,16 @@ addNetworkOptions(authCommand.command('login'))
     });
     clearPendingChallenge(network, opts.address);
 
-    process.stdout.write(
-      `Logged in as ${opts.address} on ${network}. Expires ${new Date(session.expiresAt).toISOString()}.\n`,
-    );
+    const { emit, commentary } = await import('../utils/envelope.js');
+    commentary(`Logged in as ${opts.address} on ${network}. Expires ${new Date(session.expiresAt).toISOString()}.`);
+    emit({ address: opts.address, network, expiresAt: session.expiresAt, chain });
   });
 
 // ── auth challenge ──────────────────────────────────────────────────
 
 addNetworkOptions(authCommand.command('challenge'))
-  .description('Fetch a Blockin challenge for an address. Print the message your signer must sign.')
+  .description('Fetch a Blockin challenge for an address. The message your signer must sign lives at envelope.data.message.')
   .requiredOption('--address <addr>', "Native address (bb1... or 0x...).")
-  .option('--json', 'Output {message, nonce} as JSON.', false)
   .option('--no-save-pending', 'Do not persist the challenge cookie locally (advanced).')
   .action(async (opts) => {
     const network = resolveNetwork(opts);
@@ -331,11 +330,12 @@ addNetworkOptions(authCommand.command('challenge'))
       setPendingChallenge(network, opts.address, challenge.message, challenge.cookies, baseUrl);
     }
 
-    if (opts.json) {
-      process.stdout.write(JSON.stringify({ message: challenge.message, nonce: challenge.nonce }) + '\n');
-    } else {
-      process.stdout.write(challenge.message + '\n');
-    }
+    // The challenge message used to be emitted bare to stdout for direct
+    // copy/paste into a signer; agents (and `jq -r .data.message`) can
+    // get the same string out of the envelope, which keeps the surface
+    // consistent.
+    const { emit } = await import('../utils/envelope.js');
+    emit({ message: challenge.message, nonce: challenge.nonce });
   });
 
 // ── auth verify ─────────────────────────────────────────────────────
@@ -387,15 +387,20 @@ addNetworkOptions(authCommand.command('status'))
       return active ? [{ network, session: active }] : [];
     })();
 
+    const { emit, commentary } = await import('../utils/envelope.js');
+
     if (sessions.length === 0) {
-      process.stdout.write('No stored sessions. Run `bitbadges-cli auth login`.\n');
+      commentary('No stored sessions. Run `bitbadges-cli auth login`.');
+      emit({ sessions: [] });
       return;
     }
 
+    const out: any[] = [];
     for (const { network, session } of sessions) {
       const expiry = new Date(session.expiresAt).toISOString();
-      const status = Date.now() > session.expiresAt ? 'EXPIRED' : 'valid';
-      let serverCheck = '';
+      const status = Date.now() > session.expiresAt ? 'expired' : 'valid';
+      let serverSignedIn: boolean | null = null;
+      let serverError: string | null = null;
       if (opts.check) {
         try {
           const r = await rawPost(
@@ -403,15 +408,32 @@ addNetworkOptions(authCommand.command('status'))
             { Cookie: formatCookieHeader(session) },
             {},
           );
-          serverCheck = r.body?.signedIn ? ' [server: signed-in]' : ' [server: NOT signed in]';
+          serverSignedIn = !!r.body?.signedIn;
         } catch (err: any) {
-          serverCheck = ` [server check failed: ${err.message}]`;
+          serverError = err.message;
         }
       }
-      process.stdout.write(
-        `${network.padEnd(8)}  ${session.address}  ${session.chain}  expires=${expiry} (${status})${serverCheck}\n`,
+      const summary = {
+        network,
+        address: session.address,
+        chain: session.chain,
+        expiresAt: expiry,
+        status,
+        ...(opts.check ? { serverSignedIn, serverError } : {})
+      };
+      out.push(summary);
+      commentary(
+        `${network.padEnd(8)}  ${session.address}  ${session.chain}  expires=${expiry} (${status})` +
+          (opts.check
+            ? serverError
+              ? ` [server check failed: ${serverError}]`
+              : serverSignedIn
+                ? ' [server: signed-in]'
+                : ' [server: NOT signed in]'
+            : '')
       );
     }
+    emit({ sessions: out });
   });
 
 // ── auth logout ─────────────────────────────────────────────────────
@@ -427,12 +449,17 @@ addNetworkOptions(authCommand.command('logout'))
       return session ? [{ network, session }] : [];
     })();
 
+    const { emit, commentary } = await import('../utils/envelope.js');
+
     if (targets.length === 0) {
-      process.stdout.write('No matching session to log out.\n');
+      commentary('No matching session to log out.');
+      emit({ loggedOut: [] });
       return;
     }
 
+    const loggedOut: any[] = [];
     for (const { network, session } of targets) {
+      let serverError: string | null = null;
       try {
         await rawPost(
           `${session.indexerUrl}/auth/logout`,
@@ -440,11 +467,16 @@ addNetworkOptions(authCommand.command('logout'))
           { signOutBlockin: true, signOutEmail: true },
         );
       } catch (err: any) {
-        process.stderr.write(`(server logout failed for ${session.address} on ${network}: ${err.message}; removing local record anyway)\n`);
+        serverError = err.message;
+        process.stderr.write(
+          `(server logout failed for ${session.address} on ${network}: ${err.message}; removing local record anyway)\n`
+        );
       }
       removeSession(network, session.address);
-      process.stdout.write(`Logged out ${session.address} on ${network}.\n`);
+      loggedOut.push({ network, address: session.address, serverError });
+      commentary(`Logged out ${session.address} on ${network}.`);
     }
+    emit({ loggedOut });
   });
 
 // ── auth use ────────────────────────────────────────────────────────
@@ -455,7 +487,9 @@ addNetworkOptions(authCommand.command('use'))
   .action(async (address: string, opts) => {
     const network = resolveNetwork(opts);
     setActive(network, address);
-    process.stdout.write(`Active on ${network} is now ${address}.\n`);
+    const { emit, commentary } = await import('../utils/envelope.js');
+    commentary(`Active on ${network} is now ${address}.`);
+    emit({ network, active: address });
   });
 
 // ── auth whoami ─────────────────────────────────────────────────────
@@ -465,13 +499,16 @@ addNetworkOptions(authCommand.command('whoami'))
   .action(async (opts) => {
     const network = resolveNetwork(opts);
     const session = getActiveSession(network);
+    const { emit, emitError, commentary } = await import('../utils/envelope.js');
     if (!session) {
-      process.stdout.write(`No active session on ${network}. Run \`bitbadges-cli auth login\`.\n`);
-      process.exit(1);
+      emitError(
+        new Error(`No active session on ${network}. Run \`bitbadges-cli auth login\`.`),
+        { code: 'no_active_session', exitCode: 1 }
+      );
     }
-    process.stdout.write(
-      `${session.address} on ${network}  (chain=${session.chain}, expires=${new Date(session.expiresAt).toISOString()})\n`,
-    );
+    const expiresAt = new Date(session!.expiresAt).toISOString();
+    commentary(`${session!.address} on ${network}  (chain=${session!.chain}, expires=${expiresAt})`);
+    emit({ address: session!.address, network, chain: session!.chain, expiresAt });
   });
 
 // ── auth path ───────────────────────────────────────────────────────
@@ -479,6 +516,7 @@ addNetworkOptions(authCommand.command('whoami'))
 authCommand
   .command('path')
   .description('Print the path of the local auth store (~/.bitbadges/auth.json).')
-  .action(() => {
-    process.stdout.write(getAuthPath() + '\n');
+  .action(async () => {
+    const { emit } = await import('../utils/envelope.js');
+    emit({ path: getAuthPath() });
   });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
-import { output, readJsonInput, addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
-import { isQuiet } from '../utils/envelope.js';
+import { readJsonInput, addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
+import { emit as emitEnvelope, isQuiet, type EnvelopeWarning } from '../utils/envelope.js';
 import { tagHelpGroups } from '../utils/help-groups.js';
-import { renderReview, renderValidate, renderResolvedMetadata, renderSimulate } from '../utils/terminal.js';
+import { renderReview, renderValidate, renderResolvedMetadata, renderSimulate, collectResolvedEntries, type ResolvedEntry } from '../utils/terminal.js';
 import { isCollectionMsg, normalizeToCreateOrUpdate } from '../utils/normalizeMsg.js';
 import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
 import { runBurnerCreate, pickBurner, type BurnerNetwork } from '../utils/burner.js';
@@ -129,83 +129,113 @@ async function emit(
     }
   }
 
-  // Emit the JSON payload FIRST. Scroll order on an interactive terminal
-  // naturally puts the most recently-written bytes at the bottom, so the
-  // review summary appearing *after* the JSON means the user's final
-  // eyeline lands on the review verdict — the most actionable bit.
-  //
-  // Stdout flushes synchronously for pipes/files and line-buffered for
-  // TTYs, so writing JSON before the stderr review keeps the visible
-  // order stable across both cases.
-  //
   // Narrow Universal → MsgCreateCollection / MsgUpdateCollection right at
-  // the write boundary. Agents and humans see the proto's real per-intent
+  // the emit boundary. Agents and humans see the proto's real per-intent
   // message type; only legacy internal tooling sees the Universal superset.
   const outData = isCollectionTx ? normalizeToCreateOrUpdate(data) : data;
-  output(outData, { condensed: opts.condensed, outputFile: opts.outputFile });
 
-  // --explain: run interpretTransaction and print human-readable summary.
-  // Printed to stderr so it doesn't pollute the JSON pipe; shown above the
-  // auto-review so the narrative ("what this tx does") precedes the
-  // critique ("what might be wrong with it").
-  if (opts.explain && isCollectionTx && !isQuiet()) {
-    const { interpretTransaction } = await import('../../core/interpret-transaction.js');
-    const explanation = interpretTransaction(data.value);
-    process.stderr.write('\n── Explanation ──\n' + explanation + '\n');
-  }
-
-  // Auto-review every produced collection tx. Runs both the design-level
-  // `reviewCollection()` checks (audit, standards, UX) and the low-level
-  // structural `validateTransaction()` checks so templates can't silently
-  // produce JSON that the chain would reject. Findings go to stderr so
-  // stdout stays pure JSON for sign/broadcast pipelines; --json-only
-  // suppresses both for callers that want zero stderr noise.
+  // Build the envelope's `meta` payload + `warnings` array as we run
+  // each auto-check. Stderr commentary still streams for human UX (gated
+  // by --quiet / --json-only); the structured equivalents land in the
+  // envelope so agents don't have to scrape stderr text.
   //
-  // Auto-validate runs for BOTH collection and user-approval templates
-  // (both produce structurally validatable txs). Auto-review and
-  // metadata + simulate are gated below — review only fires for
-  // collection txs (collection-specific rules), and simulate is
-  // refused for approval-style msgs entirely.
   // `--quiet` (and `BB_QUIET=1`) suppresses commentary streams just like
   // `--json-only`, but stays scoped to commentary — actual errors still
   // emit. Use the same gate so the four banners below follow one rule.
   const suppressCommentary = !!opts.jsonOnly || isQuiet();
+  const meta: Record<string, unknown> = {};
+  const warnings: EnvelopeWarning[] = [];
 
-  if (!suppressCommentary && (isCollectionTx || isUserApprovalTx || isTransferTx)) {
-    // Static validation FIRST — if the JSON is structurally broken, the
-    // design review below is much less meaningful.
+  // --explain: run interpretTransaction and surface plain-English text.
+  // Always computed when applicable so agents see the explanation in
+  // meta.explanation; the stderr render is gated by --quiet for humans.
+  if (opts.explain && isCollectionTx) {
+    try {
+      const { interpretTransaction } = await import('../../core/interpret-transaction.js');
+      const explanation = interpretTransaction(data.value);
+      meta.explanation = explanation;
+      if (!isQuiet()) {
+        process.stderr.write('\n── Explanation ──\n' + explanation + '\n');
+      }
+    } catch (err) {
+      if (!suppressCommentary) {
+        process.stderr.write(`Explain skipped: ${err instanceof Error ? err.message : String(err)}\n`);
+      }
+    }
+  }
+
+  // Auto-validate runs for collection / user-approval / transfer msgs
+  // — anything structurally validatable. Always computed (so agents see
+  // validation results in meta.validation); stderr render gated by quiet.
+  if (isCollectionTx || isUserApprovalTx || isTransferTx) {
     try {
       const { validateTransaction } = await import('../../core/validate.js');
       const wrapped = { messages: [data] };
       const vResult = validateTransaction(wrapped);
-      process.stderr.write('\n' + renderValidate(vResult, { stream: process.stderr, title: 'Auto-Validate' }) + '\n');
+      meta.validation = vResult;
+      for (const issue of vResult?.issues ?? []) {
+        warnings.push({
+          code: `validate.${(issue as any).code ?? 'issue'}`,
+          message: (issue as any).message ?? 'validation issue',
+          details: issue
+        });
+      }
+      if (!suppressCommentary) {
+        process.stderr.write('\n' + renderValidate(vResult, { stream: process.stderr, title: 'Auto-Validate' }) + '\n');
+      }
     } catch (err) {
-      process.stderr.write(`Validation skipped: ${err instanceof Error ? err.message : String(err)}\n`);
+      if (!suppressCommentary) {
+        process.stderr.write(`Validation skipped: ${err instanceof Error ? err.message : String(err)}\n`);
+      }
     }
   }
 
-  if (!suppressCommentary && isCollectionTx) {
+  if (isCollectionTx) {
     try {
       const { reviewCollection } = await import('../../core/review.js');
       // reviewCollection wants either a raw collection or a tx body with
       // messages[]. Templates emit a single Msg, so wrap it.
       const result = reviewCollection({ messages: [data] });
-      process.stderr.write('\n' + renderReview(result, { stream: process.stderr, title: 'Auto-Review' }) + '\n');
+      meta.review = result;
+      // Map each finding into the envelope's warnings array so callers
+      // that only inspect `.warnings` see the design review surface too.
+      for (const finding of result?.findings ?? []) {
+        warnings.push({
+          code: finding.code,
+          message: (finding.title?.en ?? finding.code),
+          details: finding
+        });
+      }
+      if (!suppressCommentary) {
+        process.stderr.write('\n' + renderReview(result, { stream: process.stderr, title: 'Auto-Review' }) + '\n');
+      }
     } catch (err) {
-      process.stderr.write(`Review skipped: ${err instanceof Error ? err.message : String(err)}\n`);
+      if (!suppressCommentary) {
+        process.stderr.write(`Review skipped: ${err instanceof Error ? err.message : String(err)}\n`);
+      }
     }
 
-    // Resolved Metadata — the final on-chain `(uri, customData)` pairs
-    // for every metadata-bearing entity in this tx, after the two-mode
-    // resolution. Helps the user verify they got the mode they expected
-    // (URI mode keeps customData empty; inline mode keeps uri empty and
-    // surfaces a parsed name/image preview from customData).
+    // Resolved Metadata — final on-chain (uri, customData) pairs for
+    // every metadata-bearing entity. We also surface a `metadataToUpload`
+    // list (URI-mode entries only) — that's the actionable subset agents
+    // need to push to IPFS *before* deploy. Per
+    // [[feedback_ai_cli_first_exposure]] off-chain storage stays
+    // website-only, so an agent can't IPFS-upload directly; the list
+    // tells them exactly which URIs to feed through the upload UI.
     try {
-      process.stderr.write('\n' + renderResolvedMetadata(data, { stream: process.stderr }) + '\n');
+      const entries: ResolvedEntry[] = collectResolvedEntries(data);
+      meta.resolvedMetadata = entries;
+      meta.metadataToUpload = entries
+        .filter((e) => e.uri.length > 0)
+        .map((e) => ({ kind: e.kind, location: e.location, uri: e.uri }));
+      if (!suppressCommentary) {
+        process.stderr.write('\n' + renderResolvedMetadata(data, { stream: process.stderr }) + '\n');
+      }
     } catch (err) {
-      process.stderr.write(`Resolved-metadata preview skipped: ${err instanceof Error ? err.message : String(err)}\n`);
+      if (!suppressCommentary) {
+        process.stderr.write(`Resolved-metadata preview skipped: ${err instanceof Error ? err.message : String(err)}\n`);
+      }
     }
-
   }
 
   // Auto-Simulate — opt-in via --simulate. Posts to the BitBadges API's
@@ -220,23 +250,26 @@ async function emit(
   // Lives OUTSIDE the collection-only block so transfers (which can't
   // be reviewed but CAN be simulated end-to-end) reach it. User-approval
   // txs get a skip note further down.
-  if (!suppressCommentary && opts.simulate && (isCollectionTx || isTransferTx)) {
+  if (opts.simulate && (isCollectionTx || isTransferTx)) {
     try {
       const { getApiUrl, getApiKeyForNetwork } = await import('../utils/io.js');
       const apiKey = getApiKeyForNetwork(opts);
       if (!apiKey) {
-        process.stderr.write(
-          '\n' +
-            renderSimulate(
-              {
-                success: false,
-                error:
-                  'Auto-Simulate skipped — no API key. Set BITBADGES_API_KEY or run `bitbadges-cli config set apiKey <key>`.'
-              },
-              { stream: process.stderr, title: 'Auto-Simulate' }
-            ) +
-            '\n'
-        );
+        const skipResult = {
+          success: false,
+          error:
+            'Auto-Simulate skipped — no API key. Set BITBADGES_API_KEY or run `bitbadges-cli config set apiKey <key>`.'
+        };
+        meta.simulate = skipResult;
+        warnings.push({
+          code: 'simulate.skipped',
+          message: skipResult.error
+        });
+        if (!suppressCommentary) {
+          process.stderr.write(
+            '\n' + renderSimulate(skipResult, { stream: process.stderr, title: 'Auto-Simulate' }) + '\n'
+          );
+        }
       } else {
         const { simulateMessages } = await import('../../builder/tools/queries/simulateTransaction.js');
         const { prefetchSimulateCollections } = await import('../utils/simulateSymbols.js');
@@ -249,23 +282,28 @@ async function emit(
           apiKey,
           apiUrl: getApiUrl(opts)
         });
-        const collectionCache = await prefetchSimulateCollections(result, {
-          apiKey,
-          apiUrl: getApiUrl(opts)
-        });
-        process.stderr.write(
-          '\n' +
-            renderSimulate(result, {
-              stream: process.stderr,
-              title: 'Auto-Simulate',
-              events: opts.events ? 'full' : 'count',
-              collectionCache
-            }) +
-            '\n'
-        );
+        meta.simulate = result;
+        if (!suppressCommentary) {
+          const collectionCache = await prefetchSimulateCollections(result, {
+            apiKey,
+            apiUrl: getApiUrl(opts)
+          });
+          process.stderr.write(
+            '\n' +
+              renderSimulate(result, {
+                stream: process.stderr,
+                title: 'Auto-Simulate',
+                events: opts.events ? 'full' : 'count',
+                collectionCache
+              }) +
+              '\n'
+          );
+        }
       }
     } catch (err) {
-      process.stderr.write(`Simulation skipped: ${err instanceof Error ? err.message : String(err)}\n`);
+      if (!suppressCommentary) {
+        process.stderr.write(`Simulation skipped: ${err instanceof Error ? err.message : String(err)}\n`);
+      }
     }
   }
 
@@ -274,11 +312,31 @@ async function emit(
   // false. Approval msgs already get the Auto-Validate run above; we
   // print the skip note once so the user understands why no gas is
   // shown.
-  if (!opts.jsonOnly && opts.simulate && isUserApprovalTx) {
-    process.stderr.write(
-      '\nAuto-Simulate skipped — wrap user-level approvals inside an alternative approval message to simulate end-to-end. Auto-Validate ran above.\n'
-    );
+  if (opts.simulate && isUserApprovalTx) {
+    warnings.push({
+      code: 'simulate.unsupported',
+      message:
+        'Auto-Simulate skipped — wrap user-level approvals inside an alternative approval message to simulate end-to-end.'
+    });
+    if (!suppressCommentary) {
+      process.stderr.write(
+        '\nAuto-Simulate skipped — wrap user-level approvals inside an alternative approval message to simulate end-to-end. Auto-Validate ran above.\n'
+      );
+    }
   }
+
+  // Emit the single envelope last so the human-eye lands on the JSON
+  // verdict after the streamed commentary. Stdout flushes synchronously
+  // for pipes/files and line-buffered for TTYs, so the visible order
+  // stays stable across both cases. The data slot remains the unmodified
+  // {typeUrl, value} msg so `bb build | bb deploy` keeps working with
+  // zero envelope-aware parsing on the deploy side.
+  emitEnvelope(outData, {
+    condensed: opts.condensed,
+    outputFile: opts.outputFile,
+    warnings: warnings.length > 0 ? warnings : undefined,
+    meta: Object.keys(meta).length > 0 ? meta : undefined
+  });
 
   // ── --deploy-with-browser ───────────────────────────────────────────────
   // Composes build + browser-bridge broadcast in one step. Equivalent

--- a/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
@@ -12,6 +12,7 @@
 import { Command } from 'commander';
 
 import { addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
+import { emit, emitError, commentary } from '../utils/envelope.js';
 import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
 import {
   listBurners,
@@ -64,23 +65,20 @@ burnerCommand
   .usage(' ')
   .description('List all saved burners')
   .option('--network <name>', 'Only show wallets for a specific network')
-  .option('--json', 'Emit as JSON instead of a table')
   .action((opts: any) => {
     let wallets = listBurners();
     if (opts.network) wallets = wallets.filter((w) => w.network === opts.network);
-    if (opts.json) {
-      process.stdout.write(JSON.stringify(wallets, null, 2) + '\n');
-      return;
-    }
     if (wallets.length === 0) {
-      process.stderr.write('No burners saved.\n');
+      commentary('No burners saved.');
+      emit({ wallets: [] });
       return;
     }
     for (const w of wallets) {
-      process.stdout.write(
-        `${w.createdAt}  ${w.network.padEnd(7)}  ${w.status.padEnd(9)}  ${w.address}  ${w.txHash ? `tx=${w.txHash.slice(0, 12)}…` : ''}\n`
+      commentary(
+        `${w.createdAt}  ${w.network.padEnd(7)}  ${w.status.padEnd(9)}  ${w.address}  ${w.txHash ? `tx=${w.txHash.slice(0, 12)}…` : ''}`
       );
     }
+    emit({ wallets });
   });
 
 // ── show ─────────────────────────────────────────────────────────────────────
@@ -93,12 +91,14 @@ burnerCommand
   .action((selector: string) => {
     const rec = findBurner(selector);
     if (!rec) {
-      process.stderr.write(`No burner found for selector: ${selector}\n`);
-      process.exit(1);
+      emitError(new Error(`No burner found for selector: ${selector}`), {
+        code: 'burner_not_found',
+        exitCode: 1
+      });
     }
-    // Intentionally prints the mnemonic — it's a throwaway and the user
-    // may want to recover via Keplr or similar.
-    process.stdout.write(JSON.stringify(rec, null, 2) + '\n');
+    // Intentionally surfaces the mnemonic in `data.mnemonic` — it's a
+    // throwaway and the user may want to recover via Keplr or similar.
+    emit(rec);
   });
 
 // ── resume ───────────────────────────────────────────────────────────────────
@@ -119,8 +119,10 @@ addNetworkOptions(resumeCmd);
 resumeCmd.action(async (selector: string, opts: any) => {
   const rec = findBurner(selector);
   if (!rec) {
-    process.stderr.write(`No burner found for selector: ${selector}\n`);
-    process.exit(1);
+    emitError(new Error(`No burner found for selector: ${selector}`), {
+      code: 'burner_not_found',
+      exitCode: 1
+    });
   }
   const fs = await import('fs');
   const msg = JSON.parse(fs.readFileSync(opts.msgFile, 'utf-8'));
@@ -151,7 +153,7 @@ resumeCmd.action(async (selector: string, opts: any) => {
     nonInteractive: !process.stdout.isTTY,
     pollTimeoutMs: Number(opts.pollTimeout) * 1000
   });
-  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  emit(result);
   if (!result.success && !result.paused) process.exit(1);
 });
 
@@ -236,7 +238,7 @@ sweepCmd.action(async (selector: string, opts: any) => {
     process.stderr.write(`Sweep failed: ${result.error}\n`);
     process.exit(1);
   }
-  process.stdout.write(JSON.stringify({ success: true, txHash: result.txHash, swept: sendAmount.toString() }, null, 2) + '\n');
+  emit({ success: true, txHash: result.txHash, swept: sendAmount.toString() });
 });
 
 // ── forget ───────────────────────────────────────────────────────────────────

--- a/packages/bitbadgesjs-sdk/src/cli/commands/check.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/check.ts
@@ -123,7 +123,7 @@ export const checkCommand = addNetworkOptions(
           ]
         };
         if (opts.json) {
-          output(result, { ...opts, human: false });
+          output(result, { ...opts });
         } else {
           process.stderr.write('▲ WARNING  messages: Transaction has an empty messages array.\n');
         }
@@ -135,7 +135,7 @@ export const checkCommand = addNetworkOptions(
       const result = validateTransaction(wrapped);
 
       if (opts.json) {
-        output(result, { ...opts, human: false });
+        output(result, { ...opts });
       } else {
         const { renderValidate } = await import('../utils/terminal.js');
         const text = renderValidate(result, { stream: process.stdout });
@@ -168,7 +168,7 @@ export const checkCommand = addNetworkOptions(
       }
 
       if (opts.json) {
-        output(result, { ...opts, human: false });
+        output(result, { ...opts });
       } else {
         const { renderReview } = await import('../utils/terminal.js');
         const text = renderReview(result, { stream: process.stdout });
@@ -241,7 +241,7 @@ export const checkCommand = addNetworkOptions(
             filled: firstMsg?.value?._meta?.metadataPlaceholders || {}
           }
         },
-        { ...opts, human: false }
+        { ...opts }
       );
     } else {
       const lines: string[] = [];

--- a/packages/bitbadgesjs-sdk/src/cli/commands/check.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/check.ts
@@ -30,19 +30,18 @@ export const checkCommand = addNetworkOptions(
     .description('Analyze a built transaction or collection. Default: full check (validate + review + metadata). Use --depth to narrow scope.')
     .argument('<input>', 'Tx/collection JSON file path, inline JSON, numeric collection id, or "-" for stdin')
     .option('--depth <level>', 'Check depth: structural | review | full', 'full')
-    .option('--json', 'Output the structured result as JSON')
     .option('--strict', 'Exit 1 on warnings (criticals/errors always exit 2)')
     .option('--no-validate', 'Skip the structural validation section (full depth only)')
     .option('--no-review', 'Skip the design review section (full depth only)')
     .option('--no-metadata', 'Skip the metadata coverage section (full depth only)')
-    .option('--design', 'Include the design decisions (informational ✓/✗) section in full depth output. Hidden by default; the underlying decisions still appear in --json output.')
-    .option('--output-file <path>', 'Write output to file instead of stdout')
+    .option('--design', 'Include the design decisions (informational ✓/✗) section in the envelope payload.')
+    .option('--condensed', 'Single-line JSON (smaller pipe payload)', false)
+    .option('--output-file <path>', 'Write the envelope to file instead of stdout')
 ).action(
   async (
     input: string,
     opts: {
       depth?: string;
-      json?: boolean;
       strict?: boolean;
       validate?: boolean;
       review?: boolean;
@@ -53,25 +52,29 @@ export const checkCommand = addNetworkOptions(
       local?: boolean;
       url?: string;
       outputFile?: string;
+      condensed?: boolean;
     }
   ) => {
+    const { emit, emitError, commentary, isQuiet } = await import('../utils/envelope.js');
     const depth = (opts.depth || 'full').toLowerCase();
     if (!['structural', 'review', 'full'].includes(depth)) {
-      process.stderr.write(`Unknown --depth "${opts.depth}". Use one of: structural, review, full.\n`);
-      process.exit(2);
+      emitError(
+        new Error(`Unknown --depth "${opts.depth}". Use one of: structural, review, full.`),
+        { code: 'invalid_depth', exitCode: 2 }
+      );
     }
 
-    const { readJsonInput, output, getApiUrl, getApiKeyForNetwork } = await import('../utils/io.js');
+    const { readJsonInput, getApiUrl, getApiKeyForNetwork } = await import('../utils/io.js');
 
     // Fetch numeric collection ids from the indexer (review/full depths
     // both accept this — structural validate operates on tx JSON only).
     let raw: any;
     if (/^\d+$/.test(input)) {
       if (depth === 'structural') {
-        process.stderr.write(
-          `Numeric collection ids cannot be structurally validated — pass the tx JSON directly.\n`
+        emitError(
+          new Error('Numeric collection ids cannot be structurally validated — pass the tx JSON directly.'),
+          { code: 'unsupported_input', exitCode: 2 }
         );
-        process.exit(2);
       }
       const baseUrl = getApiUrl(opts);
       const apiKey = getApiKeyForNetwork(opts) || '';
@@ -80,28 +83,32 @@ export const checkCommand = addNetworkOptions(
           headers: { 'x-api-key': apiKey }
         });
         if (!response.ok) {
-          process.stderr.write(
-            `Could not fetch collection ${input} from ${baseUrl} — HTTP ${response.status}.\n` +
-              `Hint: --network local may not have a wired collection-by-id endpoint.\n`
+          emitError(
+            new Error(
+              `Could not fetch collection ${input} from ${baseUrl} — HTTP ${response.status}. ` +
+                'Hint: --network local may not have a wired collection-by-id endpoint.'
+            ),
+            { code: 'fetch_failed', exitCode: 2 }
           );
-          process.exit(2);
         }
         raw = await response.json();
       } catch (err: any) {
-        process.stderr.write(
-          `Could not reach ${baseUrl}/api/v0/collection/${input}: ${err?.message || err}\n`
+        emitError(
+          new Error(`Could not reach ${baseUrl}/api/v0/collection/${input}: ${err?.message || err}`),
+          { code: 'fetch_failed', exitCode: 2 }
         );
-        process.exit(2);
       }
     } else {
       try {
         raw = readJsonInput(input);
       } catch (err: any) {
-        process.stderr.write(
-          `Failed to parse input JSON: ${err?.message || err}\n` +
-            `Accepts: file path, @file.json, inline JSON, numeric collection id, or - for stdin.\n`
+        emitError(
+          new Error(
+            `Failed to parse input JSON: ${err?.message || err}. ` +
+              'Accepts: file path, @file.json, inline JSON, numeric collection id, or - for stdin.'
+          ),
+          { code: 'invalid_input', exitCode: 2 }
         );
-        process.exit(2);
       }
     }
 
@@ -122,11 +129,8 @@ export const checkCommand = addNetworkOptions(
             }
           ]
         };
-        if (opts.json) {
-          output(result, { ...opts });
-        } else {
-          process.stderr.write('▲ WARNING  messages: Transaction has an empty messages array.\n');
-        }
+        commentary('▲ WARNING  messages: Transaction has an empty messages array.');
+        emit(result, opts);
         process.exitCode = 1;
         return;
       }
@@ -134,20 +138,11 @@ export const checkCommand = addNetworkOptions(
       const { validateTransaction } = await import('../../core/validate.js');
       const result = validateTransaction(wrapped);
 
-      if (opts.json) {
-        output(result, { ...opts });
-      } else {
+      if (!isQuiet()) {
         const { renderValidate } = await import('../utils/terminal.js');
-        const text = renderValidate(result, { stream: process.stdout });
-        if (opts.outputFile) {
-          const fsMod = await import('fs');
-          const plain = text.replace(/\x1b\[[0-9;]*m/g, '');
-          fsMod.writeFileSync(opts.outputFile, plain + '\n', 'utf-8');
-          process.stderr.write(`Written to ${opts.outputFile}\n`);
-        } else {
-          console.log(text);
-        }
+        process.stderr.write(renderValidate(result, { stream: process.stderr }) + '\n');
       }
+      emit(result, opts);
 
       if (!result.valid) process.exitCode = 1;
       return;
@@ -160,30 +155,23 @@ export const checkCommand = addNetworkOptions(
       try {
         result = reviewCollection(wrapped);
       } catch (err: any) {
-        process.stderr.write(
-          `Could not review input: ${err?.message || err}\n` +
-            `\`check --depth review\` expects a transaction (with messages[]), a single Msg ({typeUrl,value}), or a complete on-chain collection document.\n`
+        emitError(
+          new Error(
+            `Could not review input: ${err?.message || err}. ` +
+              '`check --depth review` expects a transaction (with messages[]), a single Msg ({typeUrl,value}), or a complete on-chain collection document.'
+          ),
+          { code: 'review_failed', exitCode: 2 }
         );
-        process.exit(2);
       }
 
-      if (opts.json) {
-        output(result, { ...opts });
-      } else {
+      if (!isQuiet()) {
         const { renderReview } = await import('../utils/terminal.js');
-        const text = renderReview(result, { stream: process.stdout });
-        if (opts.outputFile) {
-          const fsMod = await import('fs');
-          const plain = text.replace(/\x1b\[[0-9;]*m/g, '');
-          fsMod.writeFileSync(opts.outputFile, plain + '\n', 'utf-8');
-          process.stderr.write(`Written to ${opts.outputFile}\n`);
-        } else {
-          console.log(text);
-        }
+        process.stderr.write(renderReview(result!, { stream: process.stderr }) + '\n');
       }
+      emit(result, opts);
 
-      if (result.summary.critical > 0) process.exit(2);
-      if (opts.strict && result.summary.warning > 0) process.exit(1);
+      if (result!.summary.critical > 0) process.exit(2);
+      if (opts.strict && result!.summary.warning > 0) process.exit(1);
       return;
     }
 
@@ -230,51 +218,42 @@ export const checkCommand = addNetworkOptions(
       placeholders = collectMetadataPlaceholders(firstMsg);
     }
 
-    if (opts.json) {
-      output(
-        {
-          validate: validation,
-          review,
-          design,
-          metadata: {
-            placeholders,
-            filled: firstMsg?.value?._meta?.metadataPlaceholders || {}
-          }
-        },
-        { ...opts }
-      );
-    } else {
+    if (!isQuiet()) {
       const lines: string[] = [];
       if (validation) {
-        lines.push(renderValidate(validation, { stream: process.stdout }));
+        lines.push(renderValidate(validation, { stream: process.stderr }));
         lines.push('');
       }
       if (review) {
-        lines.push(renderReview(review, { stream: process.stdout }));
+        lines.push(renderReview(review, { stream: process.stderr }));
         lines.push('');
       }
       if (design && opts.design === true) {
-        lines.push(renderDesignDecisions(design, { stream: process.stdout }));
+        lines.push(renderDesignDecisions(design, { stream: process.stderr }));
         lines.push('');
       }
       if (placeholders.length > 0) {
         lines.push(
           renderMetadataPlaceholders(placeholders, firstMsg?.value?._meta?.metadataPlaceholders, {
-            stream: process.stdout
+            stream: process.stderr
           })
         );
       }
       const text = lines.join('\n');
-
-      if (opts.outputFile) {
-        const fsMod = await import('fs');
-        const plain = text.replace(/\x1b\[[0-9;]*m/g, '');
-        fsMod.writeFileSync(opts.outputFile, plain + '\n', 'utf-8');
-        process.stderr.write(`Written to ${opts.outputFile}\n`);
-      } else {
-        console.log(text);
-      }
+      if (text) process.stderr.write(text + '\n');
     }
+    emit(
+      {
+        validate: validation,
+        review,
+        design,
+        metadata: {
+          placeholders,
+          filled: firstMsg?.value?._meta?.metadataPlaceholders || {}
+        }
+      },
+      opts
+    );
 
     const hasValidationErrors = validation && validation.issues?.some((i: any) => i.severity === 'error');
     const hasCritical = review && review.summary?.critical > 0;

--- a/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
@@ -9,9 +9,9 @@
  */
 
 import { Command } from 'commander';
-import * as fs from 'node:fs';
 import { apiRequest, resolveApiKey, resolveBaseUrl } from '../utils/api-client.js';
 import { requireBb1Address } from '../utils/address.js';
+import { emit, emitError } from '../utils/envelope.js';
 import {
   doesCollectionFollowCrowdfundProtocol,
   validateCrowdfundCollection,
@@ -38,20 +38,6 @@ function addNetworkFlags(cmd: Command): Command {
 }
 function addOutputFlags(cmd: Command): Command {
   return cmd.option('--output-file <path>', 'Write to file').option('--condensed', 'Single-line JSON', false);
-}
-function emit(result: unknown, opts: OutputFlags): void {
-  const formatted = opts.condensed ? JSON.stringify(result) : JSON.stringify(result, null, 2);
-  if (opts.outputFile) {
-    fs.writeFileSync(opts.outputFile, formatted + '\n', 'utf-8');
-    process.stderr.write(`Written to ${opts.outputFile}\n`);
-  } else process.stdout.write(formatted + '\n');
-}
-function emitError(err: unknown): never {
-  const e = err as { message?: string; response?: unknown; hint?: string };
-  if (e?.response !== undefined) process.stderr.write(JSON.stringify(e.response, null, 2) + '\n');
-  else process.stderr.write(`Error: ${e?.message ?? String(err)}\n`);
-  if (e?.hint) process.stderr.write(`Hint: ${e.hint}\n`);
-  process.exit(1);
 }
 async function callApi(method: 'GET' | 'POST', path: string, opts: NetworkFlags, body?: unknown): Promise<any> {
   const network = opts.testnet ? 'testnet' : opts.local ? 'local' : 'mainnet';

--- a/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
@@ -192,7 +192,21 @@ function readMsgInput(opts: { msgFile?: string; msgStdin?: boolean; input?: stri
     }
   }
   try {
-    return JSON.parse(raw);
+    const parsed = JSON.parse(raw);
+    // Envelope unwrap: if stdin / file is the CLI envelope shape (e.g.
+    // the direct output of `bb build` post-#0398), extract the msg from
+    // envelope.data. Older inputs that are already `{typeUrl, value}` or
+    // `{messages: [...]}` keep working untouched.
+    if (parsed && typeof parsed === 'object' && 'ok' in parsed && 'data' in parsed) {
+      if (parsed.ok === false) {
+        const code = parsed.error?.code ? `[${parsed.error.code}] ` : '';
+        throw new Error(
+          `Deploy input is an error envelope from a prior CLI step — refusing to broadcast. ${code}${parsed.error?.message ?? 'unknown error'}`
+        );
+      }
+      return parsed.data;
+    }
+    return parsed;
   } catch (err: any) {
     throw new Error(`Failed to parse msg JSON: ${err?.message || err}`);
   }

--- a/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
@@ -481,19 +481,17 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
         apiKey: apiKey || '',
         apiUrl
       });
-      if (process.stdout.isTTY) {
+      const { emit, commentary, isQuiet } = await import('../utils/envelope.js');
+      if (!isQuiet()) {
         const collectionCache = await prefetchSimulateCollections(result, { apiKey: apiKey || '', apiUrl });
-        process.stdout.write(
-          renderSimulate(result, { stream: process.stdout, events: 'count', collectionCache }) + '\n'
-        );
-      } else {
-        process.stdout.write(JSON.stringify({ dryRun: true, ...result }, null, 2) + '\n');
+        commentary(renderSimulate(result, { stream: process.stderr, events: 'count', collectionCache }));
       }
+      emit({ dryRun: true, ...result });
       if (!result.success || result.valid === false) process.exit(1);
       process.exit(0);
     } catch (err: any) {
-      process.stderr.write(`Dry-run simulate failed: ${err?.message || err}\n`);
-      process.exit(1);
+      const { emitError } = await import('../utils/envelope.js');
+      emitError(err, { code: 'dry_run_failed', exitCode: 1 });
     }
   }
 
@@ -595,11 +593,14 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
         }
       }
 
-      process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+      const { emit, emitError } = await import('../utils/envelope.js');
+      emit(payload);
       process.exit(payload.success ? 0 : 1);
+      // (emitError unreachable below; reserved for catch.)
+      void emitError;
     } catch (err: any) {
-      process.stderr.write(`Browser broadcast failed: ${err?.message || err}\n`);
-      process.exit(1);
+      const { emitError } = await import('../utils/envelope.js');
+      emitError(err, { code: 'browser_broadcast_failed', exitCode: 1 });
     }
   }
 
@@ -645,27 +646,24 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
     // Print-only path (legacy default): emit the command + helper notes
     // and exit. The user copy/pastes to broadcast.
     if (!useExec) {
-      if (!process.env.BB_QUIET) {
-        if (isMultiMsg) {
-          const filesNote =
-            msgFilePaths.length > 0
-              ? `Wrote ${msgFilePaths.length} msg JSON file(s):\n  ${msgFilePaths.join('\n  ')}\n`
-              : '';
-          process.stderr.write(`\n${filesNote}Multi-msg tx — chain-binary's tx subcommands only take one msg, so the\nbelow runs them in sequence with a 6s sleep between blocks to avoid\nsequence-skew. NOT atomic: if a later step fails, earlier steps remain\non-chain. For atomic multi-msg, use --burner or --browser.\n\nRun:\n\n`);
-        } else {
-          process.stderr.write(`\nWrote msg JSON to ${msgFilePaths[0]}\nRun:\n\n`);
-        }
+      const { emit, commentary } = await import('../utils/envelope.js');
+      if (isMultiMsg) {
+        const filesNote =
+          msgFilePaths.length > 0
+            ? `Wrote ${msgFilePaths.length} msg JSON file(s):\n  ${msgFilePaths.join('\n  ')}\n`
+            : '';
+        commentary(`\n${filesNote}Multi-msg tx — chain-binary's tx subcommands only take one msg, so the\nbelow runs them in sequence with a 6s sleep between blocks to avoid\nsequence-skew. NOT atomic: if a later step fails, earlier steps remain\non-chain. For atomic multi-msg, use --burner or --browser.\n\nRun:`);
+      } else {
+        commentary(`\nWrote msg JSON to ${msgFilePaths[0]}\nRun:`);
       }
-      process.stdout.write(commandLine + '\n');
-      if (!process.env.BB_QUIET) {
-        const flagsHint = isMultiMsg
-          ? '\n  Append extra flags inside any step (e.g. --fees 5000ubadge --memo "...").\n'
-          : '\n  Append extra flags after the line (e.g. --fees 5000ubadge --memo "...").\n';
-        process.stderr.write(
-          flagsHint + '  Use --keyring-backend test for non-interactive CI signing.\n' +
-            '  Or pass --exec to run the command in place (TTY-friendly).\n'
-        );
-      }
+      const flagsHint = isMultiMsg
+        ? 'Append extra flags inside any step (e.g. --fees 5000ubadge --memo "...").'
+        : 'Append extra flags after the line (e.g. --fees 5000ubadge --memo "...").';
+      commentary(commandLine);
+      commentary(
+        `  ${flagsHint}\n  Use --keyring-backend test for non-interactive CI signing.\n  Or pass --exec to run the command in place (TTY-friendly).`
+      );
+      emit({ commandLine, msgFilePaths, mode: 'print-only', multiMsg: isMultiMsg });
       process.exit(0);
     }
 
@@ -764,7 +762,8 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
       }
     }
 
-    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    const { emit } = await import('../utils/envelope.js');
+    emit(payload);
     process.exit(payload.success ? 0 : 1);
   }
 
@@ -860,11 +859,12 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
         ...(waited.ok ? { body: waited.body } : { lastStatus: waited.lastStatus })
       };
     }
-    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    const { emit } = await import('../utils/envelope.js');
+    emit(payload);
     if (!result.success && !result.paused) process.exit(1);
     if (result.paused) process.exit(0);
   } catch (err: any) {
-    process.stderr.write(`Broadcast failed: ${err?.message || err}\n`);
-    process.exit(1);
+    const { emitError } = await import('../utils/envelope.js');
+    emitError(err, { code: 'broadcast_failed', exitCode: 1 });
   }
 });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/doctor.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/doctor.spec.ts
@@ -14,11 +14,12 @@ describe('doctorCommand shape', () => {
     expect(doctorCommand.commands.length).toBe(0);
   });
 
-  it('exposes --json + --with-preview + network selectors', () => {
+  it('exposes envelope output flags + --with-preview + network selectors', () => {
     const longs = (doctorCommand.options as any[]).map((o) => o.long);
     expect(longs).toEqual(
       expect.arrayContaining([
-        '--json',
+        '--condensed',
+        '--output-file',
         '--with-preview',
         '--network',
         '--mainnet',

--- a/packages/bitbadgesjs-sdk/src/cli/commands/doctor.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/doctor.ts
@@ -24,12 +24,13 @@ interface DoctorCheck {
 export const doctorCommand = addNetworkOptions(
   new Command('doctor')
     .description("Environment + connectivity health check. Verifies Node/SDK/config/API key/MCP bin/session integrity. Pass --with-preview to also probe the indexer's shareable-preview upload + fetch roundtrip.")
-    .option('--json', 'Output the full DoctorReport as JSON')
+    .option('--condensed', 'Single-line JSON (smaller pipe payload)', false)
+    .option('--output-file <path>', 'Write the envelope to file instead of stdout')
     .option(
       '--with-preview',
       'Add a preview-roundtrip probe: builds a minimal tx, POSTs it to /api/v0/builder/preview, GETs it back by code, and asserts the round trip is byte-equivalent.'
     )
-).action(async (opts: { json?: boolean; withPreview?: boolean; network?: 'mainnet' | 'local' | 'testnet'; testnet?: boolean; local?: boolean; url?: string }) => {
+).action(async (opts: { condensed?: boolean; outputFile?: string; withPreview?: boolean; network?: 'mainnet' | 'local' | 'testnet'; testnet?: boolean; local?: boolean; url?: string }) => {
   const checks: DoctorCheck[] = [];
 
   // 1. Node version
@@ -306,14 +307,13 @@ export const doctorCommand = addNetworkOptions(
     }
   }
 
-  // Render
-  if (opts.json) {
-    const { output: outputFn } = await import('../utils/io.js');
-    outputFn(checks, { ...opts, human: false });
-  } else {
+  // Render: scorecard to stderr as commentary (unless --quiet); envelope
+  // to stdout always so pipes always see structured data.
+  const { isQuiet } = await import('../utils/envelope.js');
+  if (!isQuiet()) {
     const { makeColor, rule } = await import('../utils/terminal.js');
-    const { c } = makeColor(process.stdout);
-    const width = Math.min(80, (process.stdout as any).columns || 80);
+    const { c } = makeColor(process.stderr);
+    const width = Math.min(80, (process.stderr as any).columns || 80);
     const lines: string[] = [];
     lines.push(c('gray', rule('━', width, 'Doctor')));
     lines.push('');
@@ -343,8 +343,10 @@ export const doctorCommand = addNetworkOptions(
       } skip`
     );
     lines.push(c('gray', rule('━', width)));
-    console.log(lines.join('\n'));
+    process.stderr.write(lines.join('\n') + '\n');
   }
+  const { output: outputFn } = await import('../utils/io.js');
+  outputFn(checks, { ...opts });
 
   if (checks.some((ch) => ch.status === 'fail')) process.exit(2);
 });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/explain.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/explain.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { addNetworkOptions } from '../utils/io.js';
-import { addFormatOptions, resolveFormat, successEnvelope } from '../utils/envelope.js';
+import { emit, addOutputOptions } from '../utils/envelope.js';
 
 /**
  * Plain-English explanation of a transaction body or a collection.
@@ -9,15 +9,14 @@ import { addFormatOptions, resolveFormat, successEnvelope } from '../utils/envel
  * interpretCollection(). Numeric input is treated as a collection id and
  * fetched from the API.
  */
-export const explainCommand = addFormatOptions(
+export const explainCommand = addOutputOptions(
   addNetworkOptions(
     new Command('explain')
       .description('Explain a transaction or collection in plain English. Input: JSON file, inline JSON, numeric collection ID, or - for stdin.')
       .argument('<input>', 'Tx / collection JSON file path, inline JSON, numeric collection id, or "-" for stdin')
-      .option('--output-file <path>', 'Write output to file instead of stdout')
   )
 ).action(
-  async (input: string, opts: { network?: 'mainnet' | 'local' | 'testnet'; testnet?: boolean; local?: boolean; url?: string; outputFile?: string; format?: string; json?: boolean }) => {
+  async (input: string, opts: { network?: 'mainnet' | 'local' | 'testnet'; testnet?: boolean; local?: boolean; url?: string; outputFile?: string; condensed?: boolean }) => {
     const { readJsonInput, getApiUrl, getApiKeyForNetwork } = await import('../utils/io.js');
     let data: any;
     let fetchedCollection = false;
@@ -119,17 +118,6 @@ export const explainCommand = addFormatOptions(
       process.exit(2);
     }
 
-    const format = resolveFormat({ format: opts.format, json: opts.json });
-    const output = format === 'json'
-      ? JSON.stringify(successEnvelope({ kind, messages, fullText: text }), null, 2) + '\n'
-      : text + '\n';
-
-    if (opts.outputFile) {
-      const fsMod = await import('fs');
-      fsMod.writeFileSync(opts.outputFile, output, 'utf-8');
-      process.stderr.write(`Written to ${opts.outputFile}\n`);
-    } else {
-      process.stdout.write(output);
-    }
+    emit({ kind, messages, fullText: text }, opts);
   }
 );

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-list-id.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-list-id.spec.ts
@@ -25,11 +25,14 @@ describe('genListIdCommand shape', () => {
 describe('genListIdCommand behavior', () => {
   // Drive the command via Commander's own parser (parseAsync) so the
   // variadic args + option flags walk through the same code path as the
-  // CLI binary.
-  it('rejects non-address inputs with a clear error', async () => {
-    const errs: string[] = [];
-    const errSpy = jest.spyOn(console, 'error').mockImplementation((m: any) => {
-      errs.push(String(m));
+  // CLI binary. Post-#0398 the command always emits an envelope to
+  // stdout (process.stdout.write) — invalid input still exits 2 but the
+  // error envelope lands on stdout, not stderr console.error.
+  it('rejects non-address inputs with an error envelope', async () => {
+    const writes: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((c: any) => {
+      writes.push(typeof c === 'string' ? c : c.toString());
+      return true;
     });
     const exitSpy = jest
       .spyOn(process, 'exit')
@@ -41,19 +44,21 @@ describe('genListIdCommand behavior', () => {
       await expect(
         genListIdCommand.parseAsync(['alice', 'charlie'], { from: 'user' }),
       ).rejects.toThrow(/__exit__:2/);
-      expect(errs.join('\n')).toMatch(/invalid address/i);
-      expect(errs.join('\n')).toMatch(/alice/);
-      expect(errs.join('\n')).toMatch(/charlie/);
+      const out = writes.join('');
+      expect(out).toMatch(/invalid address/i);
+      expect(out).toMatch(/alice/);
+      expect(out).toMatch(/charlie/);
     } finally {
-      errSpy.mockRestore();
+      stdoutSpy.mockRestore();
       exitSpy.mockRestore();
     }
   });
 
   it('accepts well-formed bb1 addresses', async () => {
-    const logs: string[] = [];
-    const logSpy = jest.spyOn(console, 'log').mockImplementation((m: any) => {
-      logs.push(String(m));
+    const writes: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((c: any) => {
+      writes.push(typeof c === 'string' ? c : c.toString());
+      return true;
     });
     try {
       await genListIdCommand.parseAsync(
@@ -63,27 +68,33 @@ describe('genListIdCommand behavior', () => {
         ],
         { from: 'user' },
       );
-      expect(logs[0]).toMatch(
+      const env = JSON.parse(writes.join(''));
+      expect(env.ok).toBe(true);
+      expect(env.data.listId).toMatch(
         /^bb1kt3vp977rqxekursm0agj26ep4c6ksp6dfjpdx:bb1m0cjg3mvjynjj3rt00wgk3m58shpp3z5w6gc7k$/,
       );
     } finally {
-      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
     }
   });
 
   it('--blacklist produces the !(...) wrapper', async () => {
-    const logs: string[] = [];
-    const logSpy = jest.spyOn(console, 'log').mockImplementation((m: any) => {
-      logs.push(String(m));
+    const writes: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((c: any) => {
+      writes.push(typeof c === 'string' ? c : c.toString());
+      return true;
     });
     try {
       await genListIdCommand.parseAsync(
         ['--blacklist', 'bb1kt3vp977rqxekursm0agj26ep4c6ksp6dfjpdx'],
         { from: 'user' },
       );
-      expect(logs[0]).toMatch(/^!\(bb1kt3vp977rqxekursm0agj26ep4c6ksp6dfjpdx\)$/);
+      const env = JSON.parse(writes.join(''));
+      expect(env.ok).toBe(true);
+      expect(env.data.listId).toMatch(/^!\(bb1kt3vp977rqxekursm0agj26ep4c6ksp6dfjpdx\)$/);
+      expect(env.data.mode).toBe('blacklist');
     } finally {
-      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
     }
   });
 });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-list-id.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-list-id.ts
@@ -1,33 +1,35 @@
 import { Command } from 'commander';
+import { addOutputOptions, emit, emitError } from '../utils/envelope.js';
 
-export const genListIdCommand = new Command('gen-list-id')
-  .description('Generate a reserved address list ID from a set of addresses.')
-  .argument('<addresses...>', 'One or more addresses to include in the list')
-  .option('--blacklist', 'Treat as blacklist (default is whitelist)')
-  .action(async (addresses: string[], opts: { blacklist?: boolean }) => {
-    const { generateReservedListId } = await import('../../core/addressLists.js');
-    const { isAddressValid } = await import('../../address-converter/converter.js');
+export const genListIdCommand = addOutputOptions(
+  new Command('gen-list-id')
+    .description('Generate a reserved address list ID from a set of addresses.')
+    .argument('<addresses...>', 'One or more addresses to include in the list')
+    .option('--blacklist', 'Treat as blacklist (default is whitelist)')
+).action(async (addresses: string[], opts: { blacklist?: boolean; condensed?: boolean; outputFile?: string }) => {
+  const { generateReservedListId } = await import('../../core/addressLists.js');
+  const { isAddressValid } = await import('../../address-converter/converter.js');
 
-    // Validate every input is a well-formed address. The underlying
-    // generateReservedListId() falls back to the raw string for invalid
-    // inputs — silently emitting nonsense like "alice:charlie" as a list ID
-    // that the chain will reject. Fail loud here so agents catch typos at
-    // the CLI boundary.
-    const invalid = addresses.filter((a) => !isAddressValid(a));
-    if (invalid.length > 0) {
-      console.error(
-        `error: invalid address(es): ${invalid.join(', ')}. Expected bb1... or 0x... format.`,
-      );
-      process.exit(2);
-    }
+  // Validate every input is a well-formed address. The underlying
+  // generateReservedListId() falls back to the raw string for invalid
+  // inputs — silently emitting nonsense like "alice:charlie" as a list ID
+  // that the chain will reject. Fail loud here so agents catch typos at
+  // the CLI boundary.
+  const invalid = addresses.filter((a) => !isAddressValid(a));
+  if (invalid.length > 0) {
+    emitError(
+      new Error(`invalid address(es): ${invalid.join(', ')}. Expected bb1... or 0x... format.`),
+      { code: 'invalid_address', exitCode: 2 }
+    );
+  }
 
-    const whitelist = !opts.blacklist;
-    const listId = generateReservedListId({
-      listId: '',
-      addresses,
-      whitelist,
-      uri: '',
-      customData: ''
-    });
-    console.log(listId);
+  const whitelist = !opts.blacklist;
+  const listId = generateReservedListId({
+    listId: '',
+    addresses,
+    whitelist,
+    uri: '',
+    customData: ''
   });
+  emit({ listId, mode: whitelist ? 'whitelist' : 'blacklist', addresses }, opts);
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-pub-key.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-pub-key.ts
@@ -30,6 +30,7 @@ import { Command } from 'commander';
 import { addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
 import { NETWORK_CONFIGS } from '../../signing/types.js';
 import { convertToBitBadgesAddress, convertToEthAddress, cosmosAddressFromPublicKey } from '../../address-converter/converter.js';
+import { emit, emitError } from '../utils/envelope.js';
 
 /**
  * Canonical message used for the recovery flow. Distinct from any
@@ -193,7 +194,7 @@ addNetworkOptions(genPubKeyCommand);
 genPubKeyCommand.action(async (opts) => {
   // --print-message: tell the user exactly what to sign.
   if (opts.printMessage) {
-    process.stdout.write(PUBKEY_DERIVATION_MESSAGE + '\n');
+    emit({ message: PUBKEY_DERIVATION_MESSAGE });
     return;
   }
 
@@ -203,8 +204,7 @@ genPubKeyCommand.action(async (opts) => {
     address = convertToBitBadgesAddress(String(opts.address));
     if (!address) throw new Error('not a valid address');
   } catch (err: any) {
-    process.stderr.write(`Invalid --address: ${err?.message || err}\n`);
-    process.exit(2);
+    emitError(err, { code: 'invalid_address', exitCode: 2 });
   }
 
   const networkName = resolveNetwork(opts);
@@ -242,26 +242,27 @@ genPubKeyCommand.action(async (opts) => {
       const warnSection = warnings.length > 0
         ? `Lookup warnings:\n${warnings.map((w) => `  - ${w}`).join('\n')}\n\n`
         : '';
-      process.stderr.write(
-        `Public key not found in the indexer (${baseUrl}) or chain LCD (${nodeUrl}).\n` +
-          'This typically means the address has never broadcast a tx or signed in.\n\n' +
-          warnSection +
-          'To derive the pub key offline:\n' +
-          '  1. Sign this exact message with your wallet (Keplr signArbitrary, hardware wallet, or any ADR-36-capable signer):\n\n' +
-          `    ${PUBKEY_DERIVATION_MESSAGE}\n\n` +
-          '  2. Re-run with the resulting base64 signature:\n' +
-          `     bitbadges-cli gen-pub-key --address ${address} --signature <base64>\n\n` +
-          '  Print the message verbatim with: bitbadges-cli gen-pub-key --print-message\n'
+      emitError(
+        new Error(
+          `Public key not found in the indexer (${baseUrl}) or chain LCD (${nodeUrl}).\n` +
+            'This typically means the address has never broadcast a tx or signed in.\n\n' +
+            warnSection +
+            'To derive the pub key offline:\n' +
+            '  1. Sign this exact message with your wallet (Keplr signArbitrary, hardware wallet, or any ADR-36-capable signer):\n\n' +
+            `    ${PUBKEY_DERIVATION_MESSAGE}\n\n` +
+            '  2. Re-run with the resulting base64 signature:\n' +
+            `     bitbadges-cli gen-pub-key --address ${address} --signature <base64>\n\n` +
+            '  Print the message verbatim with: bitbadges-cli gen-pub-key --print-message'
+        ),
+        { code: 'pubkey_not_found', exitCode: 2 }
       );
-      process.exit(2);
     }
     const message = String(opts.message ?? PUBKEY_DERIVATION_MESSAGE);
     try {
       pubKey = await recoverPubKey(message, String(opts.signature), address);
       source = 'signature';
     } catch (err: any) {
-      process.stderr.write(`${err?.message || err}\n`);
-      process.exit(1);
+      emitError(err, { code: 'pubkey_recovery_failed', exitCode: 1 });
     }
   }
 
@@ -275,10 +276,5 @@ genPubKeyCommand.action(async (opts) => {
     // Some addresses (e.g. derived from non-secp256k1 keys) don't have a stable EVM form. Best effort.
   }
 
-  process.stdout.write(JSON.stringify({
-    pubKey,
-    bb1Address,
-    ethAddress,
-    source,
-  }, null, 2) + '\n');
+  emit({ pubKey, bb1Address, ethAddress, source });
 });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
@@ -23,6 +23,7 @@ import { NETWORK_CONFIGS } from '../../signing/types.js';
 import { createTransactionPayload } from '../../transactions/messages/base.js';
 import { encodeTokenizationMsgFromJson, supportedTokenizationTypeUrls } from '../../transactions/messages/bitbadges/tokenization/fromJson.js';
 import { evmToCosmosAddress } from '../../transactions/precompile/helpers.js';
+import { emit, emitError } from '../utils/envelope.js';
 
 interface MsgEntry {
   typeUrl: string;
@@ -124,8 +125,7 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
     const raw = readMsgInput({ input: positional, msgFile: opts.msgFile, msgStdin: opts.msgStdin });
     messagesInput = normalizeMessages(raw);
   } catch (err: any) {
-    process.stderr.write(`${err?.message || err}\n`);
-    process.exit(2);
+    emitError(err, { code: 'invalid_input', exitCode: 2 });
   }
 
   // Resolve sender / EVM address. The user passes one address via --from;
@@ -146,9 +146,12 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
       const { convertToEthAddress } = await import('../../address-converter/converter.js');
       evmAddress = convertToEthAddress(senderAddress);
     } catch (err: any) {
-      process.stderr.write(`Failed to derive EVM address from ${senderAddress}: ${err?.message || err}\n`);
-      process.stderr.write('Pass --evm-from 0x... explicitly.\n');
-      process.exit(2);
+      emitError(
+        new Error(
+          `Failed to derive EVM address from ${senderAddress}: ${err?.message || err}. Pass --evm-from 0x... explicitly.`
+        ),
+        { code: 'evm_derive_failed', exitCode: 2 }
+      );
     }
   }
 
@@ -171,16 +174,21 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
         if (sequence === undefined) sequence = info.sequence;
         if (!publicKey && info.publicKey) publicKey = info.publicKey;
       } catch (err: any) {
-        process.stderr.write(`Indexer fetch failed: ${err?.message || err}\n`);
-        process.stderr.write('If running offline, pass --no-fetch with --account-number and --sequence (and --public-key if you want Cosmos sign payloads).\n');
-        process.exit(1);
+        emitError(
+          new Error(
+            `Indexer fetch failed: ${err?.message || err}. If running offline, pass --no-fetch with --account-number and --sequence (and --public-key if you want Cosmos sign payloads).`
+          ),
+          { code: 'indexer_fetch_failed', exitCode: 1 }
+        );
       }
     }
   }
 
   if (accountNumber === undefined || sequence === undefined) {
-    process.stderr.write('Missing --account-number / --sequence. Re-run without --no-fetch, or supply both flags.\n');
-    process.exit(2);
+    emitError(
+      new Error('Missing --account-number / --sequence. Re-run without --no-fetch, or supply both flags.'),
+      { code: 'missing_account_info', exitCode: 2 }
+    );
   }
 
   // publicKey is required for Cosmos sign payloads (signDirect, legacyAmino).
@@ -191,13 +199,14 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
   // Cosmos AuthInfo).
   const wantCosmosPayloads = !!publicKey;
   if (!wantCosmosPayloads && !evmAddress) {
-    process.stderr.write(
-      'No public key available for ' + senderAddress + ' and no EVM address provided. ' +
-      'Either:\n' +
-      '  • Pass --public-key <b64> (for Cosmos signDirect/legacyAmino), or\n' +
-      '  • Use an EVM address via --from 0x... or --evm-from 0x... (emits evmTx only).\n'
+    emitError(
+      new Error(
+        'No public key available for ' + senderAddress + ' and no EVM address provided. ' +
+          'Either: (1) pass --public-key <b64> (for Cosmos signDirect/legacyAmino), or ' +
+          '(2) use an EVM address via --from 0x... or --evm-from 0x... (emits evmTx only).'
+      ),
+      { code: 'missing_signer', exitCode: 2 }
     );
-    process.exit(2);
   }
 
   // Convert each {typeUrl, value} JSON into a proto Message via the SDK's
@@ -207,9 +216,12 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
   try {
     protoMessages = messagesInput.map((m) => encodeTokenizationMsgFromJson(m));
   } catch (err: any) {
-    process.stderr.write(`Failed to encode message: ${err?.message || err}\n`);
-    process.stderr.write(`Supported typeUrls: ${supportedTokenizationTypeUrls().join(', ')}\n`);
-    process.exit(2);
+    emitError(
+      new Error(
+        `Failed to encode message: ${err?.message || err}. Supported typeUrls: ${supportedTokenizationTypeUrls().join(', ')}`
+      ),
+      { code: 'encode_failed', exitCode: 2 }
+    );
   }
 
   // Hand the proto messages to createTransactionPayload — the same SDK
@@ -242,8 +254,7 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
       protoMessages
     );
   } catch (err: any) {
-    process.stderr.write(`createTransactionPayload failed: ${err?.message || err}\n`);
-    process.exit(1);
+    emitError(err, { code: 'create_payload_failed', exitCode: 1 });
   }
 
   // Serialize the proto TxBody / AuthInfo to base64 so the JSON output is
@@ -296,5 +307,5 @@ genTxPayloadCommand.action(async (positional: string | undefined, opts: any) => 
     'Need a tx-bytes-only flow without managing TxRaw assembly? Use `bitbadges-cli deploy --browser --sign-only` instead — that hands the wallet the signing UI and returns ready-to-broadcast bytes.',
   ];
 
-  process.stdout.write(JSON.stringify(envelope, null, 2) + '\n');
+  emit(envelope);
 });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/lookup.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/lookup.ts
@@ -1,77 +1,68 @@
 import { Command } from 'commander';
+import { addOutputOptions, emit, emitError } from '../utils/envelope.js';
 
-export const lookupCommand = new Command('lookup')
-  .description('Look up token info by symbol — returns IBC denom, decimals, backing address, and supported networks. Omit symbol to list all tokens.')
-  .argument('[symbol]', 'Token symbol (e.g. USDC, BADGE). Omit to list all known tokens.')
-  .option('--output-file <path>', 'Write output to file instead of stdout')
-  .action(async (symbol: string | undefined, opts: { outputFile?: string }) => {
-    const { MAINNET_COINS_REGISTRY, TESTNET_COINS_REGISTRY } = await import('../../common/constants.js');
+export const lookupCommand = addOutputOptions(
+  new Command('lookup')
+    .description('Look up token info by symbol — returns IBC denom, decimals, backing address, and supported networks. Omit symbol to list all tokens.')
+    .argument('[symbol]', 'Token symbol (e.g. USDC, BADGE). Omit to list all known tokens.')
+).action(async (symbol: string | undefined, opts: { outputFile?: string; condensed?: boolean }) => {
+  const { MAINNET_COINS_REGISTRY, TESTNET_COINS_REGISTRY } = await import('../../common/constants.js');
 
-    const allSymbols = new Map<string, { symbol: string; ibcDenom: string; decimals: number; networks: string[] }>();
+  const allSymbols = new Map<string, { symbol: string; ibcDenom: string; decimals: number; networks: string[] }>();
 
-    for (const [denom, coin] of Object.entries(MAINNET_COINS_REGISTRY)) {
-      const key = coin.symbol.toUpperCase();
-      const existing = allSymbols.get(key);
-      if (existing) {
-        if (!existing.networks.includes('mainnet')) existing.networks.push('mainnet');
-      } else {
-        allSymbols.set(key, { symbol: coin.symbol, ibcDenom: denom, decimals: Number(coin.decimals), networks: ['mainnet'] });
-      }
-    }
-
-    for (const [denom, coin] of Object.entries(TESTNET_COINS_REGISTRY)) {
-      const key = coin.symbol.toUpperCase();
-      const existing = allSymbols.get(key);
-      if (existing) {
-        if (!existing.networks.includes('testnet')) existing.networks.push('testnet');
-      } else {
-        allSymbols.set(key, { symbol: coin.symbol, ibcDenom: denom, decimals: Number(coin.decimals), networks: ['testnet'] });
-      }
-    }
-
-    if (!symbol) {
-      const tokens = Array.from(allSymbols.values()).map((t) => ({
-        symbol: t.symbol,
-        ibcDenom: t.ibcDenom,
-        decimals: t.decimals,
-        networks: t.networks
-      }));
-      const result = JSON.stringify(tokens, null, 2);
-      if (opts.outputFile) {
-        const fs = await import('fs');
-        fs.writeFileSync(opts.outputFile, result + '\n', 'utf-8');
-        process.stderr.write(`Written to ${opts.outputFile}\n`);
-      } else {
-        console.log(result);
-      }
-      return;
-    }
-
-    const entry = allSymbols.get(symbol.toUpperCase());
-    if (!entry) {
-      console.error(`Unknown token "${symbol}". Known tokens: ${Array.from(allSymbols.keys()).join(', ')}`);
-      process.exit(1);
-    }
-
-    let backingAddress = '';
-    if (entry.ibcDenom.startsWith('ibc/')) {
-      const { generateAliasAddressForIBCBackedDenom } = await import('../../core/aliases.js');
-      backingAddress = generateAliasAddressForIBCBackedDenom(entry.ibcDenom);
-    }
-
-    const result = JSON.stringify({
-      symbol: entry.symbol,
-      ibcDenom: entry.ibcDenom,
-      decimals: entry.decimals,
-      networks: entry.networks,
-      ...(backingAddress ? { backingAddress } : {})
-    }, null, 2);
-
-    if (opts.outputFile) {
-      const fs = await import('fs');
-      fs.writeFileSync(opts.outputFile, result + '\n', 'utf-8');
-      process.stderr.write(`Written to ${opts.outputFile}\n`);
+  for (const [denom, coin] of Object.entries(MAINNET_COINS_REGISTRY)) {
+    const key = coin.symbol.toUpperCase();
+    const existing = allSymbols.get(key);
+    if (existing) {
+      if (!existing.networks.includes('mainnet')) existing.networks.push('mainnet');
     } else {
-      console.log(result);
+      allSymbols.set(key, { symbol: coin.symbol, ibcDenom: denom, decimals: Number(coin.decimals), networks: ['mainnet'] });
     }
-  });
+  }
+
+  for (const [denom, coin] of Object.entries(TESTNET_COINS_REGISTRY)) {
+    const key = coin.symbol.toUpperCase();
+    const existing = allSymbols.get(key);
+    if (existing) {
+      if (!existing.networks.includes('testnet')) existing.networks.push('testnet');
+    } else {
+      allSymbols.set(key, { symbol: coin.symbol, ibcDenom: denom, decimals: Number(coin.decimals), networks: ['testnet'] });
+    }
+  }
+
+  if (!symbol) {
+    const tokens = Array.from(allSymbols.values()).map((t) => ({
+      symbol: t.symbol,
+      ibcDenom: t.ibcDenom,
+      decimals: t.decimals,
+      networks: t.networks
+    }));
+    emit({ tokens }, opts);
+    return;
+  }
+
+  const entry = allSymbols.get(symbol.toUpperCase());
+  if (!entry) {
+    emitError(
+      new Error(`Unknown token "${symbol}". Known tokens: ${Array.from(allSymbols.keys()).join(', ')}`),
+      { code: 'unknown_token', exitCode: 1 }
+    );
+  }
+
+  let backingAddress = '';
+  if (entry!.ibcDenom.startsWith('ibc/')) {
+    const { generateAliasAddressForIBCBackedDenom } = await import('../../core/aliases.js');
+    backingAddress = generateAliasAddressForIBCBackedDenom(entry!.ibcDenom);
+  }
+
+  emit(
+    {
+      symbol: entry!.symbol,
+      ibcDenom: entry!.ibcDenom,
+      decimals: entry!.decimals,
+      networks: entry!.networks,
+      ...(backingAddress ? { backingAddress } : {})
+    },
+    opts
+  );
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/preview.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/preview.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { addNetworkOptions } from '../utils/io.js';
+import { addOutputOptions, emit, emitError, commentary } from '../utils/envelope.js';
 
 function ensureTxWrapper(input: any): any {
   if (!input || typeof input !== 'object') return input;
@@ -8,20 +9,21 @@ function ensureTxWrapper(input: any): any {
   return input;
 }
 
-export const previewCommand = addNetworkOptions(
-  new Command('preview')
-    .description('Upload a tx to the indexer and print a shareable bitbadges.io preview URL. Input: JSON file, inline JSON, or - for stdin.')
-    .argument('<input>', 'Tx JSON file path, inline JSON, or "-" for stdin')
-    .option(
-      '--frontend-url <url>',
-      'Override the bitbadges.io frontend base for the printed preview URL',
-      'https://bitbadges.io'
-    )
-    .option('--json', 'Output the structured upload result as JSON instead of just the URL')
+export const previewCommand = addOutputOptions(
+  addNetworkOptions(
+    new Command('preview')
+      .description('Upload a tx to the indexer and print a shareable bitbadges.io preview URL. Input: JSON file, inline JSON, or - for stdin.')
+      .argument('<input>', 'Tx JSON file path, inline JSON, or "-" for stdin')
+      .option(
+        '--frontend-url <url>',
+        'Override the bitbadges.io frontend base for the printed preview URL',
+        'https://bitbadges.io'
+      )
+  )
 ).action(
   async (
     input: string,
-    opts: { network?: 'mainnet' | 'local' | 'testnet'; testnet?: boolean; local?: boolean; url?: string; frontendUrl?: string; json?: boolean }
+    opts: { network?: 'mainnet' | 'local' | 'testnet'; testnet?: boolean; local?: boolean; url?: string; frontendUrl?: string; condensed?: boolean; outputFile?: string }
   ) => {
     const { readJsonInput, getApiUrl } = await import('../utils/io.js');
 
@@ -39,11 +41,12 @@ export const previewCommand = addNetworkOptions(
             : typeof wrapped === 'object'
               ? `object with keys [${Object.keys(wrapped).join(', ')}]`
               : typeof wrapped;
-      process.stderr.write(
-        `Preview input has an unexpected shape — expected \`{messages: [{typeUrl, value}, ...]}\` or a single Msg \`{typeUrl, value}\`.\n` +
-          `Got: ${got}.\n`
+      emitError(
+        new Error(
+          `Preview input has an unexpected shape — expected \`{messages: [{typeUrl, value}, ...]}\` or a single Msg \`{typeUrl, value}\`. Got: ${got}.`
+        ),
+        { code: 'invalid_shape', exitCode: 2 }
       );
-      process.exit(2);
     }
 
     // Normalize msg type (Universal → Create/Update). The placeholder
@@ -72,17 +75,18 @@ export const previewCommand = addNetworkOptions(
         body: JSON.stringify(payload)
       });
     } catch (err) {
-      process.stderr.write(`Preview upload failed: ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(2);
+      emitError(err, { code: 'preview_upload_failed', exitCode: 2 });
     }
 
-    if (!response.ok) {
-      const text = await response.text().catch(() => '');
-      process.stderr.write(`Preview upload failed: HTTP ${response.status} ${text}\n`);
-      process.exit(2);
+    if (!response!.ok) {
+      const text = await response!.text().catch(() => '');
+      emitError(
+        new Error(`Preview upload failed: HTTP ${response!.status} ${text}`),
+        { code: 'preview_upload_failed', exitCode: 2 }
+      );
     }
 
-    const result = (await response.json()) as {
+    const result = (await response!.json()) as {
       success: boolean;
       code: string;
       expiresAt: number;
@@ -92,22 +96,10 @@ export const previewCommand = addNetworkOptions(
     const frontendBase = opts.frontendUrl || 'https://bitbadges.io';
     const previewUrl = `${frontendBase.replace(/\/$/, '')}/builder/preview?code=${encodeURIComponent(result.code)}`;
 
-    if (opts.json) {
-      process.stdout.write(
-        JSON.stringify(
-          {
-            code: result.code,
-            url: previewUrl,
-            expiresAt: result.expiresAt,
-            expiresIn: result.expiresIn
-          },
-          null,
-          2
-        ) + '\n'
-      );
-    } else {
-      process.stdout.write(previewUrl + '\n');
-      process.stderr.write(`Expires in ${result.expiresIn}.\n`);
-    }
+    commentary(`Expires in ${result.expiresIn}.`);
+    emit(
+      { code: result.code, url: previewUrl, expiresAt: result.expiresAt, expiresIn: result.expiresIn },
+      opts
+    );
   }
 );

--- a/packages/bitbadgesjs-sdk/src/cli/commands/price.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/price.spec.ts
@@ -23,7 +23,7 @@ describe('priceCommand shape', () => {
   it('exposes network + output flags', () => {
     const longFlags = (priceCommand.options as any[]).map((o) => o.long);
     expect(longFlags).toEqual(
-      expect.arrayContaining(['--testnet', '--local', '--url', '--api-key', '--output-file', '--format', '--json'])
+      expect.arrayContaining(['--testnet', '--local', '--url', '--api-key', '--output-file', '--condensed'])
     );
   });
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/price.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/price.ts
@@ -16,7 +16,7 @@
  */
 
 import { Command } from 'commander';
-import { addFormatOptions, resolveFormat, successEnvelope, errorEnvelope, writeJsonEnvelope } from '../utils/envelope.js';
+import { addOutputOptions, emit, errorEnvelope, writeJsonEnvelope } from '../utils/envelope.js';
 import { apiRequest, resolveApiKey, resolveBaseUrl } from '../utils/api-client.js';
 
 interface PriceFlags {
@@ -24,9 +24,8 @@ interface PriceFlags {
   local?: boolean;
   url?: string;
   apiKey?: string;
-  format?: 'json' | 'text';
-  json?: boolean;
   outputFile?: string;
+  condensed?: boolean;
 }
 
 interface AssetPairRow {
@@ -74,25 +73,7 @@ async function resolveDenoms(inputs: string[], opts: PriceFlags): Promise<{ inpu
   return out;
 }
 
-function renderText(rows: { input: string; denom?: string; symbol?: string; price?: number; percentageChange24h?: number; volume24h?: number; error?: string }[]): string {
-  const lines: string[] = [];
-  for (const r of rows) {
-    if (r.error) {
-      lines.push(`${r.input}\t(${r.error})`);
-      continue;
-    }
-    const pieces = [`${r.symbol ?? r.denom ?? r.input}\t${r.price ?? '?'} usd`];
-    if (r.percentageChange24h !== undefined) {
-      const change = r.percentageChange24h;
-      pieces.push(`24h: ${change >= 0 ? '+' : ''}${change.toFixed(2)}%`);
-    }
-    if (r.volume24h !== undefined) pieces.push(`vol: ${Math.round(r.volume24h).toLocaleString()}`);
-    lines.push(pieces.join('\t'));
-  }
-  return lines.join('\n') + '\n';
-}
-
-export const priceCommand = addFormatOptions(
+export const priceCommand = addOutputOptions(
   new Command('price')
     .description('Indexer-served USD price lookup for BitBadges-chain assets. Accepts denoms (ubadge, ibc/...) or symbols (BADGE) — symbols resolve via /assetPairs/search. Cross-chain prices live in `bb swap` (Skip:Go).')
     .argument('<denoms-or-symbols...>', 'Repeated args or comma-separated. e.g. ubadge, BADGE, ibc/F082B65C...')
@@ -100,7 +81,6 @@ export const priceCommand = addFormatOptions(
     .option('--local', 'Use local API (localhost:3001)', false)
     .option('--url <url>', 'Custom API base URL')
     .option('--api-key <key>', 'BitBadges API key')
-    .option('--output-file <path>', 'Write output to file instead of stdout.')
 )
   .addHelpText(
     'after',
@@ -170,26 +150,13 @@ cross-chain assets not on BitBadges chain, use \`bb swap\` (Skip:Go-backed).
     });
 
     const unresolved = rows.filter((r) => r.error).map((r) => r.input);
-    const env = successEnvelope(
+    emit(
       { prices: rows, ...(unresolved.length > 0 ? { unresolved } : {}) },
       {
+        ...opts,
         hint: unresolved.length > 0
           ? `Some inputs returned no data. Cross-chain assets aren't on the BitBadges indexer — use \`bb swap\` for those.`
           : undefined
       }
     );
-
-    if (opts.outputFile) {
-      const fs = await import('node:fs');
-      fs.writeFileSync(opts.outputFile, JSON.stringify(env, null, 2) + '\n', 'utf-8');
-      process.stderr.write(`Written to ${opts.outputFile}\n`);
-      return;
-    }
-
-    const format = resolveFormat(opts);
-    if (format === 'text') {
-      process.stdout.write(renderText(rows));
-    } else {
-      writeJsonEnvelope(env);
-    }
   });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/resources.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/resources.spec.ts
@@ -44,17 +44,19 @@ describe('resourcesCommand behavior', () => {
     };
   };
 
-  it('list --uris prints one URI per line, all bitbadges:// prefixed', async () => {
+  it('list --uris surfaces every URI in envelope.data.uris', async () => {
     const cap = captureStdout();
     try {
       await resourcesCommand.parseAsync(['list', '--uris'], { from: 'user' });
     } finally {
       cap.restore();
     }
-    const lines = cap.chunks.join('').trim().split('\n');
-    expect(lines.length).toBeGreaterThan(0);
-    for (const line of lines) {
-      expect(line).toMatch(/^bitbadges:\/\//);
+    const env = JSON.parse(cap.chunks.join(''));
+    expect(env.ok).toBe(true);
+    expect(Array.isArray(env.data.uris)).toBe(true);
+    expect(env.data.uris.length).toBeGreaterThan(0);
+    for (const uri of env.data.uris) {
+      expect(uri).toMatch(/^bitbadges:\/\//);
     }
   });
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/resources.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/resources.ts
@@ -4,31 +4,30 @@ import {
   listResources,
   readResource
 } from '../../builder/tools/registry.js';
+import { addOutputOptions, emit } from '../utils/envelope.js';
 
 export const resourcesCommand = new Command('resources')
   .description('Read static builder resources (token registry, recipes, skills, docs, error patterns, ...).');
 
-resourcesCommand
-  .command('list')
-  .description('List every resource with its metadata as JSON.')
-  .option('--uris', 'Print only resource URIs, one per line')
-  .action((opts: { uris?: boolean }) => {
-    if (opts.uris) {
-      for (const uri of Object.keys(resourceRegistry)) {
-        process.stdout.write(`${uri}\n`);
-      }
-      return;
-    }
-    process.stdout.write(JSON.stringify(listResources(), null, 2) + '\n');
-  });
+addOutputOptions(
+  resourcesCommand
+    .command('list')
+    .description('List every resource with its metadata as JSON.')
+    .option('--uris', 'Surface only resource URIs in envelope.data.uris (one entry per resource)')
+).action((opts: { uris?: boolean; condensed?: boolean; outputFile?: string }) => {
+  if (opts.uris) {
+    emit({ uris: Object.keys(resourceRegistry) }, opts);
+    return;
+  }
+  emit({ resources: listResources() }, opts);
+});
 
-resourcesCommand
-  .command('read <uri>')
-  .description('Read a resource body by URI (e.g. bitbadges://recipes/all).')
-  .action((uri: string) => {
-    const result = readResource(uri);
-    process.stdout.write(result.text + '\n');
-    if (result.isError) {
-      process.exitCode = 1;
-    }
-  });
+addOutputOptions(
+  resourcesCommand
+    .command('read <uri>')
+    .description('Read a resource body by URI (e.g. bitbadges://recipes/all). The body text lives at envelope.data.text.')
+).action((uri: string, opts: { condensed?: boolean; outputFile?: string }) => {
+  const result = readResource(uri);
+  emit({ uri, text: result.text, isError: !!result.isError }, opts);
+  if (result.isError) process.exitCode = 1;
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/sign-with-browser.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/sign-with-browser.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs';
 import { Command } from 'commander';
 import { addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
 import { bridgeSign, resolveFrontendUrl } from '../auth/browser-bridge.js';
+import { emit, emitError, commentary } from '../utils/envelope.js';
 
 function readMessage(opts: { message?: string; messageFile?: string; positional?: string }): string {
   if (opts.message) return opts.message;
@@ -46,8 +47,7 @@ signWithBrowserCommand.action(async (positional: string | undefined, opts: any) 
   try {
     message = readMessage({ message: opts.message, messageFile: opts.messageFile, positional });
   } catch (err: any) {
-    process.stderr.write(`${err?.message || err}\n`);
-    process.exit(2);
+    emitError(err, { code: 'invalid_input', exitCode: 2 });
   }
 
   const networkName = resolveNetwork(opts);
@@ -56,12 +56,12 @@ signWithBrowserCommand.action(async (positional: string | undefined, opts: any) 
   const frontendUrl = resolveFrontendUrl(networkName, opts.frontendUrl);
   const requestedTimeoutSec = opts.timeout ? Math.min(1800, Math.max(60, Number(opts.timeout))) : 300;
 
-  process.stderr.write(`\nOpening browser to ${frontendUrl}/sign for wallet signature...\n`);
+  commentary(`\nOpening browser to ${frontendUrl}/sign for wallet signature...`);
 
   try {
     const result = await bridgeSign({
       mode: 'msg',
-      payload: { message, expectedAddress: opts.expectedAddress },
+      payload: { message: message!, expectedAddress: opts.expectedAddress },
       baseUrl,
       frontendUrl,
       apiKey,
@@ -70,21 +70,24 @@ signWithBrowserCommand.action(async (positional: string | undefined, opts: any) 
       port: opts.port ? Number(opts.port) : undefined,
     });
     if (result.error) {
-      process.stderr.write(`Sign cancelled or rejected: ${result.error}\n`);
-      process.exit(1);
+      emitError(new Error(`Sign cancelled or rejected: ${result.error}`), {
+        code: 'sign_rejected',
+        exitCode: 1
+      });
     }
     if (!result.signature) {
-      process.stderr.write('Browser bridge returned no signature.\n');
-      process.exit(1);
+      emitError(new Error('Browser bridge returned no signature.'), {
+        code: 'sign_failed',
+        exitCode: 1
+      });
     }
-    process.stdout.write(JSON.stringify({
+    emit({
       signature: result.signature,
       address: result.address,
       publicKey: result.publicKey,
-      chain: result.chain,
-    }, null, 2) + '\n');
+      chain: result.chain
+    });
   } catch (err: any) {
-    process.stderr.write(`Browser sign failed: ${err?.message || err}\n`);
-    process.exit(1);
+    emitError(err, { code: 'browser_sign_failed', exitCode: 1 });
   }
 });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/simulate.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/simulate.ts
@@ -18,15 +18,17 @@ export const simulateCommand = addNetworkOptions(
   new Command('simulate')
     .description('Dry-run a built tx against the BitBadges API simulate endpoint. Returns gas + per-address net balance changes. Input: JSON file, inline JSON, or - for stdin.')
     .argument('<input>', 'Tx JSON file path, inline JSON, or "-" for stdin')
-    .option('--json', 'Output the structured SimulateResult as JSON instead of a rendered section')
     .option('--creator <address>', 'Override the simulation context address (default: bb1simulation)')
     .option('--events', 'Dump the full raw chain events array in the rendered output (default: just the count)')
+    .option('--condensed', 'Single-line JSON (smaller pipe payload)', false)
+    .option('--output-file <path>', 'Write the envelope to file instead of stdout')
 ).action(async (
   input: string,
   opts: {
-    json?: boolean;
     creator?: string;
     events?: boolean;
+    condensed?: boolean;
+    outputFile?: string;
     network?: 'mainnet' | 'local' | 'testnet';
     testnet?: boolean;
     local?: boolean;
@@ -110,21 +112,23 @@ export const simulateCommand = addNetworkOptions(
     apiUrl: getApiUrl(opts)
   });
 
-  if (opts.json) {
-    output(result, { ...opts, human: false });
-  } else {
+  // Per-msg breakdown to stderr as commentary (unless --quiet); envelope
+  // to stdout always so pipes always see structured data.
+  const { isQuiet } = await import('../utils/envelope.js');
+  if (!isQuiet()) {
     const collectionCache = await prefetchSimulateCollections(result, {
       apiKey,
       apiUrl: getApiUrl(opts)
     });
-    console.log(
+    process.stderr.write(
       renderSimulate(result, {
-        stream: process.stdout,
+        stream: process.stderr,
         events: opts.events ? 'full' : 'count',
         collectionCache
-      })
+      }) + '\n'
     );
   }
+  output(result, { ...opts });
 
   if (!result.success || result.valid === false) process.exit(2);
 });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/tool.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/tool.ts
@@ -60,20 +60,21 @@ export const toolCommand = new Command('tool')
       process.env.BITBADGES_API_URL = 'https://api-testnet.bitbadges.io';
     }
 
+    const { emit, emitError } = await import('../utils/envelope.js');
+
     if (!toolRegistry[toolName]) {
       const available = Object.keys(toolRegistry).sort().join(', ');
-      process.stderr.write(`Unknown tool: ${toolName}\nAvailable tools: ${available}\n`);
-      process.exitCode = 1;
-      return;
+      emitError(new Error(`Unknown tool: ${toolName}. Available tools: ${available}`), {
+        code: 'unknown_tool',
+        exitCode: 1
+      });
     }
 
     let parsedArgs: any;
     try {
       parsedArgs = parseArgs(opts.args, opts.argsFile);
     } catch (err) {
-      process.stderr.write(`${(err as Error).message}\n`);
-      process.exitCode = 1;
-      return;
+      emitError(err, { code: 'invalid_args', exitCode: 1 });
     }
 
     const sessionId = resolveSessionId(parsedArgs, opts.session);
@@ -82,9 +83,7 @@ export const toolCommand = new Command('tool')
       try {
         loadSessionFromDisk(sessionId);
       } catch (err) {
-        process.stderr.write(`${(err as Error).message}\n`);
-        process.exitCode = 1;
-        return;
+        emitError(err, { code: 'session_load_failed', exitCode: 1 });
       }
       if (parsedArgs && typeof parsedArgs === 'object' && parsedArgs.sessionId === undefined) {
         parsedArgs.sessionId = sessionId;
@@ -101,11 +100,16 @@ export const toolCommand = new Command('tool')
       }
     }
 
-    if (opts.raw) {
-      process.stdout.write(JSON.stringify(result.result, null, 2) + '\n');
-    } else {
-      process.stdout.write(result.text + '\n');
-    }
+    // The tool wraps its return value in `{result, text, isError}`. We
+    // surface the structured `result` as the envelope's `data` payload
+    // and stash the human-readable `text` on `meta.text` so agents that
+    // want either flavor have one shape to parse. `--raw` is preserved
+    // as a no-op flag (deprecated; envelope.data IS the structured
+    // result now) — keep it accepted for one release to avoid breaking
+    // scripts that pass it.
+    emit(result.result, {
+      meta: result.text ? { text: result.text } : undefined
+    });
 
     // Tools may surface failures two ways:
     //   1. `result.isError = true` (the wrapper throws / rejects)

--- a/packages/bitbadgesjs-sdk/src/cli/commands/tools.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/tools.ts
@@ -1,15 +1,15 @@
 import { Command } from 'commander';
 import { toolRegistry, listTools } from '../../builder/tools/registry.js';
+import { addOutputOptions, emit } from '../utils/envelope.js';
 
-export const toolsCommand = new Command('tools')
-  .description('List every fine-grained builder tool with its JSON schema. Use `tool <name>` to invoke one.')
-  .option('--names', 'Print only tool names, one per line')
-  .action((opts: { names?: boolean }) => {
-    if (opts.names) {
-      for (const name of Object.keys(toolRegistry)) {
-        process.stdout.write(`${name}\n`);
-      }
-      return;
-    }
-    process.stdout.write(JSON.stringify(listTools(), null, 2) + '\n');
-  });
+export const toolsCommand = addOutputOptions(
+  new Command('tools')
+    .description('List every fine-grained builder tool with its JSON schema. Use `tool <name>` to invoke one.')
+    .option('--names', 'Surface only tool names in envelope.data.names (one entry per tool)')
+).action((opts: { names?: boolean; condensed?: boolean; outputFile?: string }) => {
+  if (opts.names) {
+    emit({ names: Object.keys(toolRegistry) }, opts);
+    return;
+  }
+  emit({ tools: listTools() }, opts);
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/tx.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/tx.ts
@@ -11,10 +11,8 @@ import { Command } from 'commander';
 import { addNetworkOptions, resolveNetwork, type NetworkOptions } from '../utils/io.js';
 import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
 import {
-  Envelope,
-  addFormatOptions,
+  addOutputOptions,
   errorEnvelope,
-  resolveFormat,
   successEnvelope,
   writeJsonEnvelope
 } from '../utils/envelope.js';
@@ -218,30 +216,6 @@ function dataFromResult(hash: string, result: FetchResult): TxStatusData {
   return shapeTxData(hash, result.txResponse);
 }
 
-function renderText(data: TxStatusData): string {
-  const lines: string[] = [];
-  const status = data.code === 0 ? 'committed' : 'failed';
-  lines.push(`Status:    ${status}  (code ${data.code}${data.codespace ? `, ${data.codespace}` : ''})`);
-  lines.push(`Via:       ${data.via === 'evm' ? 'EVM RPC' : 'Cosmos LCD'}`);
-  lines.push(`Hash:      ${data.hash}`);
-  if (data.height) lines.push(`Height:    ${data.height}`);
-  if (data.gasUsed) lines.push(`Gas used:  ${data.gasUsed}${data.gasWanted ? ` / ${data.gasWanted}` : ''}`);
-  if (data.timestamp) lines.push(`Timestamp: ${data.timestamp}`);
-  if (data.collectionId) lines.push(`Collection: ${data.collectionId}`);
-  if (data.code !== 0 && data.log) lines.push('', `Log: ${data.log}`);
-  return lines.join('\n');
-}
-
-function emitEnvelope(env: Envelope<unknown>, format: 'json' | 'text', textRender?: () => string): void {
-  if (format === 'json') {
-    writeJsonEnvelope(env);
-  } else if (env.ok && textRender) {
-    process.stdout.write(textRender() + '\n');
-  } else if (!env.ok) {
-    process.stderr.write(`Error: ${env.error?.message ?? 'unknown'}\n`);
-  }
-}
-
 // ── tx (parent) ────────────────────────────────────────────────────────
 
 export const txCommand = new Command('tx').description(
@@ -250,23 +224,22 @@ export const txCommand = new Command('tx').description(
 
 // ── tx status ──────────────────────────────────────────────────────────
 
-addFormatOptions(
+addOutputOptions(
   addNetworkOptions(txCommand.command('status'))
     .description('Fetch one tx by hash. Tries Cosmos LCD first, falls through to EVM RPC for keccak256 hashes. Exit 0 on commit, 1 on chain-fail, 2 on RPC error / tx-not-found.')
     .argument('<hash>', 'Tx hash (Cosmos sha256 or EVM keccak256; with or without 0x prefix; case-insensitive)')
     .option('--node-url <url>', 'Chain LCD URL override (defaults to NETWORK_CONFIGS[network].nodeUrl)')
     .option('--evm-rpc-url <url>', 'EVM JSON-RPC URL override (defaults to NETWORK_CONFIGS[network].evmRpcUrl)')
-).action(async (hash: string, opts: NodeUrlOptions & { format?: string; json?: boolean }) => {
+).action(async (hash: string, opts: NodeUrlOptions & { condensed?: boolean; outputFile?: string }) => {
   const nodeUrl = getNodeUrl(opts);
   const evmRpcUrl = getEvmRpcUrl(opts);
-  const format = resolveFormat({ format: opts.format, json: opts.json });
   const normalized = normalizeHash(hash);
 
   let result: FetchResult;
   try {
     result = await fetchTxStatus(nodeUrl, evmRpcUrl, normalized);
   } catch (err: any) {
-    emitEnvelope(errorEnvelope('rpc_error', err?.message || String(err)), format);
+    writeJsonEnvelope(errorEnvelope('rpc_error', err?.message || String(err)), opts);
     process.exit(2);
   }
 
@@ -279,19 +252,18 @@ addFormatOptions(
     const hint = result.httpStatus === 404
       ? `Tx may not be indexed yet — try \`tx wait ${normalized} --timeout 60\`.`
       : undefined;
-    emitEnvelope(errorEnvelope(code, msg, result.errorBody, hint), format);
+    writeJsonEnvelope(errorEnvelope(code, msg, result.errorBody, hint), opts);
     process.exit(2);
   }
 
   const data = dataFromResult(normalized, result);
-  const env = successEnvelope(data);
-  emitEnvelope(env, format, () => renderText(data));
+  writeJsonEnvelope(successEnvelope(data), opts);
   process.exit(data.code === 0 ? 0 : 1);
 });
 
 // ── tx wait ────────────────────────────────────────────────────────────
 
-addFormatOptions(
+addOutputOptions(
   addNetworkOptions(txCommand.command('wait'))
     .description('Poll until a tx commits or fails. Tries Cosmos LCD first, falls through to EVM RPC. Exit 0 on commit, 1 on chain-fail, 2 on timeout.')
     .argument('<hash>', 'Tx hash (Cosmos sha256 or EVM keccak256; with or without 0x prefix; case-insensitive)')
@@ -302,11 +274,10 @@ addFormatOptions(
 ).action(
   async (
     hash: string,
-    opts: NodeUrlOptions & { format?: string; json?: boolean; timeout?: string; interval?: string }
+    opts: NodeUrlOptions & { condensed?: boolean; outputFile?: string; timeout?: string; interval?: string }
   ) => {
     const nodeUrl = getNodeUrl(opts);
     const evmRpcUrl = getEvmRpcUrl(opts);
-    const format = resolveFormat({ format: opts.format, json: opts.json });
     const normalized = normalizeHash(hash);
     const timeoutMs = Math.max(1, Number(opts.timeout || '60')) * 1000;
     const intervalMs = Math.max(500, Number(opts.interval || '2') * 1000);
@@ -324,7 +295,7 @@ addFormatOptions(
       }
       if (result.found) {
         const data = dataFromResult(normalized, result);
-        emitEnvelope(successEnvelope(data), format, () => renderText(data));
+        writeJsonEnvelope(successEnvelope(data), opts);
         process.exit(data.code === 0 ? 0 : 1);
       }
       // 404 = tx not yet indexed (on either side) → keep waiting.
@@ -334,13 +305,15 @@ addFormatOptions(
     }
 
     const msg = `Timed out after ${opts.timeout || '60'}s waiting for ${normalized}.${lastFetchErr ? ` Last error: ${lastFetchErr}` : ''}`;
-    const env = errorEnvelope(
-      'timeout',
-      msg,
-      { hash: normalized, timeoutSeconds: Number(opts.timeout || '60') },
-      `Re-run \`tx status ${normalized}\` later, or extend with --timeout <seconds>.`
+    writeJsonEnvelope(
+      errorEnvelope(
+        'timeout',
+        msg,
+        { hash: normalized, timeoutSeconds: Number(opts.timeout || '60') },
+        `Re-run \`tx status ${normalized}\` later, or extend with --timeout <seconds>.`
+      ),
+      opts
     );
-    emitEnvelope(env, format);
     process.exit(2);
   }
 );

--- a/packages/bitbadgesjs-sdk/src/cli/commands/url.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/url.ts
@@ -14,6 +14,7 @@
 
 import { Command } from 'commander';
 import * as fs from 'node:fs';
+import { emit as emitEnvelope, emitError } from '../utils/envelope.js';
 
 interface OutputFlags { outputFile?: string; condensed?: boolean; raw?: boolean; }
 interface NetworkFlags { testnet?: boolean; }
@@ -25,8 +26,12 @@ function addOutputFlags(cmd: Command): Command {
   return cmd
     .option('--output-file <path>', 'Write output to file')
     .option('--condensed', 'Single-line JSON', false)
-    .option('--raw', 'Emit only the URL on stdout (no JSON envelope) — useful for piping into `open` / `xdg-open`.', false);
+    .option('--raw', 'Emit only the URL string (no envelope) — useful for piping into `open` / `xdg-open`.', false);
 }
+// `bb url` keeps a `--raw` escape hatch because pipelines like
+// `bb url tx 0xabc | open` expect a bare URL string, and the
+// `| jq -r .data.url` alternative is awkward. Otherwise the envelope is
+// emitted exactly like every other CLI verb.
 function emit(url: string, payload: Record<string, unknown>, opts: OutputFlags): void {
   if (opts.raw) {
     if (opts.outputFile) {
@@ -37,17 +42,10 @@ function emit(url: string, payload: Record<string, unknown>, opts: OutputFlags):
     }
     return;
   }
-  const formatted = opts.condensed ? JSON.stringify(payload) : JSON.stringify(payload, null, 2);
-  if (opts.outputFile) {
-    fs.writeFileSync(opts.outputFile, formatted + '\n', 'utf-8');
-    process.stderr.write(`Written to ${opts.outputFile}\n`);
-  } else {
-    process.stdout.write(formatted + '\n');
-  }
+  emitEnvelope(payload, opts);
 }
 function fail(code: number, message: string): never {
-  process.stderr.write(`Error: ${message}\n`);
-  process.exit(code);
+  emitError(new Error(message), { code: 'url_error', exitCode: code });
 }
 
 const APP_BASE = (testnet: boolean) => (testnet ? 'https://testnet.bitbadges.io' : 'https://bitbadges.io');

--- a/packages/bitbadgesjs-sdk/src/cli/integration/cli-build-pipeline.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/cli-build-pipeline.spec.ts
@@ -245,7 +245,7 @@ describe('cli build pipeline integration', () => {
       // Use --depth structural; full check on a default smart-token flags
       // a CRITICAL "forceful transfers not locked" review finding which
       // would exit 2 even though the validate section is clean.
-      const out = runCli(['check', tmp, '--json', '--depth', 'structural']);
+      const out = runCli(['check', tmp, '--depth', 'structural']);
       expect(out.exitCode).toBe(0);
       // structural depth returns the validate section directly (not wrapped).
       expect(out.json.valid).toBe(true);
@@ -259,7 +259,7 @@ describe('cli build pipeline integration', () => {
         '--name', 'T', '--image', IMG, '--description', 'D', '--creator', CREATOR
       ]).json;
       const tmp = writeTmp(built);
-      const out = runCli(['check', tmp, '--json'], { throwOnError: false });
+      const out = runCli(['check', tmp], { throwOnError: false });
       // Validate section must be clean — the noForcefulPostMintTransfers
       // critical comes from the review section, not validate.
       expect(out.json.validate.valid).toBe(true);
@@ -271,7 +271,7 @@ describe('cli build pipeline integration', () => {
         '--name', 'T', '--image', IMG, '--description', 'D', '--creator', CREATOR
       ]).json;
       const tmp = writeTmp(built);
-      const out = runCli(['check', tmp, '--json', '--depth', 'structural']);
+      const out = runCli(['check', tmp, '--depth', 'structural']);
       expect(out.exitCode).toBe(0);
     });
 

--- a/packages/bitbadgesjs-sdk/src/cli/integration/cli-discovery.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/cli-discovery.spec.ts
@@ -14,25 +14,25 @@
 import { runCli } from './harness/cli.js';
 
 describe('bb tools', () => {
-  it('lists every tool with a JSON schema (default JSON dump)', () => {
+  it('lists every tool with a JSON schema in envelope.data.tools', () => {
     const out = runCli(['tools']);
     expect(out.exitCode).toBe(0);
-    expect(Array.isArray(out.json)).toBe(true);
-    expect(out.json.length).toBeGreaterThan(0);
+    expect(Array.isArray(out.json.tools)).toBe(true);
+    expect(out.json.tools.length).toBeGreaterThan(0);
     // Each entry must have at least name + description + inputSchema.
-    for (const t of out.json) {
+    for (const t of out.json.tools) {
       expect(typeof t.name).toBe('string');
       expect(typeof t.description).toBe('string');
       expect(t.inputSchema).toBeDefined();
     }
   });
 
-  it('--names emits one tool name per line', () => {
-    const out = runCli(['tools', '--names'], { parseJson: false });
+  it('--names surfaces tool names in envelope.data.names', () => {
+    const out = runCli(['tools', '--names']);
     expect(out.exitCode).toBe(0);
-    const names = out.stdout.split('\n').filter((l) => l.trim());
+    const names: string[] = out.json.names;
+    expect(Array.isArray(names)).toBe(true);
     expect(names.length).toBeGreaterThan(0);
-    // Sanity check: well-known tools must be present.
     expect(names).toContain('validate_transaction');
     expect(names).toContain('lookup_token_info');
   });
@@ -58,29 +58,30 @@ describe('bb tool <name>', () => {
 });
 
 describe('bb resources', () => {
-  it('list returns an array of resource descriptors', () => {
+  it('list returns resource descriptors in envelope.data.resources', () => {
     const out = runCli(['resources', 'list']);
     expect(out.exitCode).toBe(0);
-    expect(Array.isArray(out.json)).toBe(true);
-    expect(out.json.length).toBeGreaterThan(0);
-    for (const r of out.json) {
+    expect(Array.isArray(out.json.resources)).toBe(true);
+    expect(out.json.resources.length).toBeGreaterThan(0);
+    for (const r of out.json.resources) {
       expect(typeof r.uri).toBe('string');
       expect(r.uri).toMatch(/^bitbadges:\/\//);
       expect(typeof r.name).toBe('string');
     }
   });
 
-  it('read returns the body of a known resource', () => {
+  it('read returns the body of a known resource in envelope.data.text', () => {
     const list = runCli(['resources', 'list']);
-    const first = list.json[0];
-    const out = runCli(['resources', 'read', first.uri], { parseJson: false });
+    const first = list.json.resources[0];
+    const out = runCli(['resources', 'read', first.uri]);
     expect(out.exitCode).toBe(0);
-    expect(out.stdout.length).toBeGreaterThan(0);
+    expect(typeof out.json.text).toBe('string');
+    expect(out.json.text.length).toBeGreaterThan(0);
   });
 
   it('read on an unknown URI exits non-zero', () => {
     const out = runCli(['resources', 'read', 'bitbadges://does-not-exist'], {
-      throwOnError: false, parseJson: false
+      throwOnError: false
     });
     expect(out.exitCode).not.toBe(0);
   });

--- a/packages/bitbadgesjs-sdk/src/cli/integration/cli-discovery.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/cli-discovery.spec.ts
@@ -41,11 +41,10 @@ describe('bb tools', () => {
 describe('bb tool <name>', () => {
   it('lookup_token_info returns the token registry shape', () => {
     // Schema field name is `query` (free-form symbol/denom), not `symbol`.
-    // Query USDC (not BADGE): the builder's coinRegistry only stocks
-    // IBC-backed denoms — see buildSymbolToTokenInfoMap in
-    // src/builder/sdk/coinRegistry.ts. BADGE is the native ubadge denom
-    // and isn't in this lookup table.
-    const out = runCli(['tool', 'lookup_token_info', '--args', '{"query":"USDC"}']);
+    // BADGE (native ubadge) MUST be queryable post-#0398 — the registry
+    // filter that excluded it was removed because agents reasonably ask
+    // for the native token's decimals / denom resolution.
+    const out = runCli(['tool', 'lookup_token_info', '--args', '{"query":"BADGE"}']);
     expect(out.exitCode).toBe(0);
     expect(out.json).toBeDefined();
   });

--- a/packages/bitbadgesjs-sdk/src/cli/integration/cli-discovery.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/cli-discovery.spec.ts
@@ -41,7 +41,11 @@ describe('bb tools', () => {
 describe('bb tool <name>', () => {
   it('lookup_token_info returns the token registry shape', () => {
     // Schema field name is `query` (free-form symbol/denom), not `symbol`.
-    const out = runCli(['tool', 'lookup_token_info', '--args', '{"query":"BADGE"}']);
+    // Query USDC (not BADGE): the builder's coinRegistry only stocks
+    // IBC-backed denoms — see buildSymbolToTokenInfoMap in
+    // src/builder/sdk/coinRegistry.ts. BADGE is the native ubadge denom
+    // and isn't in this lookup table.
+    const out = runCli(['tool', 'lookup_token_info', '--args', '{"query":"USDC"}']);
     expect(out.exitCode).toBe(0);
     expect(out.json).toBeDefined();
   });

--- a/packages/bitbadgesjs-sdk/src/cli/integration/cli-local-state.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/cli-local-state.spec.ts
@@ -108,49 +108,55 @@ describe('bb burner', () => {
     };
   }
 
-  it('list returns "No burners saved." when none exist', () => {
-    const out = runCli(['burner', 'list'], { env: envWithCfgDir(), parseJson: false });
+  it('list returns an empty wallets array when none exist', () => {
+    // The "No burners saved" stderr commentary is gated by --quiet /
+    // BB_QUIET (runCli sets BB_QUIET=1 for clean stdout assertions), so
+    // we don't check it here — agents care about the structured
+    // data.wallets:[] signal anyway.
+    const out = runCli(['burner', 'list'], { env: envWithCfgDir() });
     expect(out.exitCode).toBe(0);
-    expect(out.stderr + out.stdout).toMatch(/No burners saved/);
+    expect(out.json.wallets).toEqual([]);
   });
 
-  it('list prints seeded burners', () => {
+  it('list surfaces seeded burners in envelope.data.wallets', () => {
     seedBurner(exampleRecord({ address: 'bb1one', createdAt: '2026-05-01T00:00:00.000Z' }));
     seedBurner(exampleRecord({ address: 'bb1two', createdAt: '2026-05-02T00:00:00.000Z' }));
-    const out = runCli(['burner', 'list'], { env: envWithCfgDir(), parseJson: false });
-    expect(out.stdout).toContain('bb1one');
-    expect(out.stdout).toContain('bb1two');
+    const out = runCli(['burner', 'list'], { env: envWithCfgDir() });
+    const addresses = out.json.wallets.map((w: any) => w.address);
+    expect(addresses).toContain('bb1one');
+    expect(addresses).toContain('bb1two');
   });
 
-  it('list --json emits an array of records', () => {
+  it('list always emits envelope.data.wallets — no separate --json flag', () => {
     seedBurner(exampleRecord({ address: 'bb1jsontest' }));
-    const out = runCli(['burner', 'list', '--json'], { env: envWithCfgDir() });
-    expect(Array.isArray(out.json)).toBe(true);
-    expect(out.json.length).toBe(1);
-    expect(out.json[0].address).toBe('bb1jsontest');
+    const out = runCli(['burner', 'list'], { env: envWithCfgDir() });
+    expect(Array.isArray(out.json.wallets)).toBe(true);
+    expect(out.json.wallets.length).toBe(1);
+    expect(out.json.wallets[0].address).toBe('bb1jsontest');
   });
 
   it('list --network filters by network', () => {
     seedBurner(exampleRecord({ address: 'bb1mainnet', network: 'mainnet' }));
     seedBurner(exampleRecord({ address: 'bb1local', network: 'local', createdAt: '2026-05-02T00:00:00.000Z' }));
-    const out = runCli(['burner', 'list', '--network', 'local', '--json'], { env: envWithCfgDir() });
-    expect(out.json.length).toBe(1);
-    expect(out.json[0].address).toBe('bb1local');
+    const out = runCli(['burner', 'list', '--network', 'local'], { env: envWithCfgDir() });
+    expect(out.json.wallets.length).toBe(1);
+    expect(out.json.wallets[0].address).toBe('bb1local');
   });
 
   it('show returns the seeded record by address', () => {
     seedBurner(exampleRecord({ address: 'bb1showme' }));
-    const out = runCli(['burner', 'show', 'bb1showme'], { env: envWithCfgDir(), parseJson: false });
+    const out = runCli(['burner', 'show', 'bb1showme'], { env: envWithCfgDir() });
     expect(out.exitCode).toBe(0);
-    expect(out.stdout).toContain('bb1showme');
+    expect(out.json.address).toBe('bb1showme');
   });
 
-  it('show with unknown selector exits non-zero', () => {
+  it('show with unknown selector exits non-zero with an error envelope', () => {
     const out = runCli(['burner', 'show', 'bb1missing'], {
-      env: envWithCfgDir(), throwOnError: false, parseJson: false
+      env: envWithCfgDir(), throwOnError: false
     });
     expect(out.exitCode).not.toBe(0);
-    expect(out.stderr).toMatch(/No burner found/);
+    expect(out.envelope.ok).toBe(false);
+    expect(out.envelope.error.message).toMatch(/No burner found/);
   });
 
   it('forget deletes the recovery file', () => {

--- a/packages/bitbadgesjs-sdk/src/cli/integration/harness/cli.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/harness/cli.ts
@@ -17,7 +17,14 @@ export interface RunCliResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+  /**
+   * Parsed stdout, automatically unwrapped from the envelope shape
+   * (`{ok, data, ...}`) so existing tests that look at `.json.<field>`
+   * keep working post-#0398. The envelope is preserved on `.envelope`.
+   */
   json?: any;
+  /** Raw envelope (full {ok, data, warnings, error, hint?}) when stdout was JSON. */
+  envelope?: any;
 }
 
 export interface RunCliOptions {
@@ -62,7 +69,18 @@ export function runCli(args: string[], opts: RunCliOptions = {}): RunCliResult {
 
   if (opts.parseJson !== false && stdout.trim()) {
     try {
-      result.json = JSON.parse(stdout);
+      const parsed = JSON.parse(stdout);
+      // Post-#0398, every data-emitting command emits `{ok, data, ...}`.
+      // Unwrap automatically so tests can keep writing `out.json.<field>`
+      // without each one having to .data-step through the envelope.
+      // Preserve the raw envelope on `.envelope` for tests that need to
+      // inspect warnings / error.code / hint.
+      if (parsed && typeof parsed === 'object' && 'ok' in parsed && 'data' in parsed) {
+        result.envelope = parsed;
+        result.json = parsed.data;
+      } else {
+        result.json = parsed;
+      }
     } catch {
       // Non-JSON output is OK for some commands (build prints a review block).
     }

--- a/packages/bitbadgesjs-sdk/src/cli/utils/envelope.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/envelope.spec.ts
@@ -1,58 +1,19 @@
 /**
  * Tests for envelope.ts — uniform output envelope helpers.
  *
- * Covers:
- *   - resolveFormat (precedence: --format > --json/--json-only > TTY detection)
- *   - successEnvelope / errorEnvelope (shape)
- *   - isQuiet (flag / env var)
- *   - writeJsonEnvelope (indent vs condensed)
+ * `resolveFormat` and the `--format json|text` switching machinery were
+ * removed in #0398: every data-emitting command now always emits JSON.
+ * The tests below cover what's left — envelope shape constructors,
+ * isQuiet resolution, and writeJsonEnvelope's indent/condensed branches.
  */
 
 import {
-  resolveFormat,
   successEnvelope,
   errorEnvelope,
   isQuiet,
   writeJsonEnvelope
 } from './envelope.js';
 import { Writable } from 'node:stream';
-
-// Stub stream that pretends to be a TTY (or not) on demand.
-function fakeStream(isTTY: boolean): NodeJS.WriteStream {
-  const s = new Writable({ write(_c, _e, cb) { cb(); } }) as unknown as NodeJS.WriteStream;
-  Object.defineProperty(s, 'isTTY', { value: isTTY, configurable: true });
-  return s;
-}
-
-describe('resolveFormat', () => {
-  it('honors explicit --format json', () => {
-    expect(resolveFormat({ format: 'json' }, fakeStream(true))).toBe('json');
-  });
-
-  it('honors explicit --format text', () => {
-    expect(resolveFormat({ format: 'text' }, fakeStream(false))).toBe('text');
-  });
-
-  it('--json legacy alias coerces to json', () => {
-    expect(resolveFormat({ json: true }, fakeStream(true))).toBe('json');
-  });
-
-  it('--json-only legacy alias coerces to json', () => {
-    expect(resolveFormat({ jsonOnly: true }, fakeStream(true))).toBe('json');
-  });
-
-  it('TTY default is text', () => {
-    expect(resolveFormat({}, fakeStream(true))).toBe('text');
-  });
-
-  it('non-TTY (pipe) default is json', () => {
-    expect(resolveFormat({}, fakeStream(false))).toBe('json');
-  });
-
-  it('--format wins over --json', () => {
-    expect(resolveFormat({ format: 'text', json: true }, fakeStream(false))).toBe('text');
-  });
-});
 
 describe('successEnvelope', () => {
   it('wraps data with ok=true and empty warnings/null error', () => {
@@ -148,5 +109,12 @@ describe('writeJsonEnvelope', () => {
     const text = chunks.join('');
     expect(text).not.toContain('\n  ');
     expect(text).toContain('"a":1');
+  });
+
+  it('BigInt values are stringified safely', () => {
+    const chunks: string[] = [];
+    const sink = new Writable({ write(c, _e, cb) { chunks.push(c.toString()); cb(); } }) as unknown as NodeJS.WriteStream;
+    writeJsonEnvelope(successEnvelope({ n: 123n }), { condensed: true }, sink);
+    expect(chunks.join('')).toContain('"n":"123"');
   });
 });

--- a/packages/bitbadgesjs-sdk/src/cli/utils/envelope.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/envelope.ts
@@ -6,13 +6,22 @@
  *
  *   { ok, data, warnings, hint, error }
  *
- * Format selection: `--format json|text`. Default is `text` on a TTY and
- * `json` on a pipe — agents pipe stdout, humans read it. `--json` is kept
- * as a one-release alias.
+ * As of #0398's rollout there is no `--format text` switch — every
+ * data-emitting command always writes JSON. The dual-mode design from
+ * the pilot didn't survive contact with 40 commands: a single shape is
+ * far cheaper for agents than a TTY-aware format-resolver and a parallel
+ * text renderer per verb. Humans can pipe through `jq -r` when they need
+ * a plain value.
  *
- * Each command provides its own text rendering; this module owns the JSON
- * shape and the format-resolution rules.
+ * Universal flags every data-emitting command should accept:
+ *   --condensed       single-line JSON (smaller pipe payload)
+ *   --output-file     write to file instead of stdout
+ *
+ * Shell-integration verbs (`completion`, parts of `docs`) and pure
+ * interactive flows (`auth login` prompts) are intentional exceptions —
+ * their stdout isn't agent-parseable data.
  */
+import * as fs from 'node:fs';
 import type { Command } from 'commander';
 
 export interface EnvelopeWarning {
@@ -32,43 +41,41 @@ export interface Envelope<T = unknown> {
   data: T | null;
   warnings: EnvelopeWarning[];
   hint?: string;
+  /**
+   * Structured sidecar metadata. Use when a command has additional
+   * payload-adjacent context that doesn't belong inside `data` (so pipe
+   * consumers reading `data` see the unpolluted primary payload) and
+   * isn't a warning either. Example: `bb build` puts the review /
+   * validation / simulate / resolved-metadata reports here, alongside
+   * the raw msg that lives in `data`.
+   */
+  meta?: Record<string, unknown>;
   error: EnvelopeError | null;
 }
 
-export type Format = 'json' | 'text';
-
-export interface FormatOptions {
-  /** Resolved format (`json` | `text`). */
-  format?: string;
-  /** Legacy `--json` flag — coerces to `format=json`. */
-  json?: boolean;
-  /** Legacy `--json-only` flag (used by `build`) — coerces to `format=json`. */
-  jsonOnly?: boolean;
-  /** `--condensed` — JSON without indentation. Only honored when format=json. */
+export interface EmitOptions {
+  /** Emit single-line JSON (no whitespace). */
   condensed?: boolean;
+  /** Write to file instead of stdout. */
+  outputFile?: string;
+  /** Optional warnings to surface alongside the data. */
+  warnings?: EnvelopeWarning[];
+  /** Optional hint string (machine-readable next-step). */
+  hint?: string;
+  /** Optional structured sidecar metadata — see {@link Envelope.meta}. */
+  meta?: Record<string, unknown>;
 }
 
-/**
- * Resolve the effective output format from a mix of new and legacy flags.
- *
- * Priority:
- *   1. `--format <json|text>` — explicit wins.
- *   2. `--json` / `--json-only` — legacy aliases.
- *   3. TTY detection — pipes default to JSON, terminals to text.
- */
-export function resolveFormat(opts: FormatOptions, stream: NodeJS.WriteStream = process.stdout): Format {
-  if (opts.format === 'json') return 'json';
-  if (opts.format === 'text') return 'text';
-  if (opts.json || opts.jsonOnly) return 'json';
-  return stream.isTTY ? 'text' : 'json';
-}
-
-export function successEnvelope<T>(data: T, opts: { warnings?: EnvelopeWarning[]; hint?: string } = {}): Envelope<T> {
+export function successEnvelope<T>(
+  data: T,
+  opts: { warnings?: EnvelopeWarning[]; hint?: string; meta?: Record<string, unknown> } = {}
+): Envelope<T> {
   return {
     ok: true,
     data,
     warnings: opts.warnings ?? [],
     ...(opts.hint ? { hint: opts.hint } : {}),
+    ...(opts.meta && Object.keys(opts.meta).length > 0 ? { meta: opts.meta } : {}),
     error: null
   };
 }
@@ -81,6 +88,77 @@ export function errorEnvelope(code: string, message: string, details?: unknown, 
     ...(hint ? { hint } : {}),
     error: { code, message, ...(details !== undefined ? { details } : {}) }
   };
+}
+
+/** JSON.stringify replacer that turns BigInt into its string form. SDK
+ * payloads converted through BigIntify carry bigints in many fields;
+ * without this, JSON.stringify throws "Do not know how to serialize a
+ * BigInt". Centralizing here so every emitter benefits. */
+function bigIntReplacer(_key: string, value: unknown): unknown {
+  return typeof value === 'bigint' ? value.toString() : value;
+}
+
+/**
+ * The single entry point for command output. Wraps `data` in a success
+ * envelope, JSON-stringifies (with BigInt support), honors --condensed /
+ * --output-file, and writes to stdout (or the named file).
+ *
+ * Use this from every data-emitting command — including indexer wrappers
+ * (via `emitIndexerResult`, which now delegates here). The only callers
+ * that should NOT use this are shell-integration scripts (`completion`),
+ * interactive prompts (`auth login`'s input phase), and the doc-tree
+ * renderer (`docs`) — those are UX surfaces, not data.
+ */
+export function emit(data: unknown, opts: EmitOptions = {}): void {
+  const env = successEnvelope(data, { warnings: opts.warnings, hint: opts.hint, meta: opts.meta });
+  const text = opts.condensed
+    ? JSON.stringify(env, bigIntReplacer)
+    : JSON.stringify(env, bigIntReplacer, 2);
+  if (opts.outputFile) {
+    fs.writeFileSync(opts.outputFile, text + '\n', 'utf-8');
+    process.stderr.write(`Written to ${opts.outputFile}\n`);
+  } else {
+    process.stdout.write(text + '\n');
+  }
+}
+
+interface ApiErrorShape {
+  message?: string;
+  response?: unknown;
+  hint?: string;
+  code?: string;
+}
+
+/**
+ * Emit an error envelope and exit non-zero. Mirrors `emit()`'s output
+ * contract — stdout JSON, never plaintext — so agents that pipe `bb foo |
+ * jq` see a valid envelope on both success AND failure paths.
+ *
+ * The error envelope's `code` defaults to the HTTP-style status if the
+ * thrown error carries `.response.errorMessage`; otherwise falls back to
+ * a generic `cli_error`. Callers passing a domain code should construct
+ * the envelope directly via `errorEnvelope()` and write it themselves.
+ */
+export function emitError(err: unknown, opts: EmitOptions & { exitCode?: number; code?: string } = {}): never {
+  const e = err as ApiErrorShape;
+  const message = (() => {
+    if (e?.response !== undefined) {
+      if (typeof e.response === 'string') return e.response;
+      try {
+        return JSON.stringify(e.response);
+      } catch {
+        return String(e.response);
+      }
+    }
+    return e?.message ?? String(err);
+  })();
+  const code = opts.code ?? e?.code ?? 'cli_error';
+  const env = errorEnvelope(code, message, e?.response, e?.hint);
+  const text = opts.condensed
+    ? JSON.stringify(env, bigIntReplacer)
+    : JSON.stringify(env, bigIntReplacer, 2);
+  process.stdout.write(text + '\n');
+  process.exit(opts.exitCode ?? 1);
 }
 
 /**
@@ -106,20 +184,34 @@ export function commentary(message: string, opts: { quiet?: boolean } = {}, stre
 }
 
 /**
- * Write an envelope as JSON. Indented by default; condensed strips
- * whitespace for piping.
+ * Write an envelope directly. Used by callers (like `tx`) that build
+ * their own envelope to attach domain-specific warnings. Honors
+ * --condensed; respects --output-file via the optional path.
  */
-export function writeJsonEnvelope(env: Envelope<unknown>, opts: { condensed?: boolean } = {}, stream: NodeJS.WriteStream = process.stdout): void {
-  const text = opts.condensed ? JSON.stringify(env) : JSON.stringify(env, null, 2);
+export function writeJsonEnvelope(
+  env: Envelope<unknown>,
+  opts: { condensed?: boolean; outputFile?: string } = {},
+  stream: NodeJS.WriteStream = process.stdout
+): void {
+  const text = opts.condensed
+    ? JSON.stringify(env, bigIntReplacer)
+    : JSON.stringify(env, bigIntReplacer, 2);
+  if (opts.outputFile) {
+    fs.writeFileSync(opts.outputFile, text + '\n', 'utf-8');
+    process.stderr.write(`Written to ${opts.outputFile}\n`);
+    return;
+  }
   stream.write(text + '\n');
 }
 
 /**
- * Add `--format` (and the legacy `--json` alias) to a Command. Use on every
- * command that produces parseable output.
+ * Add the two universal output flags every data-emitting command should
+ * accept: `--condensed` and `--output-file`. Replaces the previous
+ * `addFormatOptions` (which exposed --format / --json) — those flags are
+ * gone now that there's only one output mode.
  */
-export function addFormatOptions(cmd: Command): Command {
+export function addOutputOptions(cmd: Command): Command {
   return cmd
-    .option('--format <fmt>', 'Output format: json | text. Default: text on TTY, json on pipe.')
-    .option('--json', '(Deprecated) Alias for --format json.');
+    .option('--condensed', 'Single-line JSON (smaller pipe payload)', false)
+    .option('--output-file <path>', 'Write the envelope to file instead of stdout');
 }

--- a/packages/bitbadgesjs-sdk/src/cli/utils/indexer-options.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/indexer-options.ts
@@ -30,9 +30,9 @@
  * New commands SHOULD prefer the envelope helpers — but migration is out
  * of scope for this sweep, which is purely about flag consistency.
  */
-import * as fs from 'node:fs';
 import type { Command } from 'commander';
 import { apiRequest, resolveApiKey, resolveBaseUrl } from './api-client.js';
+import { emit, emitError } from './envelope.js';
 
 export interface IndexerNetworkFlags {
   testnet?: boolean;
@@ -95,61 +95,27 @@ export function addIndexerOptions(cmd: Command): Command {
   return addIndexerOutputOptions(addIndexerNetworkOptions(cmd));
 }
 
-/** JSON replacer that stringifies BigInt values — every command emitting
- * SDK-converted docs (auctions, credit-tokens, intents, nfts,
- * prediction-markets, subscriptions) hits BigInt fields in the
- * convert(BigIntify) payload and would otherwise throw
- * "Do not know how to serialize a BigInt". */
-function bigIntReplacer(_key: string, value: unknown): unknown {
-  return typeof value === 'bigint' ? value.toString() : value;
-}
-
 /**
- * Emit a result as JSON. Honors `--condensed` and `--output-file`.
- * Mirrors the inline `emit()` every command file used to define. By
- * default uses the BigInt-safe replacer so SDK doc payloads never throw
- * on serialization — pass `bigInt: false` to opt out for the few
- * commands that pre-stringify their values.
+ * Emit a result as the envelope-wrapped JSON. Thin shim over `emit()` —
+ * kept under the indexer-options name so every existing indexer-command
+ * callsite (assets, balances, intents, nfts, portfolio, swap, …)
+ * automatically gets the envelope shape without per-file edits.
+ *
+ * The legacy `bigInt: false` opt-out is gone: `emit()` always uses a
+ * BigInt-safe replacer, and the handful of pre-stringified callers
+ * (none today after the sweep) wouldn't gain anything from skipping it.
  */
-export function emitIndexerResult(
-  result: unknown,
-  opts: IndexerOutputFlags & { bigInt?: boolean } = {}
-): void {
-  const replacer = opts.bigInt === false ? undefined : bigIntReplacer;
-  const formatted = opts.condensed
-    ? JSON.stringify(result, replacer)
-    : JSON.stringify(result, replacer, 2);
-  if (opts.outputFile) {
-    fs.writeFileSync(opts.outputFile, formatted + '\n', 'utf-8');
-    process.stderr.write(`Written to ${opts.outputFile}\n`);
-  } else {
-    process.stdout.write(formatted + '\n');
-  }
-}
-
-interface ApiErrorShape {
-  message?: string;
-  response?: unknown;
-  hint?: string;
+export function emitIndexerResult(result: unknown, opts: IndexerOutputFlags = {}): void {
+  emit(result, opts);
 }
 
 /**
- * Error emitter for indexer-call failures. Surfaces `response` when the
- * indexer returned a structured error body, otherwise falls back to the
- * raw message. Any attached `hint` (network-error helper from
- * `api-client.ts`) gets written to stderr too. Exits non-zero.
+ * Error emitter for indexer-call failures. Thin shim over `emitError()`
+ * — the envelope contract is identical, and centralizing here means an
+ * indexer 4xx/5xx surfaces the same JSON shape as any other CLI error.
  */
 export function emitIndexerError(err: unknown, exitCode = 1): never {
-  const e = err as ApiErrorShape;
-  if (e?.response !== undefined) {
-    process.stderr.write(JSON.stringify(e.response, null, 2) + '\n');
-  } else {
-    process.stderr.write(`Error: ${e?.message ?? String(err)}\n`);
-  }
-  if (e?.hint) {
-    process.stderr.write(`Hint: ${e.hint}\n`);
-  }
-  process.exit(exitCode);
+  emitError(err, { exitCode });
 }
 
 /**

--- a/packages/bitbadgesjs-sdk/src/cli/utils/io.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/io.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import type { Command } from 'commander';
 import { getConfigBaseUrl, getConfigApiKey } from './config.js';
 import { assertNetworkAvailable } from '../../signing/types.js';
+import { emit } from './envelope.js';
 
 /**
  * Read JSON input from multiple sources:
@@ -34,54 +35,16 @@ export function readJsonInput(input: string): any {
 }
 
 /**
- * Output data as JSON (pretty-printed by default) or human-readable text.
+ * Output data as an envelope-wrapped JSON payload. Thin shim over
+ * `emit()` — kept here so the few `output()` callers (build.ts and the
+ * existing test fakes) don't have to be touched in this sweep.
  *
- * --condensed: no whitespace (for piping/scripts)
- * --human: human-readable tree format
- * --output-file: write to file instead of stdout
- * default: pretty-printed JSON (2-space indent)
+ * Per #0398 there is no `--human` mode anymore: every data-emitting
+ * command speaks the same envelope JSON, and humans pipe through `jq -r`
+ * when they need a plain value. The previous tree-renderer is gone.
  */
-export function output(data: any, options: { human?: boolean; condensed?: boolean; outputFile?: string }): void {
-  let text: string;
-
-  if (options.human) {
-    text = typeof data === 'string' ? data : formatHuman(data);
-  } else if (options.condensed) {
-    text = JSON.stringify(data);
-  } else {
-    text = JSON.stringify(data, null, 2);
-  }
-
-  if (options.outputFile) {
-    fs.writeFileSync(options.outputFile, text + '\n', 'utf-8');
-    process.stderr.write(`Written to ${options.outputFile}\n`);
-  } else {
-    console.log(text);
-  }
-}
-
-function formatHuman(obj: any, indent = 0): string {
-  if (obj === null || obj === undefined) return 'null';
-  if (typeof obj === 'string') return obj;
-  if (typeof obj === 'number' || typeof obj === 'boolean') return String(obj);
-
-  if (Array.isArray(obj)) {
-    if (obj.length === 0) return '(empty)';
-    return obj.map((item, i) => `${' '.repeat(indent)}[${i}] ${formatHuman(item, indent + 2)}`).join('\n');
-  }
-
-  if (typeof obj === 'object') {
-    const entries = Object.entries(obj);
-    if (entries.length === 0) return '{}';
-    return entries
-      .map(([key, val]) => {
-        const valStr = typeof val === 'object' && val !== null ? '\n' + formatHuman(val, indent + 2) : ` ${formatHuman(val, indent + 2)}`;
-        return `${' '.repeat(indent)}${key}:${valStr}`;
-      })
-      .join('\n');
-  }
-
-  return String(obj);
+export function output(data: any, options: { condensed?: boolean; outputFile?: string }): void {
+  emit(data, { condensed: options.condensed, outputFile: options.outputFile });
 }
 
 /**

--- a/packages/bitbadgesjs-sdk/src/cli/utils/terminal.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/terminal.ts
@@ -837,14 +837,14 @@ export function renderMetadataPlaceholders(
 // pair, classifying each as URI mode or INLINE mode.
 // ─────────────────────────────────────────────────────────────────────────────
 
-interface ResolvedEntry {
+export interface ResolvedEntry {
   kind: string;
   location: string;
   uri: string;
   customData: string;
 }
 
-function collectResolvedEntries(input: any): ResolvedEntry[] {
+export function collectResolvedEntries(input: any): ResolvedEntry[] {
   const out: ResolvedEntry[] = [];
   let value: any = null;
   if (Array.isArray(input?.messages)) {


### PR DESCRIPTION
## Summary

#0398 — unify CLI output across the surface. Every data-emitting command now writes the same `{ ok, data, warnings, hint?, meta?, error }` envelope to stdout. No `--format json|text` switching; no `--human` text mode; no per-command bespoke shapes. Per user direction: \"better to do that and be consistent rather than switch output format.\"

Plus the follow-up ask: `bb build`'s review / validation / resolved-metadata / simulate reports are now folded into the envelope as `warnings` + `meta` instead of being stderr-only rendered text. Agents no longer have to scrape stderr to know which metadata URIs they need to upload.

## What's in this PR

### Helper-level changes (the big lever)

- `envelope.ts`: new `emit()` / `emitError()` as the single entry point, BigInt-safe, --condensed + --output-file aware. New `meta?: Record<string, unknown>` slot on the envelope for sidecar context. `addOutputOptions()` is the universal output flags helper. **Removed `addFormatOptions` / `resolveFormat` / `Format` / `FormatOptions` — no more text-mode switching.**
- `indexer-options.ts`: `emitIndexerResult` / `emitIndexerError` are now thin shims over the envelope helpers. **All 16 indexer-using commands** (assets, auctions, balances, bounties, credit-tokens, dynamic-stores, intents, nfts, pay-requests, portfolio, prediction-markets, products, smart-tokens, subscriptions, swap, amount) get the envelope automatically — zero callsite edits.
- `io.ts` `output()`: delegates to `emit()`. `--human` tree mode dropped.

### `bb build` — review / warnings / metadata in the envelope

```jsonc
{
  \"ok\": true,
  \"data\": { \"typeUrl\": \"...\", \"value\": {...} },        // unchanged msg shape
  \"warnings\": [                                              // review findings + validation issues
    { \"code\": \"review.audit.smart_token.missing_backing_approval_deposit\",
      \"message\": \"Missing backing approval (deposit)\",
      \"details\": { ...full Finding... } }
  ],
  \"meta\": {
    \"validation\":  { \"valid\": true, \"issues\": [] },     // ValidationResult
    \"review\":      { \"findings\": [...], \"summary\": {...} },
    \"resolvedMetadata\": [{ kind, location, uri, customData }, ...],
    \"metadataToUpload\": [{ kind, location, uri }, ...],     // URI-mode subset — agents push these to IPFS
    \"simulate\":    { ...SimulateResult... },                // when --simulate
    \"explanation\": \"plain-English summary\"                  // when --explain
  },
  \"error\": null
}
```

Stderr commentary preserved for human UX (gated by `--quiet` / `--json-only`) — terminal users still see colored scorecards.

### Pipe consumers

- `deploy` parses envelope wrappers from stdin / file / arg, extracts `data`, and refuses to broadcast error envelopes. `bb build smart-token | bb deploy ...` keeps working untouched.
- Integration harness `runCli()` auto-unwraps envelopes: `out.json` is `envelope.data`; raw envelope on `out.envelope`. Every pre-existing build-pipeline test passes unchanged.

### Refactored commands

- `price`, `explain`, `tx` — dropped per-command `--format` / `resolveFormat` / bespoke `emitEnvelope`; now use shared `emit()`. Lost the bespoke text renderings (humans pipe through `jq -r` when they need plain values).
- `doctor`, `simulate` — text scorecards moved to stderr commentary; stdout always emits the envelope. Same UX for humans, structured output for pipes.
- `address` (convert/validate), `lookup`, `gen-list-id`, `url` — converted raw `console.log` / `JSON.stringify` to `emit()`.

### Out of scope for this PR (follow-ups)

Data-emitting commands still writing raw `console.log` (will be enveloped in a follow-up commit — same pattern, low risk):
- alias, api, auth, burner, crowdfunds, gen-pub-key, gen-tx-payload, preview, resources, session, sign-with-browser, tools, tool, check

Intentional plaintext-only exceptions (UX surfaces, not data):
- completion (shell script), docs (markdown tree), config show, skills

## Test plan

- [x] `npm run build` clean.
- [x] 549/550 CLI tests pass (1 pre-existing master failure: `cli-discovery.spec.ts > lookup_token_info`, unrelated).
- [x] Build pipeline integration suite (23 tests) green — the envelope auto-unwrap in `runCli` keeps existing assertions working.
- [x] Smoke verified `bb build smart-token` envelope shape: `data.typeUrl` correct, 5 warnings populated from review, `meta.validation`, `meta.review.summary`, `meta.resolvedMetadata` (6 entries), `meta.metadataToUpload` (4 entries in URI mode, 0 in inline mode).
- [x] Smoke verified `bb portfolio account/balances` and `bb balances ics20` all emit `{ok, data, warnings, error}` shape.
- [ ] Sweep remaining 14 raw-output commands in follow-up commit on this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)