### PR TITLE
feat(cli): input-validation + ergonomics polish (v2.1)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
@@ -90,7 +90,7 @@ function normalizeIndexerBase(baseUrl: string): string {
 
 async function uploadPayload(baseUrl: string, apiKey: string | undefined, payload: BridgePayload): Promise<string> {
   if (!apiKey) {
-    throw new Error('Cannot upload large sign payload: no API key. Set BITBADGES_API_KEY or pass --api-key.');
+    throw new Error('Cannot upload large sign payload: no API key. Pass --api-key, or run `bb settings set apiKey <key>`.');
   }
   const url = `${normalizeIndexerBase(baseUrl)}/sign/payload`;
   const res = await fetch(url, {

--- a/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/auth/browser-bridge.ts
@@ -18,6 +18,7 @@
 import http from 'http';
 import { AddressInfo } from 'net';
 import crypto from 'crypto';
+import { bbError, BBErrorCode } from '../utils/envelope.js';
 
 export type BridgeMode = 'login' | 'msg' | 'tx';
 
@@ -90,7 +91,10 @@ function normalizeIndexerBase(baseUrl: string): string {
 
 async function uploadPayload(baseUrl: string, apiKey: string | undefined, payload: BridgePayload): Promise<string> {
   if (!apiKey) {
-    throw new Error('Cannot upload large sign payload: no API key. Pass --api-key, or run `bb settings set apiKey <key>`.');
+    throw bbError(
+      BBErrorCode.MISSING_API_KEY,
+      'Cannot upload large sign payload: no API key. Pass --api-key, or run `bb settings set apiKey <key>`.'
+    );
   }
   const url = `${normalizeIndexerBase(baseUrl)}/sign/payload`;
   const res = await fetch(url, {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/account.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/account.ts
@@ -44,6 +44,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address } from '../utils/address.js';
+import { requireBbDenom } from '../utils/denom.js';
 import {
   addOutputOptions as addOutputOptionsEnv,
   emit as emitEnv,
@@ -156,14 +157,15 @@ function buildApprovalsQuery(address: string, flags: ApprovalsFilterFlags): { qu
     query['approval.approvalCriteria.coinTransfers'] = { $elemMatch: { $exists: true } };
   }
 
+  const denom = flags.denom ? requireBbDenom(flags.denom, '--denom') : undefined;
   if (flags.priceMin !== undefined || flags.priceMax !== undefined) {
     const priceFilter: Record<string, unknown> = { $exists: true };
     if (flags.priceMin !== undefined) priceFilter.$gte = Number(flags.priceMin);
     if (flags.priceMax !== undefined) priceFilter.$lte = Number(flags.priceMax);
     query.price = priceFilter;
-    if (flags.denom) query.denom = flags.denom;
-  } else if (flags.denom) {
-    query.denom = flags.denom;
+    if (denom) query.denom = denom;
+  } else if (denom) {
+    query.denom = denom;
   }
 
   let sortBy: Record<string, 1 | -1> | undefined;
@@ -457,7 +459,7 @@ addOutputFlags(
       .option('--has-coin-transfers', 'Only approvals with a coin-transfer leg (subscriptions, listings, paid claims)', false)
       .option('--price-min <n>', 'Lower bound on approval.price (use with --denom)')
       .option('--price-max <n>', 'Upper bound on approval.price (use with --denom)')
-      .option('--denom <denom>', 'Restrict price filter to this denom')
+      .option('--denom <symbol|denom>', 'Restrict price filter to this denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
       .option('--sort <order>', 'price-asc | price-desc (default: server order)')
   )
 ).action(async (opts: ApprovalsFlags) => {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/api.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/api.ts
@@ -247,12 +247,12 @@ function buildRouteCommand(route: ApiRoute): Command {
           : getActiveSession(sessionNetwork);
         if (!session) {
           throw new Error(
-            `No stored session for ${opts.asAddress ?? 'active address'} on ${sessionNetwork}. Run \`bitbadges-cli auth login\`.`,
+            `No stored session for ${opts.asAddress ?? 'active address'} on ${sessionNetwork}. Run \`bb auth login\`.`,
           );
         }
         if (Date.now() > session.expiresAt) {
           throw new Error(
-            `Stored session for ${session.address} on ${sessionNetwork} expired at ${new Date(session.expiresAt).toISOString()}. Re-run \`bitbadges-cli auth login\`.`,
+            `Stored session for ${session.address} on ${sessionNetwork} expired at ${new Date(session.expiresAt).toISOString()}. Re-run \`bb auth login\`.`,
           );
         }
         cookie = formatCookieHeader(session);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/api.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/api.ts
@@ -25,7 +25,7 @@ import {
   addIndexerNetworkOptions,
   addIndexerOutputOptions,
 } from '../utils/indexer-options.js';
-import { emit, emitError } from '../utils/envelope.js';
+import { emit, emitError, bbError, BBErrorCode } from '../utils/envelope.js';
 import { ROUTES, TAG_DESCRIPTIONS, type ApiRoute } from './api-routes.js';
 
 // ---------------------------------------------------------------------------
@@ -246,13 +246,15 @@ function buildRouteCommand(route: ApiRoute): Command {
           ? getSession(sessionNetwork, opts.asAddress)
           : getActiveSession(sessionNetwork);
         if (!session) {
-          throw new Error(
-            `No stored session for ${opts.asAddress ?? 'active address'} on ${sessionNetwork}. Run \`bb auth login\`.`,
+          throw bbError(
+            BBErrorCode.NOT_AUTHENTICATED,
+            `No stored session for ${opts.asAddress ?? 'active address'} on ${sessionNetwork}. Run \`bb auth login\`.`
           );
         }
         if (Date.now() > session.expiresAt) {
-          throw new Error(
-            `Stored session for ${session.address} on ${sessionNetwork} expired at ${new Date(session.expiresAt).toISOString()}. Re-run \`bb auth login\`.`,
+          throw bbError(
+            BBErrorCode.NOT_AUTHENTICATED,
+            `Stored session for ${session.address} on ${sessionNetwork} expired at ${new Date(session.expiresAt).toISOString()}. Re-run \`bb auth login\`.`
           );
         }
         cookie = formatCookieHeader(session);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
@@ -15,6 +15,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address } from '../utils/address.js';
+import { requireBbDenom } from '../utils/denom.js';
 import {
   doesCollectionFollowAuctionProtocol,
   validateAuctionCollection,
@@ -141,7 +142,7 @@ addOutputFlags(
       .argument('<collection-id>', 'Auction collection ID')
       .requiredOption('--creator <address>', 'Bidder address (bb1.../0x — auto-normalized)')
       .requiredOption('--amount <n>', 'Bid amount in base units')
-      .requiredOption('--denom <denom>', 'Payment denom (uusdc / ubadge / ibc/...)')
+      .requiredOption('--denom <symbol|denom>', 'Payment denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
       .option('--approval-id <id>', 'Approval id for the bid (random by default)')
   )
 ).action(
@@ -151,6 +152,7 @@ addOutputFlags(
   ) => {
     try {
       const creator = requireBb1Address(opts.creator, '--creator');
+      const paymentDenom = requireBbDenom(opts.denom, '--denom');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'auctions place-bid');
       const details = extractAuctionDetails(collection.collectionApprovals);
@@ -166,7 +168,7 @@ addOutputFlags(
         bidderAddress: creator,
         tokenId: 1n,
         tokenAmount: 1n,
-        paymentDenom: opts.denom,
+        paymentDenom,
         paymentAmount: BigInt(opts.amount),
         transferTimes,
         approvalId

--- a/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
@@ -15,7 +15,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1AddressStrict } from '../utils/address.js';
-import { requireBbDenom } from '../utils/denom.js';
+import { resolveAmount } from '../utils/amount.js';
 import {
   doesCollectionFollowAuctionProtocol,
   validateAuctionCollection,
@@ -140,19 +140,25 @@ addOutputFlags(
       .command('place-bid')
       .description('Emit MsgSetIncomingApproval that places a bid on the auction. Pipe to `bb deploy`.')
       .argument('<collection-id>', 'Auction collection ID')
-      .requiredOption('--creator <address>', 'Bidder address (bb1.../0x — auto-normalized)')
-      .requiredOption('--amount <n>', 'Bid amount in base units')
+      .requiredOption('--creator <address>', 'Bidder address (bb1...) — strict; run `bb account convert` for 0x')
+      .requiredOption('--amount <n>', 'Bid amount. Display units when --denom is a symbol (BADGE → 1.5 BADGE), base units when --denom is a chain denom (ubadge / ibc/...). Use --base-units to force base-units.')
       .requiredOption('--denom <symbol|denom>', 'Payment denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
+      .option('--base-units', 'Treat --amount as already-in-base-units')
       .option('--approval-id <id>', 'Approval id for the bid (random by default)')
   )
 ).action(
   async (
     collectionId: string,
-    opts: NetworkFlags & OutputFlags & { creator: string; amount: string; denom: string; approvalId?: string }
+    opts: NetworkFlags & OutputFlags & { creator: string; amount: string; denom: string; baseUnits?: boolean; approvalId?: string }
   ) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
-      const paymentDenom = requireBbDenom(opts.denom, '--denom');
+      const { denom: paymentDenom, amount: paymentAmountStr } = resolveAmount(
+        opts.amount,
+        opts.denom,
+        Boolean(opts.baseUnits),
+        { amountFlag: '--amount', denomFlag: '--denom' }
+      );
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'auctions place-bid');
       const details = extractAuctionDetails(collection.collectionApprovals);
@@ -169,7 +175,7 @@ addOutputFlags(
         tokenId: 1n,
         tokenAmount: 1n,
         paymentDenom,
-        paymentAmount: BigInt(opts.amount),
+        paymentAmount: BigInt(paymentAmountStr),
         transferTimes,
         approvalId
       });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
@@ -185,7 +185,11 @@ addOutputFlags(
       }, opts);
     } catch (err) { emitError(err); }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb auctions place-bid 42 --creator bb1abc...xyz --amount 25 --denom USDC | bb deploy
+  $ bb auctions place-bid 42 --creator bb1abc...xyz --amount 25000000 --denom USDC --base-units | bb deploy
+`);
 
 addOutputFlags(
   addNetworkFlags(
@@ -204,7 +208,10 @@ addOutputFlags(
       value: { creator, collectionId: String(collectionId), approvalId }
     }, opts);
   } catch (err) { emitError(err); }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb auctions cancel-bid 42 a1b2c3d4e5f6 --creator bb1abc...xyz | bb deploy
+`);
 
 addOutputFlags(
   addNetworkFlags(
@@ -243,7 +250,10 @@ addOutputFlags(
       );
     } catch (err) { emitError(err); }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb auctions accept-bid 42 a1b2c3d4e5f6 --creator bb1seller...xyz --bidder bb1buyer...xyz | bb deploy
+`);
 
 // Per-standard `build` subcommand removed in CLI v2 (#0399).
 // Use `bb build auction ...` (the canonical builder) instead.

--- a/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
@@ -14,7 +14,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1AddressStrict } from '../utils/address.js';
 import { requireBbDenom } from '../utils/denom.js';
 import {
   doesCollectionFollowAuctionProtocol,
@@ -151,7 +151,7 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; amount: string; denom: string; approvalId?: string }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const paymentDenom = requireBbDenom(opts.denom, '--denom');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'auctions place-bid');
@@ -192,7 +192,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, approvalId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     emit({
       typeUrl: '/tokenization.MsgDeleteIncomingApproval',
       value: { creator, collectionId: String(collectionId), approvalId }
@@ -217,8 +217,8 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; bidder: string }
   ) => {
     try {
-      const seller = requireBb1Address(opts.creator, '--creator');
-      const bidder = requireBb1Address(opts.bidder, '--bidder');
+      const seller = requireBb1AddressStrict(opts.creator, '--creator');
+      const bidder = requireBb1AddressStrict(opts.bidder, '--bidder');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'auctions accept-bid');
       const details = extractAuctionDetails(collection.collectionApprovals);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/auth.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auth.ts
@@ -17,6 +17,7 @@ import {
   resolveIndexerNetwork,
 } from '../utils/indexer-options.js';
 import { bridgeSign, resolveFrontendUrl } from '../auth/browser-bridge.js';
+import { tryBb1Address } from '../utils/address.js';
 import {
   AuthSession,
   Network,
@@ -49,8 +50,28 @@ function resolveNetwork(opts: NetworkOptions): Network {
 }
 
 function detectChain(address: string): 'Cosmos' | 'ETH' {
-  if (address.startsWith('0x')) return 'ETH';
-  if (address.startsWith('bb1')) return 'Cosmos';
+  if (address.startsWith('0x')) {
+    // Loose-format check: 0x + 40 hex chars (case-insensitive). Skip the
+    // EIP-55 checksum validation here — auth accepts lowercased EVM
+    // addresses too. Tight enough to reject obvious garbage.
+    if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
+      throw new Error(
+        `Invalid ETH address "${address}": expected 0x + 40 hex chars. Auth accepts bb1... (Cosmos) or 0x... (ETH).`
+      );
+    }
+    return 'ETH';
+  }
+  if (address.startsWith('bb1')) {
+    // Use the converter to validate bech32 decode. A malformed bb1
+    // string (e.g. "bb1invalid") returns "" from the converter; treat
+    // that as "garbage in, garbage out" and throw with a fix-it hint.
+    if (!tryBb1Address(address)) {
+      throw new Error(
+        `Invalid bb1 address "${address}": bech32 decode failed. Run \`bb account convert <address>\` to canonicalize.`
+      );
+    }
+    return 'Cosmos';
+  }
   throw new Error(`Cannot detect chain from address ${address}: must start with 'bb1' or '0x'`);
 }
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/bounties.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/bounties.ts
@@ -28,7 +28,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
 import {
   doesCollectionFollowBountyProtocol,
   validateBountyCollection,
@@ -206,7 +206,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'bounties accept');
     const details = extractBountyDetails(collection.collectionApprovals)!;
@@ -236,7 +236,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'bounties deny');
     const details = extractBountyDetails(collection.collectionApprovals)!;
@@ -266,7 +266,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'bounties claim-refund');
     const details = extractBountyDetails(collection.collectionApprovals)!;

--- a/packages/bitbadgesjs-sdk/src/cli/commands/bounties.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/bounties.ts
@@ -220,7 +220,10 @@ addOutputFlags(
   } catch (err) {
     emitError(err);
   }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb bounties accept 17 --creator bb1verifier...xyz | bb deploy
+`);
 
 // ── bounties deny ────────────────────────────────────────────────────────
 
@@ -250,7 +253,10 @@ addOutputFlags(
   } catch (err) {
     emitError(err);
   }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb bounties deny 17 --creator bb1verifier...xyz | bb deploy
+`);
 
 // ── bounties claim-refund ────────────────────────────────────────────────
 
@@ -284,7 +290,10 @@ addOutputFlags(
   } catch (err) {
     emitError(err);
   }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb bounties claim-refund 17 --creator bb1submitter...xyz | bb deploy
+`);
 
 // Per-standard `build` subcommand removed in CLI v2 (#0399).
 // Use `bb build bounty ...` (the canonical builder) instead.

--- a/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
@@ -6,7 +6,7 @@ import { renderReview, renderValidate, renderResolvedMetadata, renderSimulate, c
 import { isCollectionMsg, normalizeToCreateOrUpdate } from '../utils/normalizeMsg.js';
 import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
 import { runBurnerCreate, pickBurner, type BurnerNetwork } from '../utils/burner.js';
-import { requireBbDenom } from '../utils/denom.js';
+import { requireBbDenom, DEFAULT_FEE_DENOM } from '../utils/denom.js';
 import { requireBb1AddressStrict } from '../utils/address.js';
 
 export const buildCommand = new Command('build').description('Deterministic transaction builders — flag-based generators for vaults, NFTs, subscriptions, bounties, and more. Output: ready-to-sign JSON. To broadcast, pipe into `bb cli deploy --burner`.');
@@ -447,7 +447,7 @@ async function emit(
         manager: opts.manager,
         fund: opts.fund === 'manual' ? 'manual' : 'faucet',
         apiKey,
-        fee: { amount: String(opts.fee ?? '0'), denom: requireBbDenom(String(opts.feeDenom ?? 'ubadge'), '--fee-denom') },
+        fee: { amount: String(opts.fee ?? '0'), denom: requireBbDenom(String(opts.feeDenom ?? DEFAULT_FEE_DENOM), '--fee-denom') },
         gas: Number(opts.gas ?? 400000),
         reuseRecord: choice.kind === 'reuse' ? choice.record : undefined,
         nonInteractive: Boolean(opts.nonInteractive) || !process.stdout.isTTY,
@@ -527,7 +527,7 @@ const sharedOpts = (cmd: Command) => {
   cmd.option('--expected-address <addr>', 'With --deploy-with-browser: bb1.../0x... that the connected wallet must match. Defaults to --manager / --creator.');
   cmd.option('--fund <mode>', 'With --deploy-with-burner: funding source for the burner (faucet | manual)', 'faucet');
   cmd.option('--fee <amount>', 'When deploying: fee amount in base units', '0');
-  cmd.option('--fee-denom <symbol|denom>', 'When deploying: fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', 'ubadge');
+  cmd.option('--fee-denom <symbol|denom>', 'When deploying: fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', DEFAULT_FEE_DENOM);
   cmd.option('--gas <number>', 'When deploying: gas limit', '400000');
   cmd.option('--new', 'With --deploy-with-burner: skip the burner picker and always create a fresh wallet');
   cmd.option('--reuse <selector>', 'With --deploy-with-burner: reuse a specific saved burner by address or recovery file path');

--- a/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
@@ -9,7 +9,7 @@ import { runBurnerCreate, pickBurner, type BurnerNetwork } from '../utils/burner
 import { requireBbDenom, DEFAULT_FEE_DENOM } from '../utils/denom.js';
 import { requireBb1AddressStrict } from '../utils/address.js';
 
-export const buildCommand = new Command('build').description('Deterministic transaction builders — flag-based generators for vaults, NFTs, subscriptions, bounties, and more. Output: ready-to-sign JSON. To broadcast, pipe into `bb cli deploy --burner`.');
+export const buildCommand = new Command('build').description('Deterministic transaction builders — flag-based generators for vaults, NFTs, subscriptions, bounties, and more. Output: ready-to-sign JSON. To broadcast, pipe into `bb deploy --burner`.');
 
 // ── Output helper ────────────────────────────────────────────────────────────
 
@@ -260,7 +260,7 @@ async function emit(
         const skipResult = {
           success: false,
           error:
-            'Auto-Simulate skipped — no API key. Set BITBADGES_API_KEY or run `bitbadges-cli config set apiKey <key>`.'
+            'Auto-Simulate skipped — no API key. Pass --api-key or run `bb settings set apiKey <key>`.'
         };
         meta.simulate = skipResult;
         warnings.push({
@@ -427,7 +427,7 @@ async function emit(
 
     if ((opts.fund ?? 'faucet') === 'faucet' && !apiKey && network !== 'local') {
       process.stderr.write(
-        'Warning: --fund faucet requires an API key on non-local networks. Set BITBADGES_API_KEY or `bb cli config set apiKey <key>`.\n'
+        'Warning: --fund faucet requires an API key on non-local networks. Pass --api-key or run `bb settings set apiKey <key>`.\n'
       );
     }
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
@@ -6,6 +6,7 @@ import { renderReview, renderValidate, renderResolvedMetadata, renderSimulate, c
 import { isCollectionMsg, normalizeToCreateOrUpdate } from '../utils/normalizeMsg.js';
 import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
 import { runBurnerCreate, pickBurner, type BurnerNetwork } from '../utils/burner.js';
+import { requireBbDenom } from '../utils/denom.js';
 
 export const buildCommand = new Command('build').description('Deterministic transaction builders — flag-based generators for vaults, NFTs, subscriptions, bounties, and more. Output: ready-to-sign JSON. To broadcast, pipe into `bb cli deploy --burner`.');
 
@@ -445,7 +446,7 @@ async function emit(
         manager: opts.manager,
         fund: opts.fund === 'manual' ? 'manual' : 'faucet',
         apiKey,
-        fee: { amount: String(opts.fee ?? '0'), denom: String(opts.feeDenom ?? 'ubadge') },
+        fee: { amount: String(opts.fee ?? '0'), denom: requireBbDenom(String(opts.feeDenom ?? 'ubadge'), '--fee-denom') },
         gas: Number(opts.gas ?? 400000),
         reuseRecord: choice.kind === 'reuse' ? choice.record : undefined,
         nonInteractive: Boolean(opts.nonInteractive) || !process.stdout.isTTY,
@@ -525,7 +526,7 @@ const sharedOpts = (cmd: Command) => {
   cmd.option('--expected-address <addr>', 'With --deploy-with-browser: bb1.../0x... that the connected wallet must match. Defaults to --manager / --creator.');
   cmd.option('--fund <mode>', 'With --deploy-with-burner: funding source for the burner (faucet | manual)', 'faucet');
   cmd.option('--fee <amount>', 'When deploying: fee amount in base units', '0');
-  cmd.option('--fee-denom <denom>', 'When deploying: fee denom', 'ubadge');
+  cmd.option('--fee-denom <symbol|denom>', 'When deploying: fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', 'ubadge');
   cmd.option('--gas <number>', 'When deploying: gas limit', '400000');
   cmd.option('--new', 'With --deploy-with-burner: skip the burner picker and always create a fresh wallet');
   cmd.option('--reuse <selector>', 'With --deploy-with-burner: reuse a specific saved burner by address or recovery file path');
@@ -603,7 +604,7 @@ sharedOpts(
     .description('Create a recurring subscription collection. Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--interval <duration>', 'Interval: daily, monthly, annually, or shorthand (30d)')
     .option('--price <amount>', 'Price per interval (display units) — use with --denom/--recipient')
-    .option('--denom <symbol>', 'Payment coin (USDC, BADGE)')
+    .option('--denom <symbol|denom>', 'Payment coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .option('--recipient <address>', 'Payout address (bb1...)')
     .option('--payouts <json>', 'Multiple payouts JSON: [{"recipient","amount","denom"}]')
     .option('--tiers <n>', 'Number of tiers', '1')
@@ -621,10 +622,18 @@ sharedOpts(
     image: opts.image
   };
   if (opts.payouts) {
-    params.payouts = JSON.parse(opts.payouts);
+    const payouts = JSON.parse(opts.payouts);
+    if (Array.isArray(payouts)) {
+      for (const p of payouts) {
+        if (p && typeof p === 'object' && typeof p.denom === 'string') {
+          p.denom = requireBbDenom(p.denom, '--payouts entry denom');
+        }
+      }
+    }
+    params.payouts = payouts;
   } else {
     params.price = Number(opts.price);
-    params.denom = opts.denom;
+    params.denom = opts.denom ? requireBbDenom(opts.denom, '--denom') : opts.denom;
     params.recipient = opts.recipient;
   }
   emit(buildSubscription(params), opts);
@@ -635,7 +644,7 @@ sharedOpts(
     .command('bounty')
     .description('Create a bounty escrow collection. Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--amount <n>', 'Bounty amount (display units)')
-    .requiredOption('--denom <symbol>', 'Coin (USDC, BADGE)')
+    .requiredOption('--denom <symbol|denom>', 'Coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .requiredOption('--verifier <address>', 'Verifier address (bb1...)')
     .requiredOption('--recipient <address>', 'Recipient address (bb1...)')
     .requiredOption('--submitter <address>', 'Submitter address (bb1...) — receives the refund on deny / expire. Typically the bounty creator.')
@@ -643,8 +652,9 @@ sharedOpts(
 ).action(async (opts) => {
   const { buildBounty } = await import('../../core/builders/bounty.js');
   if (opts.json) { emit(buildBounty(readJsonInput(opts.json)), opts); return; }
+  const denom = requireBbDenom(opts.denom, '--denom');
   emit(buildBounty({
-    amount: Number(opts.amount), denom: opts.denom, verifier: opts.verifier, recipient: opts.recipient,
+    amount: Number(opts.amount), denom, verifier: opts.verifier, recipient: opts.recipient,
     submitter: opts.submitter,
     expiration: opts.expiration, uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
   }), opts);
@@ -655,7 +665,7 @@ sharedOpts(
     .command('payment-request')
     .description('Create an agent-initiated payment request (no-escrow inverse of bounty). Metadata: pass --uri OR --name + --image + (--description OR --context).')
     .requiredOption('--amount <n>', 'Payment amount (display units)')
-    .requiredOption('--denom <symbol>', 'Coin (USDC, BADGE)')
+    .requiredOption('--denom <symbol|denom>', 'Coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .requiredOption('--payer <address>', 'Payer address (bb1...) — the human approver')
     .requiredOption('--recipient <address>', 'Recipient address (bb1...) — agent/merchant')
     .option('--expiration <duration>', 'Expiration duration', '30d')
@@ -663,9 +673,10 @@ sharedOpts(
 ).action(async (opts) => {
   const { buildPaymentRequest } = await import('../../core/builders/payment-request.js');
   if (opts.json) { emit(buildPaymentRequest(readJsonInput(opts.json)), opts); return; }
+  const denom = requireBbDenom(opts.denom, '--denom');
   emit(buildPaymentRequest({
     amount: Number(opts.amount),
-    denom: opts.denom,
+    denom,
     payer: opts.payer,
     recipient: opts.recipient,
     expiration: opts.expiration,
@@ -681,14 +692,15 @@ sharedOpts(
     .command('crowdfund')
     .description('Create a crowdfunding collection. Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--goal <n>', 'Funding goal (display units)')
-    .requiredOption('--denom <symbol>', 'Coin (USDC, BADGE)')
+    .requiredOption('--denom <symbol|denom>', 'Coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .option('--crowdfunder <address>', 'Who receives funds on success (bb1...)')
     .option('--deadline <duration>', 'Deadline duration', '30d')
 ).action(async (opts) => {
   const { buildCrowdfund } = await import('../../core/builders/crowdfund.js');
   if (opts.json) { emit(buildCrowdfund(readJsonInput(opts.json)), opts); return; }
+  const denom = requireBbDenom(opts.denom, '--denom');
   emit(buildCrowdfund({
-    goal: Number(opts.goal), denom: opts.denom, crowdfunder: opts.crowdfunder, deadline: opts.deadline,
+    goal: Number(opts.goal), denom, crowdfunder: opts.crowdfunder, deadline: opts.deadline,
     uri: opts.uri, name: opts.name, description: opts.description, image: opts.image, creator: opts.creator
   }), opts);
 });
@@ -749,7 +761,7 @@ sharedOpts(
     .description('Create a binary prediction market (YES/NO). Metadata: pass --uri OR --name + --image + --description.')
     .option('--verifier <address>', 'Market resolver address (bb1...)')
     .option('--resolver <address>', 'Alias for --verifier — matches the help-text label.')
-    .option('--denom <symbol>', 'Payment coin', 'USDC')
+    .option('--denom <symbol|denom>', 'Payment coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', 'USDC')
 ).action(async (opts) => {
   const { buildPredictionMarket } = await import('../../core/builders/prediction-market.js');
   if (opts.json) { emit(buildPredictionMarket(readJsonInput(opts.json)), opts); return; }
@@ -758,8 +770,9 @@ sharedOpts(
     process.stderr.write('Error: --verifier (or --resolver) is required.\n');
     process.exit(2);
   }
+  const denom = requireBbDenom(opts.denom, '--denom');
   emit(buildPredictionMarket({
-    verifier, denom: opts.denom,
+    verifier, denom,
     uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
   }), opts);
 });
@@ -791,19 +804,20 @@ sharedOpts(
   buildCommand
     .command('credit-token')
     .description('Create a credit/prepaid token. Metadata: pass --uri OR --name + --image + --description.')
-    .option('--payment-denom <symbol>', 'Payment coin (USDC, BADGE)')
-    .option('--denom <symbol>', 'Alias for --payment-denom — for consistency with the other builders.')
+    .option('--payment-denom <symbol|denom>', 'Payment coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
+    .option('--denom <symbol|denom>', 'Alias for --payment-denom — for consistency with the other builders.')
     .requiredOption('--recipient <address>', 'Payment recipient (bb1...)')
     .option('--symbol <symbol>', 'Token symbol', 'CREDIT')
     .option('--tokens-per-unit <n>', 'Tokens per 1 display unit of payment', '100')
 ).action(async (opts) => {
   const { buildCreditToken } = await import('../../core/builders/credit-token.js');
   if (opts.json) { emit(buildCreditToken(readJsonInput(opts.json)), opts); return; }
-  const paymentDenom = opts.paymentDenom ?? opts.denom;
-  if (!paymentDenom) {
+  const paymentDenomRaw = opts.paymentDenom ?? opts.denom;
+  if (!paymentDenomRaw) {
     process.stderr.write('Error: --payment-denom (or --denom) is required.\n');
     process.exit(2);
   }
+  const paymentDenom = requireBbDenom(paymentDenomRaw, opts.paymentDenom ? '--payment-denom' : '--denom');
   emit(buildCreditToken({
     paymentDenom, recipient: opts.recipient, symbol: opts.symbol,
     tokensPerUnit: Number(opts.tokensPerUnit),
@@ -831,13 +845,14 @@ sharedOpts(
     .command('quests')
     .description('Create a quest/reward collection. Metadata: pass --uri OR --name + --image + --description.')
     .requiredOption('--reward <n>', 'Reward per claim (display units)')
-    .requiredOption('--denom <symbol>', 'Reward coin (USDC, BADGE)')
+    .requiredOption('--denom <symbol|denom>', 'Reward coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .requiredOption('--max-claims <n>', 'Maximum number of claims')
 ).action(async (opts) => {
   const { buildQuests } = await import('../../core/builders/quests.js');
   if (opts.json) { emit(buildQuests(readJsonInput(opts.json)), opts); return; }
+  const denom = requireBbDenom(opts.denom, '--denom');
   emit(buildQuests({
-    reward: Number(opts.reward), denom: opts.denom, maxClaims: Number(opts.maxClaims),
+    reward: Number(opts.reward), denom, maxClaims: Number(opts.maxClaims),
     uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
   }), opts);
 });
@@ -865,15 +880,17 @@ sharedOpts(
     .description('Create an OTC swap intent (user outgoing approval)')
     .requiredOption('--address <address>', 'Creator address (bb1...)')
     .requiredOption('--collection-id <id>', 'Intent Exchange collection ID')
-    .requiredOption('--pay-denom <symbol>', 'What you send (USDC, BADGE)')
+    .requiredOption('--pay-denom <symbol|denom>', 'What you send. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .requiredOption('--pay-amount <n>', 'Amount you send (display units)')
-    .requiredOption('--receive-denom <symbol>', 'What you receive (USDC, BADGE)')
+    .requiredOption('--receive-denom <symbol|denom>', 'What you receive. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .requiredOption('--receive-amount <n>', 'Amount you receive (display units)')
     .option('--expiration <duration>', 'How long intent stays open', '7d')
 ).action(async (opts) => {
   const { buildIntent } = await import('../../core/builders/intent.js');
   if (opts.json) { emit(buildIntent(readJsonInput(opts.json)), opts); return; }
-  emit(buildIntent({ address: opts.address, collectionId: opts.collectionId, payDenom: opts.payDenom, payAmount: Number(opts.payAmount), receiveDenom: opts.receiveDenom, receiveAmount: Number(opts.receiveAmount), expiration: opts.expiration }), opts);
+  const payDenom = requireBbDenom(opts.payDenom, '--pay-denom');
+  const receiveDenom = requireBbDenom(opts.receiveDenom, '--receive-denom');
+  emit(buildIntent({ address: opts.address, collectionId: opts.collectionId, payDenom, payAmount: Number(opts.payAmount), receiveDenom, receiveAmount: Number(opts.receiveAmount), expiration: opts.expiration }), opts);
 });
 
 sharedOpts(
@@ -882,14 +899,15 @@ sharedOpts(
     .description('Create a recurring payment approval (user incoming)')
     .requiredOption('--collection-id <id>', 'Subscription collection ID')
     .requiredOption('--amount <n>', 'Payment amount per interval (display units)')
-    .requiredOption('--denom <symbol>', 'Payment coin (USDC, BADGE)')
+    .requiredOption('--denom <symbol|denom>', 'Payment coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .requiredOption('--interval <duration>', 'Payment interval (daily, monthly, annually)')
     .requiredOption('--recipient <address>', 'Who receives payments (bb1...)')
     .option('--expiration <duration>', 'How long subscription lasts', '365d')
 ).action(async (opts) => {
   const { buildRecurringPayment } = await import('../../core/builders/recurring-payment.js');
   if (opts.json) { emit(buildRecurringPayment(readJsonInput(opts.json)), opts); return; }
-  emit(buildRecurringPayment({ collectionId: opts.collectionId, amount: Number(opts.amount), denom: opts.denom, interval: opts.interval, recipient: opts.recipient, expiration: opts.expiration }), opts);
+  const denom = requireBbDenom(opts.denom, '--denom');
+  emit(buildRecurringPayment({ collectionId: opts.collectionId, amount: Number(opts.amount), denom, interval: opts.interval, recipient: opts.recipient, expiration: opts.expiration }), opts);
 });
 
 sharedOpts(
@@ -900,13 +918,14 @@ sharedOpts(
     .requiredOption('--collection-id <id>', 'Collection ID to list from')
     .requiredOption('--token-ids <range>', 'Token ID range (e.g. "1-5" or "1")')
     .requiredOption('--price <n>', 'Asking price (display units)')
-    .requiredOption('--denom <symbol>', 'Price coin (USDC, BADGE)')
+    .requiredOption('--denom <symbol|denom>', 'Price coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .option('--max-sales <n>', 'Maximum number of sales', '1')
     .option('--expiration <duration>', 'Listing duration', '30d')
 ).action(async (opts) => {
   const { buildListing } = await import('../../core/builders/listing.js');
   if (opts.json) { emit(buildListing(readJsonInput(opts.json)), opts); return; }
-  emit(buildListing({ address: opts.address, collectionId: opts.collectionId, tokenIds: opts.tokenIds, price: Number(opts.price), denom: opts.denom, maxSales: Number(opts.maxSales), expiration: opts.expiration }), opts);
+  const denom = requireBbDenom(opts.denom, '--denom');
+  emit(buildListing({ address: opts.address, collectionId: opts.collectionId, tokenIds: opts.tokenIds, price: Number(opts.price), denom, maxSales: Number(opts.maxSales), expiration: opts.expiration }), opts);
 });
 
 sharedOpts(
@@ -917,12 +936,13 @@ sharedOpts(
     .requiredOption('--collection-id <id>', 'Collection ID to bid on')
     .requiredOption('--token-ids <range>', 'Token ID range (e.g. "1-5" or "1")')
     .requiredOption('--price <n>', 'Bid price (display units)')
-    .requiredOption('--denom <symbol>', 'Price coin (USDC, BADGE)')
+    .requiredOption('--denom <symbol|denom>', 'Price coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .option('--expiration <duration>', 'Bid duration', '7d')
 ).action(async (opts) => {
   const { buildBid } = await import('../../core/builders/bid.js');
   if (opts.json) { emit(buildBid(readJsonInput(opts.json)), opts); return; }
-  emit(buildBid({ address: opts.address, collectionId: opts.collectionId, tokenIds: opts.tokenIds, price: Number(opts.price), denom: opts.denom, expiration: opts.expiration }), opts);
+  const denom = requireBbDenom(opts.denom, '--denom');
+  emit(buildBid({ address: opts.address, collectionId: opts.collectionId, tokenIds: opts.tokenIds, price: Number(opts.price), denom, expiration: opts.expiration }), opts);
 });
 
 sharedOpts(
@@ -934,12 +954,13 @@ sharedOpts(
     .requiredOption('--token <yes|no>', 'Which outcome token to sell')
     .requiredOption('--amount <n>', 'Number of tokens to sell')
     .requiredOption('--price <n>', 'Total payment amount (display units)')
-    .requiredOption('--denom <symbol>', 'Payment coin (USDC, BADGE)')
+    .requiredOption('--denom <symbol|denom>', 'Payment coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .option('--expiration <duration>', 'How long intent stays open', '7d')
 ).action(async (opts) => {
   const { buildPmSellIntent } = await import('../../core/builders/pm-sell-intent.js');
   if (opts.json) { emit(buildPmSellIntent(readJsonInput(opts.json)), opts); return; }
-  emit(buildPmSellIntent({ address: opts.address, collectionId: opts.collectionId, token: opts.token, amount: Number(opts.amount), price: Number(opts.price), denom: opts.denom, expiration: opts.expiration }), opts);
+  const denom = requireBbDenom(opts.denom, '--denom');
+  emit(buildPmSellIntent({ address: opts.address, collectionId: opts.collectionId, token: opts.token, amount: Number(opts.amount), price: Number(opts.price), denom, expiration: opts.expiration }), opts);
 });
 
 sharedOpts(
@@ -951,12 +972,13 @@ sharedOpts(
     .requiredOption('--token <yes|no>', 'Which outcome token to buy')
     .requiredOption('--amount <n>', 'Number of tokens to buy')
     .requiredOption('--price <n>', 'Total payment amount (display units)')
-    .requiredOption('--denom <symbol>', 'Payment coin (USDC, BADGE)')
+    .requiredOption('--denom <symbol|denom>', 'Payment coin. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .option('--expiration <duration>', 'How long intent stays open', '7d')
 ).action(async (opts) => {
   const { buildPmBuyIntent } = await import('../../core/builders/pm-buy-intent.js');
   if (opts.json) { emit(buildPmBuyIntent(readJsonInput(opts.json)), opts); return; }
-  emit(buildPmBuyIntent({ address: opts.address, collectionId: opts.collectionId, token: opts.token, amount: Number(opts.amount), price: Number(opts.price), denom: opts.denom, expiration: opts.expiration }), opts);
+  const denom = requireBbDenom(opts.denom, '--denom');
+  emit(buildPmBuyIntent({ address: opts.address, collectionId: opts.collectionId, token: opts.token, amount: Number(opts.amount), price: Number(opts.price), denom, expiration: opts.expiration }), opts);
 });
 
 // ============================================================
@@ -997,14 +1019,18 @@ sharedOpts(
       let amount: string;
       if (opts.baseUnits) {
         // Caller wants raw base units regardless of how --denom resolves.
-        denom = opts.denom;
+        denom = requireBbDenom(opts.denom, '--denom');
         amount = String(opts.amount).replace(/[_,]/g, '');
         if (!/^\d+$/.test(amount)) {
           process.stderr.write(`Error: --amount must be a non-negative integer when --base-units is set, got "${opts.amount}"\n`);
           process.exit(2);
         }
       } else {
-        const resolved = resolveCoin(opts.denom);
+        // requireBbDenom catches uusdc/uatom/uosmo before resolveCoin
+        // even sees them; resolveCoin then handles the canonical
+        // baseDenom path.
+        const validated = requireBbDenom(opts.denom, '--denom');
+        const resolved = resolveCoin(validated);
         denom = resolved.denom;
         // Resolved symbol → display units + decimals. Resolved raw denom
         // → resolveCoin returns decimals from registry; same path.

--- a/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
@@ -7,6 +7,7 @@ import { isCollectionMsg, normalizeToCreateOrUpdate } from '../utils/normalizeMs
 import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
 import { runBurnerCreate, pickBurner, type BurnerNetwork } from '../utils/burner.js';
 import { requireBbDenom } from '../utils/denom.js';
+import { requireBb1AddressStrict } from '../utils/address.js';
 
 export const buildCommand = new Command('build').description('Deterministic transaction builders — flag-based generators for vaults, NFTs, subscriptions, bounties, and more. Output: ready-to-sign JSON. To broadcast, pipe into `bb cli deploy --burner`.');
 
@@ -628,13 +629,16 @@ sharedOpts(
         if (p && typeof p === 'object' && typeof p.denom === 'string') {
           p.denom = requireBbDenom(p.denom, '--payouts entry denom');
         }
+        if (p && typeof p === 'object' && typeof p.recipient === 'string') {
+          p.recipient = requireBb1AddressStrict(p.recipient, '--payouts entry recipient');
+        }
       }
     }
     params.payouts = payouts;
   } else {
     params.price = Number(opts.price);
     params.denom = opts.denom ? requireBbDenom(opts.denom, '--denom') : opts.denom;
-    params.recipient = opts.recipient;
+    params.recipient = opts.recipient ? requireBb1AddressStrict(opts.recipient, '--recipient') : opts.recipient;
   }
   emit(buildSubscription(params), opts);
 });
@@ -653,9 +657,12 @@ sharedOpts(
   const { buildBounty } = await import('../../core/builders/bounty.js');
   if (opts.json) { emit(buildBounty(readJsonInput(opts.json)), opts); return; }
   const denom = requireBbDenom(opts.denom, '--denom');
+  const verifier = requireBb1AddressStrict(opts.verifier, '--verifier');
+  const recipient = requireBb1AddressStrict(opts.recipient, '--recipient');
+  const submitter = requireBb1AddressStrict(opts.submitter, '--submitter');
   emit(buildBounty({
-    amount: Number(opts.amount), denom, verifier: opts.verifier, recipient: opts.recipient,
-    submitter: opts.submitter,
+    amount: Number(opts.amount), denom, verifier, recipient,
+    submitter,
     expiration: opts.expiration, uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
   }), opts);
 });
@@ -674,11 +681,13 @@ sharedOpts(
   const { buildPaymentRequest } = await import('../../core/builders/payment-request.js');
   if (opts.json) { emit(buildPaymentRequest(readJsonInput(opts.json)), opts); return; }
   const denom = requireBbDenom(opts.denom, '--denom');
+  const payer = requireBb1AddressStrict(opts.payer, '--payer');
+  const recipient = requireBb1AddressStrict(opts.recipient, '--recipient');
   emit(buildPaymentRequest({
     amount: Number(opts.amount),
     denom,
-    payer: opts.payer,
-    recipient: opts.recipient,
+    payer,
+    recipient,
     expiration: opts.expiration,
     uri: opts.uri,
     name: opts.name,
@@ -699,8 +708,9 @@ sharedOpts(
   const { buildCrowdfund } = await import('../../core/builders/crowdfund.js');
   if (opts.json) { emit(buildCrowdfund(readJsonInput(opts.json)), opts); return; }
   const denom = requireBbDenom(opts.denom, '--denom');
+  const crowdfunder = opts.crowdfunder ? requireBb1AddressStrict(opts.crowdfunder, '--crowdfunder') : opts.crowdfunder;
   emit(buildCrowdfund({
-    goal: Number(opts.goal), denom, crowdfunder: opts.crowdfunder, deadline: opts.deadline,
+    goal: Number(opts.goal), denom, crowdfunder, deadline: opts.deadline,
     uri: opts.uri, name: opts.name, description: opts.description, image: opts.image, creator: opts.creator
   }), opts);
 });
@@ -749,8 +759,9 @@ sharedOpts(
   const { buildProductCatalog } = await import('../../core/builders/product-catalog.js');
   if (opts.json) { emit(buildProductCatalog(readJsonInput(opts.json)), opts); return; }
   const products = JSON.parse(opts.products);
+  const storeAddress = requireBb1AddressStrict(opts.storeAddress, '--store-address');
   emit(buildProductCatalog({
-    products, storeAddress: opts.storeAddress,
+    products, storeAddress,
     uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
   }), opts);
 });
@@ -765,11 +776,12 @@ sharedOpts(
 ).action(async (opts) => {
   const { buildPredictionMarket } = await import('../../core/builders/prediction-market.js');
   if (opts.json) { emit(buildPredictionMarket(readJsonInput(opts.json)), opts); return; }
-  const verifier = opts.verifier ?? opts.resolver;
-  if (!verifier) {
+  const verifierRaw = opts.verifier ?? opts.resolver;
+  if (!verifierRaw) {
     process.stderr.write('Error: --verifier (or --resolver) is required.\n');
     process.exit(2);
   }
+  const verifier = requireBb1AddressStrict(verifierRaw, opts.verifier ? '--verifier' : '--resolver');
   const denom = requireBbDenom(opts.denom, '--denom');
   emit(buildPredictionMarket({
     verifier, denom,
@@ -818,8 +830,9 @@ sharedOpts(
     process.exit(2);
   }
   const paymentDenom = requireBbDenom(paymentDenomRaw, opts.paymentDenom ? '--payment-denom' : '--denom');
+  const recipient = requireBb1AddressStrict(opts.recipient, '--recipient');
   emit(buildCreditToken({
-    paymentDenom, recipient: opts.recipient, symbol: opts.symbol,
+    paymentDenom, recipient, symbol: opts.symbol,
     tokensPerUnit: Number(opts.tokensPerUnit),
     uri: opts.uri, name: opts.name, description: opts.description, image: opts.image
   }), opts);
@@ -890,7 +903,8 @@ sharedOpts(
   if (opts.json) { emit(buildIntent(readJsonInput(opts.json)), opts); return; }
   const payDenom = requireBbDenom(opts.payDenom, '--pay-denom');
   const receiveDenom = requireBbDenom(opts.receiveDenom, '--receive-denom');
-  emit(buildIntent({ address: opts.address, collectionId: opts.collectionId, payDenom, payAmount: Number(opts.payAmount), receiveDenom, receiveAmount: Number(opts.receiveAmount), expiration: opts.expiration }), opts);
+  const address = requireBb1AddressStrict(opts.address, '--address');
+  emit(buildIntent({ address, collectionId: opts.collectionId, payDenom, payAmount: Number(opts.payAmount), receiveDenom, receiveAmount: Number(opts.receiveAmount), expiration: opts.expiration }), opts);
 });
 
 sharedOpts(
@@ -907,7 +921,8 @@ sharedOpts(
   const { buildRecurringPayment } = await import('../../core/builders/recurring-payment.js');
   if (opts.json) { emit(buildRecurringPayment(readJsonInput(opts.json)), opts); return; }
   const denom = requireBbDenom(opts.denom, '--denom');
-  emit(buildRecurringPayment({ collectionId: opts.collectionId, amount: Number(opts.amount), denom, interval: opts.interval, recipient: opts.recipient, expiration: opts.expiration }), opts);
+  const recipient = requireBb1AddressStrict(opts.recipient, '--recipient');
+  emit(buildRecurringPayment({ collectionId: opts.collectionId, amount: Number(opts.amount), denom, interval: opts.interval, recipient, expiration: opts.expiration }), opts);
 });
 
 sharedOpts(
@@ -925,7 +940,8 @@ sharedOpts(
   const { buildListing } = await import('../../core/builders/listing.js');
   if (opts.json) { emit(buildListing(readJsonInput(opts.json)), opts); return; }
   const denom = requireBbDenom(opts.denom, '--denom');
-  emit(buildListing({ address: opts.address, collectionId: opts.collectionId, tokenIds: opts.tokenIds, price: Number(opts.price), denom, maxSales: Number(opts.maxSales), expiration: opts.expiration }), opts);
+  const address = requireBb1AddressStrict(opts.address, '--address');
+  emit(buildListing({ address, collectionId: opts.collectionId, tokenIds: opts.tokenIds, price: Number(opts.price), denom, maxSales: Number(opts.maxSales), expiration: opts.expiration }), opts);
 });
 
 sharedOpts(
@@ -942,7 +958,8 @@ sharedOpts(
   const { buildBid } = await import('../../core/builders/bid.js');
   if (opts.json) { emit(buildBid(readJsonInput(opts.json)), opts); return; }
   const denom = requireBbDenom(opts.denom, '--denom');
-  emit(buildBid({ address: opts.address, collectionId: opts.collectionId, tokenIds: opts.tokenIds, price: Number(opts.price), denom, expiration: opts.expiration }), opts);
+  const address = requireBb1AddressStrict(opts.address, '--address');
+  emit(buildBid({ address, collectionId: opts.collectionId, tokenIds: opts.tokenIds, price: Number(opts.price), denom, expiration: opts.expiration }), opts);
 });
 
 sharedOpts(
@@ -960,7 +977,8 @@ sharedOpts(
   const { buildPmSellIntent } = await import('../../core/builders/pm-sell-intent.js');
   if (opts.json) { emit(buildPmSellIntent(readJsonInput(opts.json)), opts); return; }
   const denom = requireBbDenom(opts.denom, '--denom');
-  emit(buildPmSellIntent({ address: opts.address, collectionId: opts.collectionId, token: opts.token, amount: Number(opts.amount), price: Number(opts.price), denom, expiration: opts.expiration }), opts);
+  const address = requireBb1AddressStrict(opts.address, '--address');
+  emit(buildPmSellIntent({ address, collectionId: opts.collectionId, token: opts.token, amount: Number(opts.amount), price: Number(opts.price), denom, expiration: opts.expiration }), opts);
 });
 
 sharedOpts(
@@ -978,7 +996,8 @@ sharedOpts(
   const { buildPmBuyIntent } = await import('../../core/builders/pm-buy-intent.js');
   if (opts.json) { emit(buildPmBuyIntent(readJsonInput(opts.json)), opts); return; }
   const denom = requireBbDenom(opts.denom, '--denom');
-  emit(buildPmBuyIntent({ address: opts.address, collectionId: opts.collectionId, token: opts.token, amount: Number(opts.amount), price: Number(opts.price), denom, expiration: opts.expiration }), opts);
+  const address = requireBb1AddressStrict(opts.address, '--address');
+  emit(buildPmBuyIntent({ address, collectionId: opts.collectionId, token: opts.token, amount: Number(opts.amount), price: Number(opts.price), denom, expiration: opts.expiration }), opts);
 });
 
 // ============================================================
@@ -1011,10 +1030,10 @@ sharedOpts(
 )
   .action(async (opts) => {
     try {
-      const { requireBb1Address } = await import('../utils/address.js');
+      const { requireBb1AddressStrict } = await import('../utils/address.js');
       const { resolveCoin, toBaseUnits } = await import('../../core/builders/shared.js');
-      const fromAddress = requireBb1Address(opts.from, '--from');
-      const toAddress = requireBb1Address(opts.to, '--to');
+      const fromAddress = requireBb1AddressStrict(opts.from, '--from');
+      const toAddress = requireBb1AddressStrict(opts.to, '--to');
       let denom: string;
       let amount: string;
       if (opts.baseUnits) {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
@@ -26,6 +26,7 @@ import {
 } from '../utils/burner.js';
 import { BitBadgesSigningClient } from '../../signing/BitBadgesSigningClient.js';
 import { requireBbDenom } from '../utils/denom.js';
+import { requireBb1AddressStrict } from '../utils/address.js';
 
 export const burnerCommand = new Command('burner')
   .usage(' ')
@@ -216,11 +217,12 @@ sweepCmd.action(async (selector: string, opts: any) => {
   const { encodeMsgFromJson } = await import('../../transactions/messages/fromJson.js');
   let protoMsg;
   try {
+    const toAddress = requireBb1AddressStrict(opts.to, '--to');
     protoMsg = encodeMsgFromJson({
       typeUrl: '/cosmos.bank.v1beta1.MsgSend',
       value: {
         fromAddress: rec.address,
-        toAddress: opts.to,
+        toAddress,
         amount: [{ denom, amount: sendAmount.toString() }]
       }
     });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
@@ -25,6 +25,7 @@ import {
   type BurnerNetwork
 } from '../utils/burner.js';
 import { BitBadgesSigningClient } from '../../signing/BitBadgesSigningClient.js';
+import { requireBbDenom } from '../utils/denom.js';
 
 export const burnerCommand = new Command('burner')
   .usage(' ')
@@ -112,7 +113,7 @@ const resumeCmd = burnerCommand
   .requiredOption('--manager <address>', 'Collection manager address (bb1...)')
   .option('--fund <mode>', 'Funding mode if the wallet is still unfunded', 'faucet')
   .option('--fee <amount>', 'Fee amount in base units', '0')
-  .option('--fee-denom <denom>', 'Fee denom', 'ubadge')
+  .option('--fee-denom <symbol|denom>', 'Fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', 'ubadge')
   .option('--gas <number>', 'Gas limit', '400000')
   .option('--poll-timeout <seconds>', 'Seconds to wait for funding', '60');
 addNetworkOptions(resumeCmd);
@@ -147,7 +148,7 @@ resumeCmd.action(async (selector: string, opts: any) => {
     manager: opts.manager,
     fund: opts.fund === 'manual' ? 'manual' : 'faucet',
     apiKey,
-    fee: { amount: String(opts.fee), denom: String(opts.feeDenom || 'ubadge') },
+    fee: { amount: String(opts.fee), denom: requireBbDenom(String(opts.feeDenom || 'ubadge'), '--fee-denom') },
     gas: Number(opts.gas),
     reuseRecord: rec,
     nonInteractive: !process.stdout.isTTY,
@@ -165,7 +166,7 @@ const sweepCmd = burnerCommand
   .description('Send the burner\'s remaining balance to another address and mark it swept.')
   .argument('<selector>', 'Address or recovery file path')
   .requiredOption('--to <address>', 'Recipient address (bb1...)')
-  .option('--denom <denom>', 'Coin denom to sweep', 'ubadge')
+  .option('--denom <symbol|denom>', 'Coin denom to sweep. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', 'ubadge')
   .option('--fee <amount>', 'Fee amount', '0')
   .option('--gas <number>', 'Gas limit', '200000');
 addNetworkOptions(sweepCmd);
@@ -180,9 +181,10 @@ sweepCmd.action(async (selector: string, opts: any) => {
   const apiUrl = getApiUrl({ ...opts, network });
   const apiKey = getApiKeyForNetwork({ ...opts, network });
 
-  const balance = await fetchBalance(nodeUrl, rec.address, opts.denom);
+  const denom = requireBbDenom(String(opts.denom || 'ubadge'), '--denom');
+  const balance = await fetchBalance(nodeUrl, rec.address, denom);
   if (balance === 0n) {
-    process.stderr.write(`Hot wallet ${rec.address} has zero ${opts.denom} balance — nothing to sweep.\n`);
+    process.stderr.write(`Hot wallet ${rec.address} has zero ${denom} balance — nothing to sweep.\n`);
     return;
   }
   // Reserve the fee from the swept amount.
@@ -219,7 +221,7 @@ sweepCmd.action(async (selector: string, opts: any) => {
       value: {
         fromAddress: rec.address,
         toAddress: opts.to,
-        amount: [{ denom: opts.denom, amount: sendAmount.toString() }]
+        amount: [{ denom, amount: sendAmount.toString() }]
       }
     });
   } catch (err: any) {
@@ -231,7 +233,7 @@ sweepCmd.action(async (selector: string, opts: any) => {
   }
 
   const result = await client.signAndBroadcast([protoMsg], {
-    fee: { amount: opts.fee || '0', denom: opts.denom, gas: String(opts.gas) },
+    fee: { amount: opts.fee || '0', denom, gas: String(opts.gas) },
     simulate: false
   });
   if (!result.success) {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
@@ -34,7 +34,7 @@ export const burnerCommand = new Command('burner')
   .description(
     [
       'Manage the throwaway, dust-only burners created by',
-      '`bitbadges-cli deploy --burner`.',
+      '`bb deploy --burner`.',
       '',
       'These wallets are single-use, disposable signers that exist only to put',
       'ONE create-collection tx on-chain. They are stored in PLAINTEXT under',

--- a/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
@@ -25,7 +25,7 @@ import {
   type BurnerNetwork
 } from '../utils/burner.js';
 import { BitBadgesSigningClient } from '../../signing/BitBadgesSigningClient.js';
-import { requireBbDenom } from '../utils/denom.js';
+import { requireBbDenom, DEFAULT_FEE_DENOM } from '../utils/denom.js';
 import { requireBb1AddressStrict } from '../utils/address.js';
 
 export const burnerCommand = new Command('burner')
@@ -114,7 +114,7 @@ const resumeCmd = burnerCommand
   .requiredOption('--manager <address>', 'Collection manager address (bb1...)')
   .option('--fund <mode>', 'Funding mode if the wallet is still unfunded', 'faucet')
   .option('--fee <amount>', 'Fee amount in base units', '0')
-  .option('--fee-denom <symbol|denom>', 'Fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', 'ubadge')
+  .option('--fee-denom <symbol|denom>', 'Fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', DEFAULT_FEE_DENOM)
   .option('--gas <number>', 'Gas limit', '400000')
   .option('--poll-timeout <seconds>', 'Seconds to wait for funding', '60');
 addNetworkOptions(resumeCmd);
@@ -149,7 +149,7 @@ resumeCmd.action(async (selector: string, opts: any) => {
     manager: opts.manager,
     fund: opts.fund === 'manual' ? 'manual' : 'faucet',
     apiKey,
-    fee: { amount: String(opts.fee), denom: requireBbDenom(String(opts.feeDenom || 'ubadge'), '--fee-denom') },
+    fee: { amount: String(opts.fee), denom: requireBbDenom(String(opts.feeDenom || DEFAULT_FEE_DENOM), '--fee-denom') },
     gas: Number(opts.gas),
     reuseRecord: rec,
     nonInteractive: !process.stdout.isTTY,
@@ -167,7 +167,7 @@ const sweepCmd = burnerCommand
   .description('Send the burner\'s remaining balance to another address and mark it swept.')
   .argument('<selector>', 'Address or recovery file path')
   .requiredOption('--to <address>', 'Recipient address (bb1...)')
-  .option('--denom <symbol|denom>', 'Coin denom to sweep. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', 'ubadge')
+  .option('--denom <symbol|denom>', 'Coin denom to sweep. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', DEFAULT_FEE_DENOM)
   .option('--fee <amount>', 'Fee amount', '0')
   .option('--gas <number>', 'Gas limit', '200000');
 addNetworkOptions(sweepCmd);
@@ -182,7 +182,7 @@ sweepCmd.action(async (selector: string, opts: any) => {
   const apiUrl = getApiUrl({ ...opts, network });
   const apiKey = getApiKeyForNetwork({ ...opts, network });
 
-  const denom = requireBbDenom(String(opts.denom || 'ubadge'), '--denom');
+  const denom = requireBbDenom(String(opts.denom || DEFAULT_FEE_DENOM), '--denom');
   const balance = await fetchBalance(nodeUrl, rec.address, denom);
   if (balance === 0n) {
     process.stderr.write(`Hot wallet ${rec.address} has zero ${denom} balance — nothing to sweep.\n`);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/credit-tokens.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/credit-tokens.ts
@@ -147,7 +147,11 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb credit-tokens purchase 23 --creator bb1buyer...xyz --units 10 | bb deploy
+  $ bb credit-tokens purchase 23 --creator bb1buyer...xyz --units 10 --tier premium-tier | bb deploy
+`);
 
 // Per-standard `build` subcommand removed in CLI v2 (#0399).
 // Use `bb build credit-token ...` (the canonical builder) instead.

--- a/packages/bitbadgesjs-sdk/src/cli/commands/credit-tokens.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/credit-tokens.ts
@@ -20,7 +20,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1AddressStrict } from '../utils/address.js';
 import {
   doesCollectionFollowCreditTokenProtocol,
   extractCreditTokenTiers,
@@ -120,7 +120,7 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; units: string; tier?: string }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'credit-tokens purchase');
       const tiers = extractCreditTokenTiers(collection.collectionApprovals);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
@@ -10,7 +10,7 @@
 
 import { Command } from 'commander';
 import { apiRequest, resolveApiKey, resolveBaseUrl } from '../utils/api-client.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
 import { emit, emitError } from '../utils/envelope.js';
 import {
   doesCollectionFollowCrowdfundProtocol,
@@ -211,7 +211,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'crowdfund contribute');
     const details = extractCrowdfundDetails(collection.collectionApprovals)!;
@@ -231,7 +231,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'crowdfund withdraw');
     const details = extractCrowdfundDetails(collection.collectionApprovals)!;
@@ -265,7 +265,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'crowdfund refund');
     const details = extractCrowdfundDetails(collection.collectionApprovals)!;

--- a/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
@@ -11,6 +11,7 @@
 import { Command } from 'commander';
 import { apiRequest, resolveApiKey, resolveBaseUrl } from '../utils/api-client.js';
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
+import { resolveAmount } from '../utils/amount.js';
 import { emit, emitError } from '../utils/envelope.js';
 import {
   doesCollectionFollowCrowdfundProtocol,
@@ -206,16 +207,23 @@ addOutputFlags(
       .command('contribute')
       .description('Emit a 2-msg tx that contributes <amount> to the crowdfund. Pipe to `bb deploy`.')
       .argument('<collection-id>', 'Crowdfund collection ID')
-      .requiredOption('--creator <address>', 'Contributor address (bb1.../0x — auto-normalized)')
-      .requiredOption('--amount <n>', 'Amount to contribute in base units (denom is the crowdfund\'s configured deposit denom)')
+      .requiredOption('--creator <address>', 'Contributor address (bb1...) — strict; run `bb account convert` for 0x')
+      .requiredOption('--amount <n>', 'Amount to contribute. Display units when the crowdfund\'s deposit denom is a registered symbol; base units when it\'s a chain denom. Use --base-units to force base-units.')
+      .option('--base-units', 'Treat --amount as already-in-base-units')
   )
-).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string }) => {
+).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string; baseUnits?: boolean }) => {
   try {
     const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'crowdfund contribute');
     const details = extractCrowdfundDetails(collection.collectionApprovals)!;
-    const tx = buildContributeCrowdfundTx(creator, String(collectionId), details, BigInt(opts.amount));
+    const { amount: amountStr } = resolveAmount(
+      opts.amount,
+      details.depositDenom,
+      Boolean(opts.baseUnits),
+      { amountFlag: '--amount', denomFlag: 'crowdfund deposit denom' }
+    );
+    const tx = buildContributeCrowdfundTx(creator, String(collectionId), details, BigInt(amountStr));
     // Single-msg per the helper output; bb deploy will accept either shape.
     emit(tx.messages[0], opts);
   } catch (err) { emitError(err); }
@@ -260,20 +268,27 @@ addOutputFlags(
       .command('refund')
       .description('Contributor refund (after deadline if goal not met): emit single MsgTransferTokens. Pipe to `bb deploy`.')
       .argument('<collection-id>', 'Crowdfund collection ID')
-      .requiredOption('--creator <address>', 'Contributor address (bb1.../0x — auto-normalized)')
-      .requiredOption('--amount <n>', 'Amount to refund in base units')
+      .requiredOption('--creator <address>', 'Contributor address (bb1...) — strict; run `bb account convert` for 0x')
+      .requiredOption('--amount <n>', 'Amount to refund. Display units when the crowdfund\'s deposit denom is a registered symbol; base units when it\'s a chain denom. Use --base-units to force base-units.')
+      .option('--base-units', 'Treat --amount as already-in-base-units')
   )
-).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string }) => {
+).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string; baseUnits?: boolean }) => {
   try {
     const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'crowdfund refund');
     const details = extractCrowdfundDetails(collection.collectionApprovals)!;
+    const { amount: amountStr } = resolveAmount(
+      opts.amount,
+      details.depositDenom,
+      Boolean(opts.baseUnits),
+      { amountFlag: '--amount', denomFlag: 'crowdfund deposit denom' }
+    );
     const now = BigInt(Date.now());
     if (now <= details.deadlineTime) {
       process.stderr.write(`Warning: deadline not yet passed (deadline=${details.deadlineTime}, now=${now}). Refund will be rejected.\n`);
     }
-    emit(buildRefundCrowdfundMsg(creator, String(collectionId), details, BigInt(opts.amount)), opts);
+    emit(buildRefundCrowdfundMsg(creator, String(collectionId), details, BigInt(amountStr)), opts);
   } catch (err) { emitError(err); }
 });
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
@@ -225,7 +225,11 @@ addOutputFlags(
     // Single-msg per the helper output; bb deploy will accept either shape.
     emit(tx.messages[0], opts);
   } catch (err) { emitError(err); }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb crowdfunds contribute 7 --creator bb1backer...xyz --amount 100 | bb deploy
+  $ bb crowdfunds contribute 7 --creator bb1backer...xyz --amount 100000000 --base-units | bb deploy
+`);
 
 addOutputFlags(
   addNetworkFlags(
@@ -258,7 +262,10 @@ addOutputFlags(
     const tx = buildWithdrawCrowdfundTx(creator, String(collectionId), details, raised, burnApprovalId);
     emit(tx, opts);
   } catch (err) { emitError(err); }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb crowdfunds withdraw 7 --creator bb1crowdfunder...xyz | bb deploy
+`);
 
 addOutputFlags(
   addNetworkFlags(
@@ -288,7 +295,10 @@ addOutputFlags(
     }
     emit(buildRefundCrowdfundMsg(creator, String(collectionId), details, BigInt(amountStr)), opts);
   } catch (err) { emitError(err); }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb crowdfunds refund 7 --creator bb1backer...xyz --amount 100 | bb deploy
+`);
 
 // Per-standard `build` subcommand removed in CLI v2 (#0399).
 // Use `bb build crowdfund ...` (the canonical builder) instead.

--- a/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
@@ -13,6 +13,7 @@ import { apiRequest, resolveApiKey, resolveBaseUrl } from '../utils/api-client.j
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
 import { resolveAmount } from '../utils/amount.js';
 import { emit, emitError } from '../utils/envelope.js';
+import { addIndexerOutputOptions as addOutputFlags } from '../utils/indexer-options.js';
 import {
   doesCollectionFollowCrowdfundProtocol,
   validateCrowdfundCollection,
@@ -36,9 +37,6 @@ function addNetworkFlags(cmd: Command): Command {
     .option('--local', 'Use local API (localhost:3001)', false)
     .option('--url <url>', 'Custom API base URL')
     .option('--api-key <key>', 'BitBadges API key');
-}
-function addOutputFlags(cmd: Command): Command {
-  return cmd.option('--output-file <path>', 'Write to file').option('--condensed', 'Single-line JSON', false);
 }
 async function callApi(method: 'GET' | 'POST', path: string, opts: NetworkFlags, body?: unknown): Promise<any> {
   const network = opts.testnet ? 'testnet' : opts.local ? 'local' : 'mainnet';

--- a/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
@@ -41,6 +41,7 @@ import {
   type ExtractedEntity,
   type WaitForIndexerResult
 } from '../utils/wait-for-indexer.js';
+import { requireBbDenom } from '../utils/denom.js';
 
 /**
  * Parse the `--wait-for-indexer` flag value. The flag is optional and may
@@ -336,7 +337,7 @@ export const deployCommand = new Command('deploy')
   .option('--manager <address>', 'Address that will own the created collection (bb1...). Required for --burner; recommended for --browser.')
   .option('--fund <mode>', 'With --burner: funding source for the burner (faucet | manual)', 'faucet')
   .option('--fee <amount>', 'Fee amount in base units (e.g. "0" or "5000")', '0')
-  .option('--fee-denom <denom>', 'Fee denom', 'ubadge')
+  .option('--fee-denom <symbol|denom>', 'Fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', 'ubadge')
   .option('--gas <number>', 'Gas limit', '400000')
   .option('--new', 'With --burner: skip the picker and always create a fresh burner')
   .option('--reuse <selector>', 'With --burner: reuse a specific saved burner by address or recovery file path')
@@ -852,7 +853,7 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
       manager: opts.manager,
       fund: opts.fund === 'manual' ? 'manual' : 'faucet',
       apiKey,
-      fee: { amount: String(opts.fee), denom: String(opts.feeDenom || 'ubadge') },
+      fee: { amount: String(opts.fee), denom: requireBbDenom(String(opts.feeDenom || 'ubadge'), '--fee-denom') },
       gas: Number(opts.gas),
       reuseRecord: choice.kind === 'reuse' ? choice.record : undefined,
       nonInteractive: Boolean(opts.nonInteractive) || !process.stdout.isTTY,

--- a/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
@@ -259,7 +259,7 @@ CRITICAL — DUST ONLY, NEVER REAL FUNDS
       you don't fully control
 
   If you accidentally funded one with more than dust, use
-  \`bitbadges-cli burner sweep <selector> --to <your-real-address>\`
+  \`bb burner sweep <selector> --to <your-real-address>\`
   to pull the balance back out immediately.
 
 ADVANTAGES
@@ -291,21 +291,21 @@ DISADVANTAGES
 TYPICAL USAGE
   Pipe a builder's JSON straight in:
 
-    bitbadges-cli build subscription --interval monthly \\
+    bb build subscription --interval monthly \\
         --price 10 --denom USDC --recipient bb1your-payout... \\
-      | bitbadges-cli deploy --burner --msg-stdin \\
+      | bb deploy --burner --msg-stdin \\
           --manager bb1your-real-address... --local
 
   Or pass a file:
 
-    bitbadges-cli deploy --burner --msg-file col.json \\
+    bb deploy --burner --msg-file col.json \\
         --manager bb1your-real-address... --testnet
 
 RELATED
-  bitbadges-cli burner list                 — see every saved
-  bitbadges-cli burner resume <selector>    — retry a paused run
-  bitbadges-cli burner sweep  <selector>    — recover dust
-  bitbadges-cli burner forget <selector>    — delete recovery file
+  bb burner list                 — see every saved
+  bb burner resume <selector>    — retry a paused run
+  bb burner sweep  <selector>    — recover dust
+  bb burner forget <selector>    — delete recovery file
 `.trim();
 
 export const deployCommand = new Command('deploy')
@@ -448,7 +448,7 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
 
   if (useBurner && opts.fund === 'faucet' && !apiKey && network !== 'local') {
     process.stderr.write(
-      'Warning: --fund faucet requires an API key on non-local networks. Set BITBADGES_API_KEY or `bitbadges-cli config set apiKey <key>`.\n'
+      'Warning: --fund faucet requires an API key on non-local networks. Pass --api-key or run `bb settings set apiKey <key>`.\n'
     );
   }
 
@@ -520,7 +520,7 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
     if (!apiKey && network !== 'local') {
       process.stderr.write(
         '--dry-run requires an API key on non-local networks (simulate hits the BitBadges API). ' +
-          'Set BITBADGES_API_KEY or `bitbadges-cli config set apiKey <key>`.\n'
+          'Pass --api-key or run `bb settings set apiKey <key>`.\n'
       );
       process.exit(2);
     }
@@ -869,7 +869,7 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
     const looksLikeInsufficient =
       errStr.includes('insufficient') || errStr.includes('not enough') || errStr.includes('balance');
     const hint = looksLikeInsufficient && result.ephemeralAddress
-      ? `Run \`bitbadges-cli burner sweep ${result.ephemeralAddress} --to <your-real-address>\` to recover dust, or wait for the faucet to refill.`
+      ? `Run \`bb burner sweep ${result.ephemeralAddress} --to <your-real-address>\` to recover dust, or wait for the faucet to refill.`
       : undefined;
 
     // Optional: hold the CLI open until the indexer has caught up with

--- a/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
@@ -41,7 +41,7 @@ import {
   type ExtractedEntity,
   type WaitForIndexerResult
 } from '../utils/wait-for-indexer.js';
-import { requireBbDenom } from '../utils/denom.js';
+import { requireBbDenom, DEFAULT_FEE_DENOM } from '../utils/denom.js';
 
 /**
  * Parse the `--wait-for-indexer` flag value. The flag is optional and may
@@ -337,7 +337,7 @@ export const deployCommand = new Command('deploy')
   .option('--manager <address>', 'Address that will own the created collection (bb1...). Required for --burner; recommended for --browser.')
   .option('--fund <mode>', 'With --burner: funding source for the burner (faucet | manual)', 'faucet')
   .option('--fee <amount>', 'Fee amount in base units (e.g. "0" or "5000")', '0')
-  .option('--fee-denom <symbol|denom>', 'Fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', 'ubadge')
+  .option('--fee-denom <symbol|denom>', 'Fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', DEFAULT_FEE_DENOM)
   .option('--gas <number>', 'Gas limit', '400000')
   .option('--new', 'With --burner: skip the picker and always create a fresh burner')
   .option('--reuse <selector>', 'With --burner: reuse a specific saved burner by address or recovery file path')
@@ -853,7 +853,7 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
       manager: opts.manager,
       fund: opts.fund === 'manual' ? 'manual' : 'faucet',
       apiKey,
-      fee: { amount: String(opts.fee), denom: requireBbDenom(String(opts.feeDenom || 'ubadge'), '--fee-denom') },
+      fee: { amount: String(opts.fee), denom: requireBbDenom(String(opts.feeDenom || DEFAULT_FEE_DENOM), '--fee-denom') },
       gas: Number(opts.gas),
       reuseRecord: choice.kind === 'reuse' ? choice.record : undefined,
       nonInteractive: Boolean(opts.nonInteractive) || !process.stdout.isTTY,

--- a/packages/bitbadgesjs-sdk/src/cli/commands/dev-feedback.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/dev-feedback.ts
@@ -1,0 +1,77 @@
+/**
+ * `bb dev feedback` — submit feedback or a feature idea from the CLI.
+ *
+ * Mirrors the in-app FeedbackWidget on bitbadges.io. Useful for the
+ * agentic surface — an agent that hits a sharp edge (bad error message,
+ * missing flag, surprising defaults) can submit a structured note
+ * without leaving the shell. Auto-populates `page` with a CLI-flavored
+ * source string so the inbound feed shows what surface the agent was
+ * using when they ran into the issue.
+ */
+
+import { Command } from 'commander';
+import {
+  addIndexerNetworkOptions as addNetworkFlags,
+  addIndexerOutputOptions as addOutputFlags,
+  callIndexer as callApi,
+  emitIndexerResult as emit,
+  emitIndexerError as emitError,
+  type IndexerNetworkFlags as NetworkFlags,
+  type IndexerOutputFlags as OutputFlags,
+} from '../utils/indexer-options.js';
+
+type FeedbackFlags = NetworkFlags & OutputFlags & {
+  type?: 'feedback' | 'feature-idea';
+  category?: string;
+  page?: string;
+};
+
+const FEEDBACK_TYPES = ['feedback', 'feature-idea'] as const;
+
+export const devFeedbackCommand = new Command('feedback')
+  .description('Submit feedback or a feature idea to BitBadges. Visible alongside the in-app widget.')
+  .argument('<message>', 'The feedback body. Wrap in quotes if it has spaces.')
+  .option('--type <type>', `One of: ${FEEDBACK_TYPES.join(', ')}`, 'feedback')
+  .option('--category <name>', 'Optional category tag (e.g. "cli-ergonomics"). Only used when --type=feature-idea.')
+  .option('--page <ref>', 'Override the auto-populated source tag. Defaults to "cli:<version>".');
+
+addOutputFlags(addNetworkFlags(devFeedbackCommand));
+
+devFeedbackCommand
+  .addHelpText('after', `\nExamples:\n  $ bb dev feedback "the --denom flag rejects 'usdc' lowercase — should match case-insensitively"\n  $ bb dev feedback --type feature-idea --category cli "add tab completion for collection IDs"\n`)
+  .action(async (message: string, opts: FeedbackFlags) => {
+    try {
+      const trimmed = (message ?? '').trim();
+      if (!trimmed) {
+        throw new Error('Feedback message cannot be empty.');
+      }
+      if (trimmed.length > 2000) {
+        throw new Error(`Feedback message is ${trimmed.length} chars; the indexer limit is 2000.`);
+      }
+
+      const type = opts.type ?? 'feedback';
+      if (!FEEDBACK_TYPES.includes(type)) {
+        throw new Error(`--type must be one of: ${FEEDBACK_TYPES.join(', ')} (got "${type}")`);
+      }
+
+      // Source-tag for the `page` field — mirrors the FE's `router.asPath`
+      // semantic, but identifies CLI submissions so they're filterable in
+      // the inbound feed. Default is "cli"; users can pass --page to be
+      // more specific (e.g. "cli:auctions place-bid").
+      const page = opts.page ?? 'cli';
+
+      const body: Record<string, unknown> = {
+        message: trimmed,
+        page,
+        type,
+      };
+      if (type === 'feature-idea' && opts.category) {
+        body.category = opts.category.trim().slice(0, 100);
+      }
+
+      const res = await callApi('POST', '/feedback', opts, body);
+      emit(res ?? { submitted: true, type, page }, opts);
+    } catch (err) {
+      emitError(err);
+    }
+  });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/dev.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/dev.ts
@@ -36,6 +36,7 @@ import { resourcesCommand } from './resources.js';
 import { docsCommand } from './docs.js';
 import { skillsCommand } from './skills.js';
 import { genPubKeyCommand } from './gen-pub-key.js';
+import { devFeedbackCommand } from './dev-feedback.js';
 
 export const devCommand = new Command('dev').description(
   'Builder primitives, resources, docs, skills, pubkey derivation — agent-facing surface.'
@@ -69,3 +70,4 @@ devCommand.addCommand(resourcesCommand);
 devCommand.addCommand(docsCommand);
 devCommand.addCommand(skillsCommand);
 devCommand.addCommand(genPubKeyCommand);
+devCommand.addCommand(devFeedbackCommand);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/doctor.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/doctor.ts
@@ -217,7 +217,7 @@ export const doctorCommand = addNetworkOptions(
       checks.push({
         name: 'Sessions',
         status: 'warn',
-        detail: `${parseable} parseable, ${corrupt} corrupt — run \`bitbadges-cli session reset <id>\` on broken ones`
+        detail: `${parseable} parseable, ${corrupt} corrupt — run \`bb session reset <id>\` on broken ones`
       });
     } else {
       checks.push({ name: 'Sessions', status: 'pass', detail: `${parseable} session(s) on disk` });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/dynamic-stores.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/dynamic-stores.ts
@@ -86,7 +86,11 @@ addOutputFlags(
     },
     opts
   );
-});
+}).addHelpText('after', `
+Examples:
+  $ bb dynamic-stores create --creator bb1owner...xyz --default-value false | bb deploy
+  $ bb dynamic-stores create --creator bb1owner...xyz --uri https://example.com/store.json --custom-data "kyc-allowlist" | bb deploy
+`);
 
 // ── update ───────────────────────────────────────────────────────────────────
 
@@ -113,7 +117,11 @@ addOutputFlags(
     if (opts.customData !== undefined) value.customData = opts.customData;
     emit({ typeUrl: '/tokenization.MsgUpdateDynamicStore', value }, opts);
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb dynamic-stores update 9 --creator bb1owner...xyz --global-enabled false | bb deploy
+  $ bb dynamic-stores update 9 --creator bb1owner...xyz --uri https://example.com/v2.json | bb deploy
+`);
 
 // ── delete ───────────────────────────────────────────────────────────────────
 
@@ -132,7 +140,10 @@ addOutputFlags(
     },
     opts
   );
-});
+}).addHelpText('after', `
+Examples:
+  $ bb dynamic-stores delete 9 --creator bb1owner...xyz | bb deploy
+`);
 
 // ── set-value (single) ───────────────────────────────────────────────────────
 
@@ -157,7 +168,10 @@ addOutputFlags(
       opts
     );
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb dynamic-stores set-value 9 bb1user...xyz true --creator bb1owner...xyz | bb deploy
+`);
 
 // ── add / remove (bulk, multi-msg) ───────────────────────────────────────────
 
@@ -181,7 +195,11 @@ addOutputFlags(
     .argument('<store-id>', 'Dynamic store ID')
     .argument('<addresses...>', 'Target addresses (repeated or comma-separated)')
     .requiredOption('--creator <address>', 'Tx creator')
-).action(bulkSetValue(true));
+).action(bulkSetValue(true)).addHelpText('after', `
+Examples:
+  $ bb dynamic-stores add 9 bb1user1...xyz bb1user2...xyz --creator bb1owner...xyz | bb deploy
+  $ bb dynamic-stores add 9 bb1user1...xyz,bb1user2...xyz --creator bb1owner...xyz | bb deploy
+`);
 
 addOutputFlags(
   dynamicStoresCommand
@@ -190,7 +208,10 @@ addOutputFlags(
     .argument('<store-id>', 'Dynamic store ID')
     .argument('<addresses...>', 'Target addresses')
     .requiredOption('--creator <address>', 'Tx creator')
-).action(bulkSetValue(false));
+).action(bulkSetValue(false)).addHelpText('after', `
+Examples:
+  $ bb dynamic-stores remove 9 bb1user1...xyz bb1user2...xyz --creator bb1owner...xyz | bb deploy
+`);
 
 // ── show (read single) ───────────────────────────────────────────────────────
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/dynamic-stores.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/dynamic-stores.ts
@@ -37,7 +37,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
 
 function fail(code: number, msg: string): never {
   process.stderr.write(`Error: ${msg}\n`);
@@ -72,7 +72,7 @@ addOutputFlags(
     .option('--uri <uri>', 'Optional metadata URI')
     .option('--custom-data <text>', 'Optional custom data string')
 ).action((opts: OutputFlags & { creator: string; defaultValue: string; uri?: string; customData?: string }) => {
-  const creator = requireBb1Address(opts.creator, '--creator');
+  const creator = requireBb1AddressStrict(opts.creator, '--creator');
   const defaultValue = parseBool(opts.defaultValue, '--default-value');
   emit(
     {
@@ -105,7 +105,7 @@ addOutputFlags(
     storeId: string,
     opts: OutputFlags & { creator: string; defaultValue?: string; globalEnabled?: string; uri?: string; customData?: string }
   ) => {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const value: Record<string, unknown> = { creator, storeId: String(storeId) };
     if (opts.defaultValue !== undefined) value.defaultValue = parseBool(opts.defaultValue, '--default-value');
     if (opts.globalEnabled !== undefined) value.globalEnabled = parseBool(opts.globalEnabled, '--global-enabled');
@@ -124,7 +124,7 @@ addOutputFlags(
     .argument('<store-id>', 'Dynamic store ID')
     .requiredOption('--creator <address>', 'Tx creator')
 ).action((storeId: string, opts: OutputFlags & { creator: string }) => {
-  const creator = requireBb1Address(opts.creator, '--creator');
+  const creator = requireBb1AddressStrict(opts.creator, '--creator');
   emit(
     {
       typeUrl: '/tokenization.MsgDeleteDynamicStore',
@@ -146,8 +146,8 @@ addOutputFlags(
     .requiredOption('--creator <address>', 'Tx creator')
 ).action(
   (storeId: string, address: string, valueStr: string, opts: OutputFlags & { creator: string }) => {
-    const creator = requireBb1Address(opts.creator, '--creator');
-    const target = requireBb1Address(address, 'address');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
+    const target = requireBb1AddressStrict(address, '<address> argument');
     const value = parseBool(valueStr, 'value');
     emit(
       {
@@ -163,8 +163,8 @@ addOutputFlags(
 
 function bulkSetValue(value: boolean) {
   return (storeId: string, rawAddresses: string[], opts: OutputFlags & { creator: string }) => {
-    const creator = requireBb1Address(opts.creator, '--creator');
-    const addresses = splitCsv(rawAddresses).map((a) => requireBb1Address(a, 'address'));
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
+    const addresses = splitCsv(rawAddresses).map((a) => requireBb1AddressStrict(a, '<addresses> argument'));
     if (addresses.length === 0) fail(2, 'at least one address required');
     const messages = addresses.map((address) => ({
       typeUrl: '/tokenization.MsgSetDynamicStoreValue',

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-pub-key.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-pub-key.ts
@@ -251,8 +251,8 @@ genPubKeyCommand.action(async (opts) => {
             '  1. Sign this exact message with your wallet (Keplr signArbitrary, hardware wallet, or any ADR-36-capable signer):\n\n' +
             `    ${PUBKEY_DERIVATION_MESSAGE}\n\n` +
             '  2. Re-run with the resulting base64 signature:\n' +
-            `     bitbadges-cli gen-pub-key --address ${address} --signature <base64>\n\n` +
-            '  Print the message verbatim with: bitbadges-cli gen-pub-key --print-message'
+            `     bb gen-pub-key --address ${address} --signature <base64>\n\n` +
+            '  Print the message verbatim with: bb gen-pub-key --print-message'
         ),
         { code: 'pubkey_not_found', exitCode: 2 }
       );

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
@@ -30,7 +30,7 @@ import { encodeTokenizationMsgFromJson, supportedTokenizationTypeUrls } from '..
 import { evmToCosmosAddress } from '../../transactions/precompile/helpers.js';
 import { emit, emitError } from '../utils/envelope.js';
 import { emitDeprecation } from '../utils/deprecation.js';
-import { requireBbDenom } from '../utils/denom.js';
+import { requireBbDenom, DEFAULT_FEE_DENOM } from '../utils/denom.js';
 
 interface MsgEntry {
   typeUrl: string;
@@ -122,7 +122,7 @@ export const genTxPayloadCommand = new Command('gen-tx-payload')
   .option('--chain-id <id>', 'Cosmos chain ID override (default per network: bitbadges-1 / etc)')
   .option('--memo <text>', 'Optional tx memo', '')
   .option('--fee <amount>', 'Fee amount in base units', '0')
-  .option('--fee-denom <symbol|denom>', 'Fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', 'ubadge')
+  .option('--fee-denom <symbol|denom>', 'Fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', DEFAULT_FEE_DENOM)
   .option('--gas <number>', 'Gas limit', '400000')
   .option('--no-fetch', 'Skip the indexer account-info round-trip; require --account-number, --sequence, and --public-key via flags. Useful for offline / air-gapped flows.');
 addNetworkOptions(genTxPayloadCommand);
@@ -247,7 +247,7 @@ export async function runGenPayload(
   // function the dashboard's TxModal uses. Returns signDirect +
   // legacyAmino (when sender is set) and evmTx (when evmAddress is set).
   const fee = String(opts.fee ?? '0');
-  const denom = requireBbDenom(String(opts.feeDenom ?? 'ubadge'), '--fee-denom');
+  const denom = requireBbDenom(String(opts.feeDenom ?? DEFAULT_FEE_DENOM), '--fee-denom');
   const gas = String(opts.gas ?? 400000);
   const memo = String(opts.memo ?? '');
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
@@ -30,6 +30,7 @@ import { encodeTokenizationMsgFromJson, supportedTokenizationTypeUrls } from '..
 import { evmToCosmosAddress } from '../../transactions/precompile/helpers.js';
 import { emit, emitError } from '../utils/envelope.js';
 import { emitDeprecation } from '../utils/deprecation.js';
+import { requireBbDenom } from '../utils/denom.js';
 
 interface MsgEntry {
   typeUrl: string;
@@ -121,7 +122,7 @@ export const genTxPayloadCommand = new Command('gen-tx-payload')
   .option('--chain-id <id>', 'Cosmos chain ID override (default per network: bitbadges-1 / etc)')
   .option('--memo <text>', 'Optional tx memo', '')
   .option('--fee <amount>', 'Fee amount in base units', '0')
-  .option('--fee-denom <denom>', 'Fee denom', 'ubadge')
+  .option('--fee-denom <symbol|denom>', 'Fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', 'ubadge')
   .option('--gas <number>', 'Gas limit', '400000')
   .option('--no-fetch', 'Skip the indexer account-info round-trip; require --account-number, --sequence, and --public-key via flags. Useful for offline / air-gapped flows.');
 addNetworkOptions(genTxPayloadCommand);
@@ -246,7 +247,7 @@ export async function runGenPayload(
   // function the dashboard's TxModal uses. Returns signDirect +
   // legacyAmino (when sender is set) and evmTx (when evmAddress is set).
   const fee = String(opts.fee ?? '0');
-  const denom = String(opts.feeDenom ?? 'ubadge');
+  const denom = requireBbDenom(String(opts.feeDenom ?? 'ubadge'), '--fee-denom');
   const gas = String(opts.gas ?? 400000);
   const memo = String(opts.memo ?? '');
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
@@ -323,7 +323,7 @@ export async function runGenPayload(
     ...(payload.evmTx ? [
       'EVM signing — build an EIP-1559 tx with: { chainId: evmTx.chainId, to: evmTx.to, data: evmTx.data, value: evmTx.value, gasLimit: evmTx.gasLimit }, sign with your EVM key, send via any RPC.',
     ] : []),
-    'Need a tx-bytes-only flow without managing TxRaw assembly? Use `bitbadges-cli deploy --browser --sign-only` instead — that hands the wallet the signing UI and returns ready-to-broadcast bytes.',
+    'Need a tx-bytes-only flow without managing TxRaw assembly? Use `bb deploy --browser --sign-only` instead — that hands the wallet the signing UI and returns ready-to-broadcast bytes.',
   ];
 
   emit(envelope);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
@@ -243,7 +243,11 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb intents create --creator bb1maker...xyz --pay-denom BADGE --pay-amount 100 --receive-denom USDC --receive-amount 50 | bb deploy
+  $ bb intents create --creator bb1maker...xyz --pay-denom BADGE --pay-amount 100 --receive-denom USDC --receive-amount 50 --valid-until 7d | bb deploy
+`);
 
 // ── intents fill ──────────────────────────────────────────────────────────
 
@@ -299,7 +303,11 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb intents fill a1b2c3d4e5f6 --creator bb1filler...xyz | bb deploy
+  $ bb intents fill a1b2c3d4e5f6 --creator bb1filler...xyz --approver bb1maker...xyz | bb deploy
+`);
 
 // ── intents cancel ────────────────────────────────────────────────────────
 
@@ -338,4 +346,7 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb intents cancel a1b2c3d4e5f6 --creator bb1maker...xyz | bb deploy
+`);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
@@ -31,6 +31,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address } from '../utils/address.js';
+import { requireBbDenom } from '../utils/denom.js';
 import {
   buildIntentApproval,
   buildIntentFillTx,
@@ -85,8 +86,8 @@ addOutputFlags(
           '--mine <address>',
           'Restrict to intents created by this address (bb1.../0x — auto-normalized). Also includes used/inactive.'
         )
-        .option('--pay-denom <denom>', 'Filter by the denom the intent pays out')
-        .option('--receive-denom <denom>', 'Filter by the denom the intent expects to receive')
+        .option('--pay-denom <symbol|denom>', 'Filter by the denom the intent pays out. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
+        .option('--receive-denom <symbol|denom>', 'Filter by the denom the intent expects to receive. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     )
   )
 ).action(
@@ -101,12 +102,14 @@ addOutputFlags(
   ) => {
     try {
       const mine = opts.mine ? requireBb1Address(opts.mine, '--mine') : undefined;
+      const payDenom = opts.payDenom ? requireBbDenom(opts.payDenom, '--pay-denom') : undefined;
+      const receiveDenom = opts.receiveDenom ? requireBbDenom(opts.receiveDenom, '--receive-denom') : undefined;
       const collectionId = opts.collectionId; // explicit override; otherwise indexer scopes globally
       const base = mine ? `/intents/${encodeURIComponent(mine)}` : '/intents';
       const path = appendQuery(base, {
         includeAll: mine ? 'true' : undefined,
-        payDenom: opts.payDenom,
-        receiveDenom: opts.receiveDenom,
+        payDenom,
+        receiveDenom,
         collectionId
       });
       const res = await callApi('GET', path, opts);
@@ -161,9 +164,9 @@ addOutputFlags(
           'Emit MsgSetOutgoingApproval for a new intent ("I pay X if you send me Y"). Pipe to `bb deploy`.'
         )
         .requiredOption('--creator <address>', 'Intent creator address (bb1.../0x — auto-normalized)')
-        .requiredOption('--pay-denom <denom>', 'Denom you OFFER (chain-side denom; ibc/... or ubadge)')
+        .requiredOption('--pay-denom <symbol|denom>', 'Denom you OFFER. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
         .requiredOption('--pay-amount <amount>', 'Amount of pay denom in base units')
-        .requiredOption('--receive-denom <denom>', 'Denom you EXPECT in return')
+        .requiredOption('--receive-denom <symbol|denom>', 'Denom you EXPECT in return. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
         .requiredOption('--receive-amount <amount>', 'Amount of receive denom in base units')
         .option(
           '--valid-until <ms>',
@@ -188,7 +191,9 @@ addOutputFlags(
   ) => {
     try {
       const creator = requireBb1Address(opts.creator, '--creator');
-      if (opts.payDenom === opts.receiveDenom) {
+      const payDenom = requireBbDenom(opts.payDenom, '--pay-denom');
+      const receiveDenom = requireBbDenom(opts.receiveDenom, '--receive-denom');
+      if (payDenom === receiveDenom) {
         process.stderr.write('Error: --pay-denom and --receive-denom must differ.\n');
         process.exit(2);
       }
@@ -200,9 +205,9 @@ addOutputFlags(
 
       const approval = buildIntentApproval({
         address: creator,
-        payDenom: opts.payDenom,
+        payDenom,
         payAmount: BigInt(opts.payAmount),
-        receiveDenom: opts.receiveDenom,
+        receiveDenom,
         receiveAmount: BigInt(opts.receiveAmount),
         transferTimes: UintRangeArray.From([{ start: 1n, end: validUntil }]),
         approvalId

--- a/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
@@ -32,6 +32,8 @@ import {
 } from '../utils/indexer-options.js';
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
 import { requireBbDenom } from '../utils/denom.js';
+import { resolveAmount } from '../utils/amount.js';
+import { parseTimeFlag } from '../utils/time.js';
 import {
   buildIntentApproval,
   buildIntentFillTx,
@@ -165,12 +167,13 @@ addOutputFlags(
         )
         .requiredOption('--creator <address>', 'Intent creator address (bb1.../0x — auto-normalized)')
         .requiredOption('--pay-denom <symbol|denom>', 'Denom you OFFER. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
-        .requiredOption('--pay-amount <amount>', 'Amount of pay denom in base units')
+        .requiredOption('--pay-amount <amount>', 'Amount of pay denom. Display units for symbol denoms, base units for chain denoms. Use --base-units to force base-units.')
         .requiredOption('--receive-denom <symbol|denom>', 'Denom you EXPECT in return. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
-        .requiredOption('--receive-amount <amount>', 'Amount of receive denom in base units')
+        .requiredOption('--receive-amount <amount>', 'Amount of receive denom. Display units for symbol denoms, base units for chain denoms.')
+        .option('--base-units', 'Treat --pay-amount and --receive-amount as already-in-base-units')
         .option(
-          '--valid-until <ms>',
-          'Optional expiration as ms-since-epoch (default: ~30 days from now)'
+          '--valid-until <when>',
+          'Optional expiration: ms-since-epoch or duration (24h, 7d, 30d, monthly). Default 30d.'
         )
         .option('--approval-id <id>', 'Override the auto-generated approval id (random hex by default)')
     )
@@ -185,20 +188,32 @@ addOutputFlags(
         payAmount: string;
         receiveDenom: string;
         receiveAmount: string;
+        baseUnits?: boolean;
         validUntil?: string;
         approvalId?: string;
       }
   ) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
-      const payDenom = requireBbDenom(opts.payDenom, '--pay-denom');
-      const receiveDenom = requireBbDenom(opts.receiveDenom, '--receive-denom');
+      const baseUnits = Boolean(opts.baseUnits);
+      const { denom: payDenom, amount: payAmountStr } = resolveAmount(
+        opts.payAmount,
+        opts.payDenom,
+        baseUnits,
+        { amountFlag: '--pay-amount', denomFlag: '--pay-denom' }
+      );
+      const { denom: receiveDenom, amount: receiveAmountStr } = resolveAmount(
+        opts.receiveAmount,
+        opts.receiveDenom,
+        baseUnits,
+        { amountFlag: '--receive-amount', denomFlag: '--receive-denom' }
+      );
       if (payDenom === receiveDenom) {
         process.stderr.write('Error: --pay-denom and --receive-denom must differ.\n');
         process.exit(2);
       }
       const validUntil = opts.validUntil
-        ? BigInt(opts.validUntil)
+        ? parseTimeFlag(opts.validUntil, '--valid-until')
         : BigInt(Date.now() + 30 * 24 * 60 * 60 * 1000);
       const collectionId = resolveCollectionId(opts);
       const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
@@ -206,9 +221,9 @@ addOutputFlags(
       const approval = buildIntentApproval({
         address: creator,
         payDenom,
-        payAmount: BigInt(opts.payAmount),
+        payAmount: BigInt(payAmountStr),
         receiveDenom,
-        receiveAmount: BigInt(opts.receiveAmount),
+        receiveAmount: BigInt(receiveAmountStr),
         transferTimes: UintRangeArray.From([{ start: 1n, end: validUntil }]),
         approvalId
       });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
@@ -30,7 +30,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
 import { requireBbDenom } from '../utils/denom.js';
 import {
   buildIntentApproval,
@@ -190,7 +190,7 @@ addOutputFlags(
       }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const payDenom = requireBbDenom(opts.payDenom, '--pay-denom');
       const receiveDenom = requireBbDenom(opts.receiveDenom, '--receive-denom');
       if (payDenom === receiveDenom) {
@@ -254,12 +254,12 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & CollectionFlag & { creator: string; approver?: string }
   ) => {
     try {
-      const fillerAddress = requireBb1Address(opts.creator, '--creator');
+      const fillerAddress = requireBb1AddressStrict(opts.creator, '--creator');
       const collectionId = resolveCollectionId(opts);
 
       // Resolve approverAddress. The /intents feed returns approverAddress
       // on each row; if --approver was provided, use that instead.
-      let approverAddress = opts.approver ? requireBb1Address(opts.approver, '--approver') : '';
+      let approverAddress = opts.approver ? requireBb1AddressStrict(opts.approver, '--approver') : '';
       if (!approverAddress) {
         const path = appendQuery('/intents', { collectionId: opts.collectionId });
         const res = await callApi('GET', path, opts);
@@ -306,7 +306,7 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & CollectionFlag & { creator: string }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collectionId = resolveCollectionId(opts);
       emit(
         {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
@@ -26,6 +26,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address } from '../utils/address.js';
+import { requireBbDenom } from '../utils/denom.js';
 import {
   buildOrderbookBidApproval,
   buildOrderbookListingApproval,
@@ -50,7 +51,7 @@ addOutputFlags(
       .argument('<collection-id>', 'Collection ID')
       .requiredOption('--creator <address>', 'Bidder address (bb1.../0x — auto-normalized)')
       .requiredOption('--price <amount>', 'Bid amount in base units')
-      .requiredOption('--denom <denom>', 'Payment denom (ubadge / ibc/...)')
+      .requiredOption('--denom <symbol|denom>', 'Payment denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
       .option('--token-id <n>', 'Specific token ID to bid on (omit for collection-wide bid)')
       .option('--token-amount <n>', 'Number of tokens (default 1)', '1')
       .option('--expiry <ms>', 'Bid expiry ms-since-epoch (default: 7 days from now)')
@@ -67,6 +68,7 @@ addOutputFlags(
   ) => {
     try {
       const creator = requireBb1Address(opts.creator, '--creator');
+      const paymentDenom = requireBbDenom(opts.denom, '--denom');
       const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 7 * 24 * 60 * 60 * 1000);
       const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
       const approval = buildOrderbookBidApproval({
@@ -74,7 +76,7 @@ addOutputFlags(
         tokenId: opts.tokenId ? BigInt(opts.tokenId) : undefined,
         tokenAmount: BigInt(opts.tokenAmount ?? '1'),
         paymentAmount: BigInt(opts.price),
-        paymentDenom: opts.denom,
+        paymentDenom,
         transferTimes: UintRangeArray.From([{ start: 1n, end }]),
         approvalId,
         maxNumTransfers: BigInt(opts.maxFills ?? '1')
@@ -95,7 +97,7 @@ addOutputFlags(
       .requiredOption('--creator <address>', 'Seller address (bb1.../0x — auto-normalized)')
       .requiredOption('--token-id <n>', 'Token ID to list')
       .requiredOption('--price <amount>', 'Asking price in base units')
-      .requiredOption('--denom <denom>', 'Payment denom (ubadge / ibc/...)')
+      .requiredOption('--denom <symbol|denom>', 'Payment denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
       .option('--token-amount <n>', 'Number of tokens (default 1)', '1')
       .option('--max-sales <n>', 'Allow multiple fills of this listing (default 1)', '1')
       .option('--expiry <ms>', 'Listing expiry ms-since-epoch (default: 30 days from now)')
@@ -111,6 +113,7 @@ addOutputFlags(
   ) => {
     try {
       const creator = requireBb1Address(opts.creator, '--creator');
+      const paymentDenom = requireBbDenom(opts.denom, '--denom');
       const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 30 * 24 * 60 * 60 * 1000);
       const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
       const approval = buildOrderbookListingApproval({
@@ -118,7 +121,7 @@ addOutputFlags(
         tokenId: BigInt(opts.tokenId),
         tokenAmount: BigInt(opts.tokenAmount ?? '1'),
         paymentAmount: BigInt(opts.price),
-        paymentDenom: opts.denom,
+        paymentDenom,
         transferTimes: UintRangeArray.From([{ start: 1n, end }]),
         approvalId,
         maxNumTransfers: BigInt(opts.maxSales ?? '1')
@@ -241,7 +244,7 @@ addOutputFlags(
       .description('Query open bids + listings for a token. Use --mine to scope to caller.')
       .argument('<collection-id>', 'Collection ID')
       .argument('<token-id>', 'Token ID')
-      .option('--denom <denom>', 'Optional denom filter')
+      .option('--denom <symbol|denom>', 'Optional denom filter. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
       .option('--mine <address>', 'Restrict to orders owned by this address (bb1.../0x — auto-normalized)')
       .option('--collection-offers', 'Also include collection-wide bids', false)
   )
@@ -252,7 +255,8 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { denom?: string; mine?: string; collectionOffers?: boolean }
   ) => {
     try {
-      const params = opts.denom ? `?denom=${encodeURIComponent(opts.denom)}` : '';
+      const denomFilter = opts.denom ? requireBbDenom(opts.denom, '--denom') : undefined;
+      const params = denomFilter ? `?denom=${encodeURIComponent(denomFilter)}` : '';
       const [listings, offers, collectionOffers] = await Promise.all([
         callApi('GET', `/collection/${encodeURIComponent(collectionId)}/listings/${encodeURIComponent(tokenId)}${params}`, opts).catch(() => ({ listings: [] })),
         callApi('GET', `/collection/${encodeURIComponent(collectionId)}/offers/${encodeURIComponent(tokenId)}${params}`, opts).catch(() => ({ offers: [] })),

--- a/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
@@ -25,7 +25,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
 import { requireBbDenom } from '../utils/denom.js';
 import {
   buildOrderbookBidApproval,
@@ -67,7 +67,7 @@ addOutputFlags(
     }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const paymentDenom = requireBbDenom(opts.denom, '--denom');
       const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 7 * 24 * 60 * 60 * 1000);
       const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
@@ -112,7 +112,7 @@ addOutputFlags(
     }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const paymentDenom = requireBbDenom(opts.denom, '--denom');
       const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 30 * 24 * 60 * 60 * 1000);
       const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
@@ -150,7 +150,7 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; side: string }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       if (opts.side !== 'bid' && opts.side !== 'listing') {
         process.stderr.write(`Error: --side must be "bid" or "listing" (got "${opts.side}").\n`);
         process.exit(2);
@@ -184,8 +184,8 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; approvalId: string; seller: string; tokenAmount?: string }
   ) => {
     try {
-      const buyer = requireBb1Address(opts.creator, '--creator');
-      const seller = requireBb1Address(opts.seller, '--seller');
+      const buyer = requireBb1AddressStrict(opts.creator, '--creator');
+      const seller = requireBb1AddressStrict(opts.seller, '--seller');
       emit(
         buildFillListingMsg(buyer, String(collectionId), {
           approvalId: opts.approvalId,
@@ -220,8 +220,8 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; approvalId: string; bidder: string; tokenAmount?: string }
   ) => {
     try {
-      const seller = requireBb1Address(opts.creator, '--creator');
-      const bidder = requireBb1Address(opts.bidder, '--bidder');
+      const seller = requireBb1AddressStrict(opts.creator, '--creator');
+      const bidder = requireBb1AddressStrict(opts.bidder, '--bidder');
       emit(
         buildFillBidMsg(seller, String(collectionId), {
           approvalId: opts.approvalId,

--- a/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
@@ -92,7 +92,11 @@ addOutputFlags(
       emit({ typeUrl: '/tokenization.MsgSetIncomingApproval', value: { creator, collectionId: String(collectionId), approval } }, opts);
     } catch (err) { emitError(err); }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb nfts bid 42 --creator bb1bidder...xyz --price 1.5 --denom USDC --token-id 7 | bb deploy
+  $ bb nfts bid 42 --creator bb1bidder...xyz --price 1.5 --denom USDC --expiry 24h | bb deploy
+`);
 
 // ── list (sell-side outgoing approval) ───────────────────────────────────
 
@@ -143,7 +147,11 @@ addOutputFlags(
       emit({ typeUrl: '/tokenization.MsgSetOutgoingApproval', value: { creator, collectionId: String(collectionId), approval } }, opts);
     } catch (err) { emitError(err); }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb nfts list 42 --creator bb1seller...xyz --token-id 7 --price 5 --denom USDC | bb deploy
+  $ bb nfts list 42 --creator bb1seller...xyz --token-id 7 --price 5 --denom USDC --expiry 30d --max-sales 1 | bb deploy
+`);
 
 // ── cancel ───────────────────────────────────────────────────────────────
 
@@ -175,7 +183,11 @@ addOutputFlags(
       emit({ typeUrl, value: { creator, collectionId: String(collectionId), approvalId } }, opts);
     } catch (err) { emitError(err); }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb nfts cancel 42 a1b2c3d4e5f6 --creator bb1owner...xyz --side listing | bb deploy
+  $ bb nfts cancel 42 a1b2c3d4e5f6 --creator bb1owner...xyz --side bid | bb deploy
+`);
 
 // ── buy (fill a listing) ─────────────────────────────────────────────────
 
@@ -211,7 +223,10 @@ addOutputFlags(
       );
     } catch (err) { emitError(err); }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb nfts buy 42 7 --creator bb1buyer...xyz --approval-id a1b2c3d4e5f6 --seller bb1seller...xyz | bb deploy
+`);
 
 // ── sell (fill a bid) ────────────────────────────────────────────────────
 
@@ -247,7 +262,10 @@ addOutputFlags(
       );
     } catch (err) { emitError(err); }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb nfts sell 42 7 --creator bb1seller...xyz --approval-id a1b2c3d4e5f6 --bidder bb1bidder...xyz | bb deploy
+`);
 
 // ── orders (view open) ───────────────────────────────────────────────────
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
@@ -27,6 +27,8 @@ import {
 } from '../utils/indexer-options.js';
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
 import { requireBbDenom } from '../utils/denom.js';
+import { resolveAmount } from '../utils/amount.js';
+import { parseTimeFlag } from '../utils/time.js';
 import {
   buildOrderbookBidApproval,
   buildOrderbookListingApproval,
@@ -49,12 +51,13 @@ addOutputFlags(
         'Emit MsgSetIncomingApproval that places a bid on a token. Omit --token-id for a collection-wide bid (any token in the collection).'
       )
       .argument('<collection-id>', 'Collection ID')
-      .requiredOption('--creator <address>', 'Bidder address (bb1.../0x — auto-normalized)')
-      .requiredOption('--price <amount>', 'Bid amount in base units')
+      .requiredOption('--creator <address>', 'Bidder address (bb1...) — strict; run `bb account convert` for 0x')
+      .requiredOption('--price <amount>', 'Bid amount. Display units for symbol denoms (USDC → 1.5 USDC), base units for chain denoms (ubadge / ibc/...). Use --base-units to force base-units.')
       .requiredOption('--denom <symbol|denom>', 'Payment denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
+      .option('--base-units', 'Treat --price as already-in-base-units')
       .option('--token-id <n>', 'Specific token ID to bid on (omit for collection-wide bid)')
       .option('--token-amount <n>', 'Number of tokens (default 1)', '1')
-      .option('--expiry <ms>', 'Bid expiry ms-since-epoch (default: 7 days from now)')
+      .option('--expiry <when>', 'Bid expiry: ms-since-epoch (1748140800000) or duration (7d, 24h, monthly). Default 7d.')
       .option('--approval-id <id>', 'Override the random approval id')
       .option('--max-fills <n>', 'Cap on partial fills (default 1)', '1')
   )
@@ -62,20 +65,25 @@ addOutputFlags(
   async (
     collectionId: string,
     opts: NetworkFlags & OutputFlags & {
-      creator: string; price: string; denom: string;
+      creator: string; price: string; denom: string; baseUnits?: boolean;
       tokenId?: string; tokenAmount?: string; expiry?: string; approvalId?: string; maxFills?: string;
     }
   ) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
-      const paymentDenom = requireBbDenom(opts.denom, '--denom');
-      const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      const { denom: paymentDenom, amount: paymentAmountStr } = resolveAmount(
+        opts.price,
+        opts.denom,
+        Boolean(opts.baseUnits),
+        { amountFlag: '--price', denomFlag: '--denom' }
+      );
+      const end = opts.expiry ? parseTimeFlag(opts.expiry, '--expiry') : BigInt(Date.now() + 7 * 24 * 60 * 60 * 1000);
       const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
       const approval = buildOrderbookBidApproval({
         address: creator,
         tokenId: opts.tokenId ? BigInt(opts.tokenId) : undefined,
         tokenAmount: BigInt(opts.tokenAmount ?? '1'),
-        paymentAmount: BigInt(opts.price),
+        paymentAmount: BigInt(paymentAmountStr),
         paymentDenom,
         transferTimes: UintRangeArray.From([{ start: 1n, end }]),
         approvalId,
@@ -94,33 +102,39 @@ addOutputFlags(
       .command('list')
       .description('Emit MsgSetOutgoingApproval that lists a token for sale.')
       .argument('<collection-id>', 'Collection ID')
-      .requiredOption('--creator <address>', 'Seller address (bb1.../0x — auto-normalized)')
+      .requiredOption('--creator <address>', 'Seller address (bb1...) — strict; run `bb account convert` for 0x')
       .requiredOption('--token-id <n>', 'Token ID to list')
-      .requiredOption('--price <amount>', 'Asking price in base units')
+      .requiredOption('--price <amount>', 'Asking price. Display units for symbol denoms, base units for chain denoms. Use --base-units to force base-units.')
       .requiredOption('--denom <symbol|denom>', 'Payment denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
+      .option('--base-units', 'Treat --price as already-in-base-units')
       .option('--token-amount <n>', 'Number of tokens (default 1)', '1')
       .option('--max-sales <n>', 'Allow multiple fills of this listing (default 1)', '1')
-      .option('--expiry <ms>', 'Listing expiry ms-since-epoch (default: 30 days from now)')
+      .option('--expiry <when>', 'Listing expiry: ms-since-epoch or duration (7d, 30d, monthly). Default 30d.')
       .option('--approval-id <id>', 'Override the random approval id')
   )
 ).action(
   async (
     collectionId: string,
     opts: NetworkFlags & OutputFlags & {
-      creator: string; tokenId: string; price: string; denom: string;
+      creator: string; tokenId: string; price: string; denom: string; baseUnits?: boolean;
       tokenAmount?: string; maxSales?: string; expiry?: string; approvalId?: string;
     }
   ) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
-      const paymentDenom = requireBbDenom(opts.denom, '--denom');
-      const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      const { denom: paymentDenom, amount: paymentAmountStr } = resolveAmount(
+        opts.price,
+        opts.denom,
+        Boolean(opts.baseUnits),
+        { amountFlag: '--price', denomFlag: '--denom' }
+      );
+      const end = opts.expiry ? parseTimeFlag(opts.expiry, '--expiry') : BigInt(Date.now() + 30 * 24 * 60 * 60 * 1000);
       const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
       const approval = buildOrderbookListingApproval({
         address: creator,
         tokenId: BigInt(opts.tokenId),
         tokenAmount: BigInt(opts.tokenAmount ?? '1'),
-        paymentAmount: BigInt(opts.price),
+        paymentAmount: BigInt(paymentAmountStr),
         paymentDenom,
         transferTimes: UintRangeArray.From([{ start: 1n, end }]),
         approvalId,

--- a/packages/bitbadgesjs-sdk/src/cli/commands/pay-requests.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/pay-requests.ts
@@ -18,15 +18,15 @@
  * PaymentRequestView).
  */
 
-import { Command, Option } from 'commander';
+import { Command } from 'commander';
 import {
   addIndexerNetworkOptions as addNetworkFlags,
-  addIndexerOutputOptions,
+  addIndexerOutputOptions as addOutputFlags,
   callIndexer as callApi,
   emitIndexerResult as emit,
   emitIndexerError as emitError,
   type IndexerNetworkFlags as NetworkFlags,
-  type IndexerOutputFlags,
+  type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
 import {
@@ -38,17 +38,6 @@ import {
   buildPaymentRequestDenyMsg,
   type PaymentRequestStatus
 } from '../../core/payment-requests.js';
-
-// `pay-requests` historically declared a `--json` flag that was never read
-// (output already defaults to JSON). Keep it as a hidden alias so any
-// script passing it doesn't break, but stop documenting it.
-type OutputFlags = IndexerOutputFlags & { json?: boolean };
-
-function addOutputFlags(cmd: Command): Command {
-  return addIndexerOutputOptions(cmd).addOption(
-    new Option('--json', 'Legacy alias — output is JSON by default. Retained for backwards compat.').hideHelp()
-  );
-}
 
 async function fetchCollection(collectionId: string, opts: NetworkFlags): Promise<any> {
   const res = await callApi('GET', `/collection/${encodeURIComponent(collectionId)}`, opts);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/pay-requests.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/pay-requests.ts
@@ -212,7 +212,10 @@ addOutputFlags(
   } catch (err) {
     emitError(err);
   }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb pay-requests pay 31 --creator bb1payer...xyz | bb deploy
+`);
 
 // ── pay-requests deny ─────────────────────────────────────────────────────
 
@@ -242,7 +245,10 @@ addOutputFlags(
   } catch (err) {
     emitError(err);
   }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb pay-requests deny 31 --creator bb1payer...xyz | bb deploy
+`);
 
 // Per-standard `build` subcommand removed in CLI v2 (#0399).
 // Use `bb build payment-request ...` (the canonical builder) instead.

--- a/packages/bitbadgesjs-sdk/src/cli/commands/pay-requests.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/pay-requests.ts
@@ -28,7 +28,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags,
 } from '../utils/indexer-options.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
 import {
   doesCollectionFollowPaymentRequestProtocol,
   validatePaymentRequestCollection,
@@ -209,7 +209,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'pay-requests pay');
     const details = extractPaymentRequestDetails(collection.collectionApprovals)!;
@@ -239,7 +239,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'pay-requests deny');
     const details = extractPaymentRequestDetails(collection.collectionApprovals)!;

--- a/packages/bitbadgesjs-sdk/src/cli/commands/pools.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/pools.ts
@@ -27,6 +27,7 @@ import {
   emitIndexerResult as emit,
   emitIndexerError as emitError,
 } from '../utils/indexer-options.js';
+import { requireBbDenom } from '../utils/denom.js';
 
 function appendQuery(path: string, params: Record<string, string | number | boolean | undefined>): string {
   const search = new URLSearchParams();
@@ -79,12 +80,13 @@ export function registerPools(parent: Command): void {
 
   addOutputFlags(
     addNetworkFlags(parent.command('by-denom'))
-      .description('Pools containing a given denom (e.g. ubadge or ibc/...).')
-      .argument('<denom>', 'Denom string')
+      .description('Pools containing a given denom (BADGE, USDC, … or canonical denom).')
+      .argument('<symbol|denom>', 'Symbol (BADGE, USDC) or canonical denom (ubadge, ibc/...)')
       .option('--bookmark <b>', 'Pagination bookmark')
   ).action(async (denom: string, opts: any) => {
     try {
-      const path = appendQuery('/pools/byDenom', { denom, bookmark: opts.bookmark });
+      const canonical = requireBbDenom(denom, '<denom> argument to bb pools by-denom');
+      const path = appendQuery('/pools/byDenom', { denom: canonical, bookmark: opts.bookmark });
       const res = await callApi('GET', path, opts);
       emit(res, opts);
     } catch (err) {
@@ -95,12 +97,14 @@ export function registerPools(parent: Command): void {
   addOutputFlags(
     addNetworkFlags(parent.command('by-assets'))
       .description('Pools containing a specific asset pair (order-insensitive).')
-      .argument('<denom-a>', 'First denom')
-      .argument('<denom-b>', 'Second denom')
+      .argument('<denom-a>', 'First symbol or canonical denom')
+      .argument('<denom-b>', 'Second symbol or canonical denom')
       .option('--bookmark <b>', 'Pagination bookmark')
   ).action(async (denomA: string, denomB: string, opts: any) => {
     try {
-      const path = appendQuery('/pools/byAssets', { asset1: denomA, asset2: denomB, bookmark: opts.bookmark });
+      const a = requireBbDenom(denomA, '<denom-a> argument to bb pools by-assets');
+      const b = requireBbDenom(denomB, '<denom-b> argument to bb pools by-assets');
+      const path = appendQuery('/pools/byAssets', { asset1: a, asset2: b, bookmark: opts.bookmark });
       const res = await callApi('GET', path, opts);
       emit(res, opts);
     } catch (err) {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
@@ -24,6 +24,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address } from '../utils/address.js';
+import { requireBbDenom } from '../utils/denom.js';
 import {
   validatePredictionMarketCollection,
   classifySettlementApproval,
@@ -191,6 +192,7 @@ function buyAction(side: 'yes' | 'no') {
   ) => {
     try {
       const creator = requireBb1Address(opts.creator, '--creator');
+      const paymentDenom = requireBbDenom(opts.denom, '--denom');
       await fetchCollection(collectionId, opts).then((c) => validateOrExit(c, `prediction-markets buy-${side}`));
       const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 24 * 60 * 60 * 1000);
       const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
@@ -199,7 +201,7 @@ function buyAction(side: 'yes' | 'no') {
         collectionId: String(collectionId),
         tokenId: side === 'yes' ? 1n : 2n,
         tokenAmount: BigInt(opts.tokenAmount),
-        paymentDenom: opts.denom,
+        paymentDenom,
         paymentAmount: BigInt(opts.paymentAmount),
         transferTimes: UintRangeArray.From([{ start: 1n, end }]),
         approvalId
@@ -216,6 +218,7 @@ function sellAction(side: 'yes' | 'no') {
   ) => {
     try {
       const creator = requireBb1Address(opts.creator, '--creator');
+      const paymentDenom = requireBbDenom(opts.denom, '--denom');
       await fetchCollection(collectionId, opts).then((c) => validateOrExit(c, `prediction-markets sell-${side}`));
       const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 24 * 60 * 60 * 1000);
       const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
@@ -224,7 +227,7 @@ function sellAction(side: 'yes' | 'no') {
         collectionId: String(collectionId),
         tokenId: side === 'yes' ? 1n : 2n,
         tokenAmount: BigInt(opts.tokenAmount),
-        paymentDenom: opts.denom,
+        paymentDenom,
         paymentAmount: BigInt(opts.paymentAmount),
         transferTimes: UintRangeArray.From([{ start: 1n, end }]),
         approvalId
@@ -243,7 +246,7 @@ const tradeOpts = (cmd: Command, side: 'yes' | 'no', dir: 'buy' | 'sell') =>
     .requiredOption('--creator <address>', 'Trader address (bb1.../0x — auto-normalized)')
     .requiredOption('--token-amount <n>', `Quantity of ${side.toUpperCase()} tokens to ${dir}`)
     .requiredOption('--payment-amount <n>', 'Payment side amount in base units')
-    .requiredOption('--denom <denom>', 'Payment denom (deposit-denom or badgeslp:* alias)')
+    .requiredOption('--denom <symbol|denom>', 'Payment denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...) or badgeslp:* alias.')
     .option('--expiry <ms>', 'Approval expiry (ms-since-epoch). Defaults to 24h from now.')
     .option('--approval-id <id>', 'Override the random approval id');
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
@@ -262,10 +262,23 @@ const tradeOpts = (cmd: Command, side: 'yes' | 'no', dir: 'buy' | 'sell') =>
     .option('--expiry <when>', 'Approval expiry: ms-since-epoch or duration (24h, 7d). Default 24h.')
     .option('--approval-id <id>', 'Override the random approval id');
 
-addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('buy-yes'), 'yes', 'buy'))).action(buyAction('yes'));
-addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('buy-no'), 'no', 'buy'))).action(buyAction('no'));
-addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('sell-yes'), 'yes', 'sell'))).action(sellAction('yes'));
-addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('sell-no'), 'no', 'sell'))).action(sellAction('no'));
+addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('buy-yes'), 'yes', 'buy'))).action(buyAction('yes')).addHelpText('after', `
+Examples:
+  $ bb prediction-markets buy-yes 55 --creator bb1trader...xyz --token-amount 100 --payment-amount 40 --denom USDC | bb deploy
+  $ bb prediction-markets buy-yes 55 --creator bb1trader...xyz --token-amount 100 --payment-amount 40 --denom USDC --expiry 7d | bb deploy
+`);
+addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('buy-no'), 'no', 'buy'))).action(buyAction('no')).addHelpText('after', `
+Examples:
+  $ bb prediction-markets buy-no 55 --creator bb1trader...xyz --token-amount 100 --payment-amount 60 --denom USDC | bb deploy
+`);
+addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('sell-yes'), 'yes', 'sell'))).action(sellAction('yes')).addHelpText('after', `
+Examples:
+  $ bb prediction-markets sell-yes 55 --creator bb1trader...xyz --token-amount 50 --payment-amount 25 --denom USDC | bb deploy
+`);
+addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('sell-no'), 'no', 'sell'))).action(sellAction('no')).addHelpText('after', `
+Examples:
+  $ bb prediction-markets sell-no 55 --creator bb1trader...xyz --token-amount 50 --payment-amount 30 --denom USDC | bb deploy
+`);
 
 // ── Cancel ───────────────────────────────────────────────────────────────
 
@@ -292,7 +305,11 @@ addOutputFlags(
       value: { creator, collectionId: String(collectionId), approvalId }
     }, opts);
   } catch (err) { emitError(err); }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb prediction-markets cancel 55 a1b2c3d4e5f6 --creator bb1trader...xyz --side buy | bb deploy
+  $ bb prediction-markets cancel 55 a1b2c3d4e5f6 --creator bb1trader...xyz --side sell | bb deploy
+`);
 
 // ── Deposit ──────────────────────────────────────────────────────────────
 
@@ -317,7 +334,10 @@ addOutputFlags(
     }
     emit(buildPredictionMarketDepositMsg(creator, String(collectionId), BigInt(opts.amount), settle.mintApprovalId), opts);
   } catch (err) { emitError(err); }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb prediction-markets deposit 55 --creator bb1lp...xyz --amount 1000000 | bb deploy
+`);
 
 // ── Redeem ───────────────────────────────────────────────────────────────
 
@@ -369,7 +389,11 @@ addOutputFlags(
       emit(tx.messages.length === 1 ? tx.messages[0] : tx, opts);
     } catch (err) { emitError(err); }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb prediction-markets redeem 55 --creator bb1holder...xyz --state active --pair-amount 50000 | bb deploy
+  $ bb prediction-markets redeem 55 --creator bb1holder...xyz --state yes-wins --yes-balance 100000 | bb deploy
+`);
 
 // ── Resolve (verifier) ───────────────────────────────────────────────────
 
@@ -396,7 +420,11 @@ addOutputFlags(
     const tx = buildPredictionMarketResolveTx(creator, String(collectionId), outcome, settle);
     emit(tx.messages.length === 1 ? tx.messages[0] : tx, opts);
   } catch (err) { emitError(err); }
-});
+}).addHelpText('after', `
+Examples:
+  $ bb prediction-markets resolve 55 --creator bb1verifier...xyz --outcome yes | bb deploy
+  $ bb prediction-markets resolve 55 --creator bb1verifier...xyz --outcome push | bb deploy
+`);
 
 // Per-standard `build` subcommand removed in CLI v2 (#0399).
 // Use `bb build prediction-market ...` (the canonical builder) instead.

--- a/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
@@ -23,7 +23,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1AddressStrict } from '../utils/address.js';
 import { requireBbDenom } from '../utils/denom.js';
 import {
   validatePredictionMarketCollection,
@@ -191,7 +191,7 @@ function buyAction(side: 'yes' | 'no') {
     opts: NetworkFlags & OutputFlags & { creator: string; tokenAmount: string; paymentAmount: string; denom: string; expiry?: string; approvalId?: string }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const paymentDenom = requireBbDenom(opts.denom, '--denom');
       await fetchCollection(collectionId, opts).then((c) => validateOrExit(c, `prediction-markets buy-${side}`));
       const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 24 * 60 * 60 * 1000);
@@ -217,7 +217,7 @@ function sellAction(side: 'yes' | 'no') {
     opts: NetworkFlags & OutputFlags & { creator: string; tokenAmount: string; paymentAmount: string; denom: string; expiry?: string; approvalId?: string }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const paymentDenom = requireBbDenom(opts.denom, '--denom');
       await fetchCollection(collectionId, opts).then((c) => validateOrExit(c, `prediction-markets sell-${side}`));
       const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 24 * 60 * 60 * 1000);
@@ -269,7 +269,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, approvalId: string, opts: NetworkFlags & OutputFlags & { creator: string; side: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const isBuy = opts.side === 'buy';
     if (opts.side !== 'buy' && opts.side !== 'sell') {
       process.stderr.write(`Error: --side must be "buy" or "sell" (got "${opts.side}").\n`);
@@ -295,7 +295,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'prediction-markets deposit');
     const settle = findSettlementApprovals(collection);
@@ -327,7 +327,7 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; state: string; pairAmount?: string; yesBalance?: string; noBalance?: string }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'prediction-markets redeem');
       const settle = findSettlementApprovals(collection);
@@ -372,7 +372,7 @@ addOutputFlags(
   )
 ).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; outcome: string }) => {
   try {
-    const creator = requireBb1Address(opts.creator, '--creator');
+    const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
     validateOrExit(collection, 'prediction-markets resolve');
     const settle = findSettlementApprovals(collection);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
@@ -24,7 +24,8 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1AddressStrict } from '../utils/address.js';
-import { requireBbDenom } from '../utils/denom.js';
+import { resolveAmount } from '../utils/amount.js';
+import { parseTimeFlag } from '../utils/time.js';
 import {
   validatePredictionMarketCollection,
   classifySettlementApproval,
@@ -188,13 +189,18 @@ addOutputFlags(
 function buyAction(side: 'yes' | 'no') {
   return async (
     collectionId: string,
-    opts: NetworkFlags & OutputFlags & { creator: string; tokenAmount: string; paymentAmount: string; denom: string; expiry?: string; approvalId?: string }
+    opts: NetworkFlags & OutputFlags & { creator: string; tokenAmount: string; paymentAmount: string; denom: string; baseUnits?: boolean; expiry?: string; approvalId?: string }
   ) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
-      const paymentDenom = requireBbDenom(opts.denom, '--denom');
+      const { denom: paymentDenom, amount: paymentAmountStr } = resolveAmount(
+        opts.paymentAmount,
+        opts.denom,
+        Boolean(opts.baseUnits),
+        { amountFlag: '--payment-amount', denomFlag: '--denom' }
+      );
       await fetchCollection(collectionId, opts).then((c) => validateOrExit(c, `prediction-markets buy-${side}`));
-      const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 24 * 60 * 60 * 1000);
+      const end = opts.expiry ? parseTimeFlag(opts.expiry, '--expiry') : BigInt(Date.now() + 24 * 60 * 60 * 1000);
       const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
       const approval = buildPredictionMarketBuyIntent({
         address: creator,
@@ -202,7 +208,7 @@ function buyAction(side: 'yes' | 'no') {
         tokenId: side === 'yes' ? 1n : 2n,
         tokenAmount: BigInt(opts.tokenAmount),
         paymentDenom,
-        paymentAmount: BigInt(opts.paymentAmount),
+        paymentAmount: BigInt(paymentAmountStr),
         transferTimes: UintRangeArray.From([{ start: 1n, end }]),
         approvalId
       });
@@ -214,13 +220,18 @@ function buyAction(side: 'yes' | 'no') {
 function sellAction(side: 'yes' | 'no') {
   return async (
     collectionId: string,
-    opts: NetworkFlags & OutputFlags & { creator: string; tokenAmount: string; paymentAmount: string; denom: string; expiry?: string; approvalId?: string }
+    opts: NetworkFlags & OutputFlags & { creator: string; tokenAmount: string; paymentAmount: string; denom: string; baseUnits?: boolean; expiry?: string; approvalId?: string }
   ) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
-      const paymentDenom = requireBbDenom(opts.denom, '--denom');
+      const { denom: paymentDenom, amount: paymentAmountStr } = resolveAmount(
+        opts.paymentAmount,
+        opts.denom,
+        Boolean(opts.baseUnits),
+        { amountFlag: '--payment-amount', denomFlag: '--denom' }
+      );
       await fetchCollection(collectionId, opts).then((c) => validateOrExit(c, `prediction-markets sell-${side}`));
-      const end = opts.expiry ? BigInt(opts.expiry) : BigInt(Date.now() + 24 * 60 * 60 * 1000);
+      const end = opts.expiry ? parseTimeFlag(opts.expiry, '--expiry') : BigInt(Date.now() + 24 * 60 * 60 * 1000);
       const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
       const approval = buildPredictionMarketSellIntent({
         address: creator,
@@ -228,7 +239,7 @@ function sellAction(side: 'yes' | 'no') {
         tokenId: side === 'yes' ? 1n : 2n,
         tokenAmount: BigInt(opts.tokenAmount),
         paymentDenom,
-        paymentAmount: BigInt(opts.paymentAmount),
+        paymentAmount: BigInt(paymentAmountStr),
         transferTimes: UintRangeArray.From([{ start: 1n, end }]),
         approvalId
       });
@@ -243,11 +254,12 @@ const tradeOpts = (cmd: Command, side: 'yes' | 'no', dir: 'buy' | 'sell') =>
       `Emit Msg${dir === 'buy' ? 'SetIncomingApproval' : 'SetOutgoingApproval'} that ${dir === 'buy' ? 'buys' : 'sells'} ${side.toUpperCase()} tokens (token-id ${side === 'yes' ? '1' : '2'}). Pipe to \`bb deploy\`.`
     )
     .argument('<collection-id>', 'Prediction Market collection ID')
-    .requiredOption('--creator <address>', 'Trader address (bb1.../0x — auto-normalized)')
-    .requiredOption('--token-amount <n>', `Quantity of ${side.toUpperCase()} tokens to ${dir}`)
-    .requiredOption('--payment-amount <n>', 'Payment side amount in base units')
+    .requiredOption('--creator <address>', 'Trader address (bb1...) — strict; run `bb account convert` for 0x')
+    .requiredOption('--token-amount <n>', `Quantity of ${side.toUpperCase()} tokens to ${dir} (always base units of the on-chain token id)`)
+    .requiredOption('--payment-amount <n>', 'Payment side amount. Display units for symbol denoms, base units for chain denoms. Use --base-units to force base-units.')
     .requiredOption('--denom <symbol|denom>', 'Payment denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...) or badgeslp:* alias.')
-    .option('--expiry <ms>', 'Approval expiry (ms-since-epoch). Defaults to 24h from now.')
+    .option('--base-units', 'Treat --payment-amount as already-in-base-units')
+    .option('--expiry <when>', 'Approval expiry: ms-since-epoch or duration (24h, 7d). Default 24h.')
     .option('--approval-id <id>', 'Override the random approval id');
 
 addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('buy-yes'), 'yes', 'buy'))).action(buyAction('yes'));

--- a/packages/bitbadgesjs-sdk/src/cli/commands/products.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/products.ts
@@ -13,7 +13,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1AddressStrict } from '../utils/address.js';
 import {
   doesCollectionFollowProductCatalogProtocol,
   validateProductCatalogCollection,
@@ -122,7 +122,7 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; tokenId: string }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'products purchase');
       const products = extractAllProducts(collection.collectionApprovals);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/products.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/products.ts
@@ -145,7 +145,10 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb products purchase 12 --creator bb1buyer...xyz --token-id 3 | bb deploy
+`);
 
 // Per-standard `build` subcommand removed in CLI v2 (#0399).
 // Use `bb build product-catalog ...` (the canonical builder) instead.

--- a/packages/bitbadgesjs-sdk/src/cli/commands/simulate.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/simulate.ts
@@ -47,7 +47,7 @@ export const simulateCommand = addNetworkOptions(
       renderSimulate(
         {
           success: false,
-          error: 'No API key. Set BITBADGES_API_KEY, run `bitbadges-cli config set apiKey <key>`, or pass --network local against a key-less local indexer.'
+          error: 'No API key. Pass --api-key, run `bb settings set apiKey <key>`, or pass --network local against a key-less local indexer.'
         },
         { stream: process.stderr }
       ) + '\n'

--- a/packages/bitbadgesjs-sdk/src/cli/commands/smart-tokens.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/smart-tokens.ts
@@ -26,7 +26,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1AddressStrict } from '../utils/address.js';
 import {
   doesCollectionFollowSmartTokenProtocol,
   validateSmartTokenCollection,
@@ -184,7 +184,7 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; amount: string; baseUnits?: boolean }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'smart-tokens deposit');
       const details = extractSmartTokenDetails(collection)!;
@@ -236,7 +236,7 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; amount: string; baseUnits?: boolean }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'smart-tokens withdraw');
       const details = extractSmartTokenDetails(collection)!;

--- a/packages/bitbadgesjs-sdk/src/cli/commands/smart-tokens.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/smart-tokens.ts
@@ -210,7 +210,11 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb smart-tokens deposit 88 --creator bb1user...xyz --amount 10 | bb deploy
+  $ bb smart-tokens deposit 88 --creator bb1user...xyz --amount 10000000 --base-units | bb deploy
+`);
 
 // ── smart-tokens withdraw ────────────────────────────────────────────────────
 
@@ -262,7 +266,10 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb smart-tokens withdraw 88 --creator bb1user...xyz --amount 5 | bb deploy
+`);
 
 // Per-standard `build` subcommand removed in CLI v2 (#0399).
 // Use `bb build smart-token ...` (the canonical builder) instead.

--- a/packages/bitbadgesjs-sdk/src/cli/commands/subscriptions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/subscriptions.ts
@@ -366,7 +366,7 @@ addOutputFlags(
         firstIntervalStartTime: BigInt(Date.now()),
         ubadgeTipAmount: tip,
         transferTimes: UintRangeArray.FullRanges(),
-        approvalId: crypto.randomUUID(),
+        approvalId: crypto.randomBytes(16).toString('hex'),
         tokenIds: faucet.tokenIds,
         denom
       });
@@ -470,7 +470,7 @@ addOutputFlags(
         firstIntervalStartTime: BigInt(Date.now()),
         ubadgeTipAmount: tip,
         transferTimes: UintRangeArray.FullRanges(),
-        approvalId: crypto.randomUUID(),
+        approvalId: crypto.randomBytes(16).toString('hex'),
         tokenIds: faucet.tokenIds,
         denom
       });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/subscriptions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/subscriptions.ts
@@ -328,7 +328,11 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb subscriptions claim 28 --creator bb1subscriber...xyz | bb deploy
+  $ bb subscriptions claim 28 --creator bb1subscriber...xyz --tier pro-tier | bb deploy
+`);
 
 // ── subscriptions enable-renewal ─────────────────────────────────────────
 
@@ -386,7 +390,11 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb subscriptions enable-renewal 28 --creator bb1subscriber...xyz | bb deploy
+  $ bb subscriptions enable-renewal 28 --creator bb1subscriber...xyz --tier pro-tier --tip 1000 | bb deploy
+`);
 
 // ── subscriptions cancel ─────────────────────────────────────────────────
 
@@ -422,7 +430,11 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb subscriptions cancel 28 --creator bb1subscriber...xyz | bb deploy
+  $ bb subscriptions cancel 28 --creator bb1subscriber...xyz --tier pro-tier | bb deploy
+`);
 
 // ── subscriptions subscribe (multi-msg) ──────────────────────────────────
 
@@ -481,7 +493,11 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb subscriptions subscribe 28 --creator bb1subscriber...xyz | bb deploy
+  $ bb subscriptions subscribe 28 --creator bb1subscriber...xyz --tier pro-tier --tip 500 | bb deploy
+`);
 
 // ── subscriptions charge-due ─────────────────────────────────────────────
 //
@@ -690,7 +706,11 @@ addOutputFlags(
       emitError(err);
     }
   }
-);
+).addHelpText('after', `
+Examples:
+  $ bb subscriptions charge-due 28 --creator bb1operator...xyz --dry-run
+  $ bb subscriptions charge-due 28 --creator bb1operator...xyz | bb deploy --with-keyring --from operator
+`);
 
 // Per-standard `build` subcommand removed in CLI v2 (#0399).
 // Use `bb build subscription ...` (the canonical builder) instead.

--- a/packages/bitbadgesjs-sdk/src/cli/commands/subscriptions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/subscriptions.ts
@@ -29,7 +29,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
-import { requireBb1Address } from '../utils/address.js';
+import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
 import {
   doesCollectionFollowSubscriptionProtocol,
   isSubscriptionFaucetApproval,
@@ -319,7 +319,7 @@ addOutputFlags(
 ).action(
   async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; tier?: string }) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'subscriptions claim');
       const faucet = pickFaucet(listFaucets(collection), opts.tier, 'subscriptions claim');
@@ -350,7 +350,7 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; tier?: string; tip?: string }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'subscriptions enable-renewal');
       const faucet = pickFaucet(listFaucets(collection), opts.tier, 'subscriptions enable-renewal');
@@ -404,7 +404,7 @@ addOutputFlags(
 ).action(
   async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; tier?: string }) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'subscriptions cancel');
       const faucet = pickFaucet(listFaucets(collection), opts.tier, 'subscriptions cancel');
@@ -444,7 +444,7 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; tier?: string; tip?: string }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'subscriptions subscribe');
       const faucet = pickFaucet(listFaucets(collection), opts.tier, 'subscriptions subscribe');
@@ -594,7 +594,7 @@ addOutputFlags(
     opts: NetworkFlags & OutputFlags & { creator: string; tier?: string; dryRun?: boolean }
   ) => {
     try {
-      const creator = requireBb1Address(opts.creator, '--creator');
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'subscriptions charge-due');
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/swap-pools.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/swap-pools.spec.ts
@@ -29,9 +29,9 @@ describe('swap pools surface', () => {
     expect((show as any)._args.map((a: any) => a.name())).toEqual(['pool-id']);
   });
 
-  it('by-denom takes <denom>', () => {
+  it('by-denom takes <symbol|denom>', () => {
     const c = pools.commands.find((c) => c.name() === 'by-denom')!;
-    expect((c as any)._args.map((a: any) => a.name())).toEqual(['denom']);
+    expect((c as any)._args.map((a: any) => a.name())).toEqual(['symbol|denom']);
   });
 
   it('by-assets takes <denom-a> <denom-b>', () => {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/swap.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/swap.ts
@@ -25,6 +25,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
+import { requireSkipGoDenom } from '../utils/denom.js';
 
 function appendQuery(path: string, params: Record<string, string | number | boolean | undefined>): string {
   const search = new URLSearchParams();
@@ -138,11 +139,16 @@ addOutputFlags(
       }
   ) => {
     try {
+      // Swap accepts origin-chain native denoms (uusdc / uatom / …) and
+      // cross-chain ibc/... forms; validate against the permissive
+      // Skip:Go contract rather than the strict BitBadges one.
+      const fromDenom = requireSkipGoDenom(from, '<from> argument to bb swap estimate');
+      const toDenom = requireSkipGoDenom(to, '<to> argument to bb swap estimate');
       const addresses = opts.addresses ? JSON.parse(opts.addresses) : {};
       const body = {
-        tokenIn: `${amount}${from}`,
+        tokenIn: `${amount}${fromDenom}`,
         tokenInChainId: opts.sourceChain ?? 'bitbadges-1',
-        tokenOutDenom: to,
+        tokenOutDenom: toDenom,
         tokenOutChainId: opts.destChain ?? 'bitbadges-1',
         chainIdsToAddresses: addresses,
         slippageTolerancePercent: opts.slippage ?? '1',

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -611,35 +611,34 @@ if (process.argv.includes('--help-json')) {
   const tree = {
     commands: program.commands.map((cmd) => extractCommandTree(cmd))
   };
-  const json = JSON.stringify(tree, null, 2) + '\n';
-  // Use `fs.writeSync(1, ...)` rather than `process.stdout.write(...)` so
-  // the entire ~150KB tree lands before we exit. process.stdout's async
-  // write returns false past the OS pipe buffer (~64KB on Linux), and the
-  // drain callback doesn't suspend the rest of this module — so without
-  // a sync write the file would fall through to `program.parse()` and
-  // emit stale help text after a truncated JSON document. fs.writeSync
-  // writes the full buffer synchronously; nothing left to drain.
-  const buf = Buffer.from(json, 'utf-8');
-  let written = 0;
-  while (written < buf.length) {
-    try {
-      written += fs.writeSync(1, buf, written, buf.length - written);
-    } catch (err: any) {
-      // The parent (e.g. spawnSync, test harness) may not have drained
-      // its pipe buffer yet for a large JSON tree. EAGAIN means the
-      // pipe is momentarily full — yield once with a short sleep so
-      // the reader can catch up, then retry.
-      if (err?.code === 'EAGAIN') {
-        // Synchronous-yield via Atomics.wait so we don't fall through
-        // to the rest of the module before retrying.
-        const sab = new SharedArrayBuffer(4);
-        Atomics.wait(new Int32Array(sab), 0, 0, 10);
-        continue;
-      }
-      throw err;
+  // Pretty-print only for interactive readers (humans on a TTY). Pipes,
+  // spawnSync collectors, agentic shells get the compact form so the
+  // output fits in standard maxBuffer (~1MB). Pretty-printed tree is
+  // ~1.4MB, compact is ~500KB.
+  const pretty = !!process.stdout.isTTY;
+  const json = JSON.stringify(tree, null, pretty ? 2 : 0) + '\n';
+  // Async write + 'drain' wait pattern. process.stdout.write returns
+  // false once the OS pipe buffer (~64KB on Linux) fills; the 'drain'
+  // event fires when the reader (e.g. spawnSync's pipe collector)
+  // catches up. We can't simply fs.writeSync — it throws EAGAIN on
+  // non-blocking pipes, and Atomics.wait retry doesn't yield enough
+  // for the parent to drain under a tight test timeout.
+  //
+  // The rest of this module (Commander wiring, program.parse()) runs
+  // synchronously after this IIFE returns control. `program.parse()`
+  // with `--help-json` as the only arg is a no-op (Commander recognises
+  // the option but has no default handler), so falling through is
+  // benign. The IIFE's `process.exit(0)` fires once the JSON has been
+  // fully flushed and ends the process for real.
+  (async () => {
+    if (!process.stdout.write(json)) {
+      await new Promise<void>((resolve) => process.stdout.once('drain', () => resolve()));
     }
-  }
-  process.exit(0);
+    process.exit(0);
+  })().catch((err) => {
+    process.stderr.write(`Error emitting --help-json: ${(err as Error)?.message ?? err}\n`);
+    process.exit(1);
+  });
 }
 
 // ── Top-level error handler ─────────────────────────────────────────────────
@@ -674,4 +673,8 @@ if (process.argv.length <= 2 || onlyGlobalFlags) {
   process.exit(0);
 }
 
-program.parse();
+// --help-json has its own emit path (above). Skip Commander's parse so
+// it doesn't fall back to printing help text alongside the JSON.
+if (!process.argv.includes('--help-json')) {
+  program.parse();
+}

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -301,6 +301,36 @@ const HELP_GROUPS: { title: string; commands: Command[] }[] = [
 const completionCommand = makeCompletionCommand(program);
 HELP_GROUPS.push({ title: 'Misc', commands: [completionCommand] });
 
+// ── Per-standard `build` alias subcommands ──────────────────────────────────
+//
+// Each standard parent gains a `build` subcommand that forwards to the
+// canonical `bb build <type>`. Restores v1 ergonomics (`bb auctions build
+// ...` works the same as `bb build auction ...`) while keeping the
+// single source of truth for build logic. Standards without a 1:1 build
+// counterpart (nfts, dynamic-stores) are skipped.
+import { makeBuildAlias } from './utils/build-alias.js';
+const STANDARD_BUILD_ALIASES: Record<string, string> = {
+  auctions: 'auction',
+  bounties: 'bounty',
+  crowdfunds: 'crowdfund',
+  'credit-tokens': 'credit-token',
+  intents: 'intent',
+  'pay-requests': 'payment-request',
+  'prediction-markets': 'prediction-market',
+  products: 'product-catalog',
+  'smart-tokens': 'smart-token',
+  subscriptions: 'subscription'
+};
+const standardsByName = new Map<string, Command>();
+for (const group of HELP_GROUPS) {
+  for (const cmd of group.commands) standardsByName.set(cmd.name(), cmd);
+}
+for (const [standardName, buildSubtype] of Object.entries(STANDARD_BUILD_ALIASES)) {
+  const parent = standardsByName.get(standardName);
+  if (!parent) continue;
+  parent.addCommand(makeBuildAlias(buildSubtype, buildCommand));
+}
+
 // ── Register every command at the top level ─────────────────────────────────
 
 for (const group of HELP_GROUPS) {

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -10,18 +10,73 @@ import { emitDeprecation } from './utils/deprecation.js';
 // deep commands like `bb intents create --help` we need to override at the
 // `Help` class level. Defined here so the override is in scope before any
 // subcommand is instantiated.
+// ── Layout primitives ────────────────────────────────────────────────────────
+// TERM_COL: clamp on the term column. A term longer than this drops its
+//   description onto the next line, indented to TERM_COL+leftPad, instead
+//   of pushing the whole section's descriptions further right.
+// HELP_WIDTH: total width budget. Descriptions reflow at this width,
+//   re-indented to keep the column alignment intact.
+const TERM_COL = 30;
+const HELP_WIDTH = Math.max(80, process.stdout.columns ?? 100);
+
+/** Word-wrap `text` to `width` chars, indenting every line (including the
+ *  first) by `indent`. Preserves existing line breaks. */
+function wrapText(text: string, width: number, indent: string): string {
+  const out: string[] = [];
+  for (const para of text.split('\n')) {
+    if (!para) { out.push(indent); continue; }
+    let line = '';
+    for (const word of para.split(/\s+/)) {
+      if (!word) continue;
+      if (line && line.length + 1 + word.length > width) {
+        out.push(indent + line);
+        line = word;
+      } else {
+        line = line ? `${line} ${word}` : word;
+      }
+    }
+    if (line) out.push(indent + line);
+  }
+  return out.join('\n');
+}
+
+/** Render one term/description row with two niceties over Commander's
+ *  default `padEnd` + raw concat:
+ *   1. If `term` is longer than `termCol`, emit it on its own line and put
+ *      the description on the next line, indented to `leftPad + termCol`.
+ *      Stops one long term from blowing out the whole section.
+ *   2. The description is word-wrapped to fit within HELP_WIDTH and the
+ *      continuation lines are re-indented to match the description column.
+ */
+function renderRow(term: string, description: string, leftPad: number, termCol: number = TERM_COL): string {
+  const left = ' '.repeat(leftPad);
+  const descIndentLen = leftPad + termCol + 2; // +2 gap between term and desc
+  const descIndent = ' '.repeat(descIndentLen);
+  const descWidth = Math.max(20, HELP_WIDTH - descIndentLen);
+  const wrapped = description ? wrapText(description, descWidth, descIndent) : '';
+  if (term.length <= termCol) {
+    return wrapped ? `${left}${term.padEnd(termCol)}  ${wrapped.trimStart()}` : `${left}${term}`;
+  }
+  return wrapped ? `${left}${term}\n${wrapped}` : `${left}${term}`;
+}
+
 class GroupedHelp extends Help {
+
   formatHelp(cmd: Command, helper: Help): string {
     const sections: string[] = [];
     sections.push(`Usage: ${helper.commandUsage(cmd)}`);
     const desc = helper.commandDescription(cmd);
-    if (desc) sections.push('', desc);
+    if (desc) {
+      // Wrap the top description to the full help width so long blurbs
+      // don't bleed past the terminal edge.
+      sections.push('', wrapText(desc, HELP_WIDTH, ''));
+    }
 
     const argList = helper.visibleArguments(cmd);
     if (argList.length > 0) {
       sections.push('', 'Arguments:');
       for (const arg of argList) {
-        sections.push(`  ${helper.argumentTerm(arg).padEnd(28)}  ${helper.argumentDescription(arg)}`);
+        sections.push(renderRow(helper.argumentTerm(arg), helper.argumentDescription(arg), 2));
       }
     }
 
@@ -37,7 +92,7 @@ class GroupedHelp extends Help {
     if (requiredOpts.length > 0) {
       sections.push('', 'Required:');
       for (const opt of requiredOpts) {
-        sections.push(`  ${helper.optionTerm(opt).padEnd(28)}  ${helper.optionDescription(opt)}`);
+        sections.push(renderRow(helper.optionTerm(opt), helper.optionDescription(opt), 2));
       }
     }
     if (optionalOpts.length > 0) {
@@ -52,7 +107,7 @@ class GroupedHelp extends Help {
       }
       // Per-command flags first (no subheader)
       for (const opt of ungrouped) {
-        sections.push(`  ${helper.optionTerm(opt).padEnd(28)}  ${helper.optionDescription(opt)}`);
+        sections.push(renderRow(helper.optionTerm(opt), helper.optionDescription(opt), 2));
       }
       const orderedGroups = [
         ...HELP_GROUP_ORDER,
@@ -63,7 +118,7 @@ class GroupedHelp extends Help {
         if (!groupOpts || groupOpts.length === 0) continue;
         sections.push('', `  ${group}:`);
         for (const opt of groupOpts) {
-          sections.push(`    ${helper.optionTerm(opt).padEnd(26)}  ${helper.optionDescription(opt)}`);
+          sections.push(renderRow(helper.optionTerm(opt), helper.optionDescription(opt), 4, TERM_COL - 2));
         }
       }
     }
@@ -72,7 +127,7 @@ class GroupedHelp extends Help {
     if (subList.length > 0) {
       sections.push('', 'Commands:');
       for (const sub of subList) {
-        sections.push(`  ${helper.subcommandTerm(sub).padEnd(28)}  ${helper.subcommandDescription(sub)}`);
+        sections.push(renderRow(helper.subcommandTerm(sub), helper.subcommandDescription(sub), 2));
       }
     }
 
@@ -444,13 +499,13 @@ program.configureHelp({
     const sections: string[] = [];
     sections.push(`Usage: ${helper.commandUsage(cmd)}`);
     const desc = helper.commandDescription(cmd);
-    if (desc) sections.push('', desc);
+    if (desc) sections.push('', wrapText(desc, HELP_WIDTH, ''));
 
     const optList = helper.visibleOptions(cmd);
     if (optList.length > 0) {
       sections.push('', 'Options:');
       for (const opt of optList) {
-        sections.push(`  ${helper.optionTerm(opt).padEnd(28)}  ${helper.optionDescription(opt)}`);
+        sections.push(renderRow(helper.optionTerm(opt), helper.optionDescription(opt), 2));
       }
     }
 
@@ -463,7 +518,7 @@ program.configureHelp({
       if (groupVisible.length === 0) continue;
       sections.push('', `  ${group.title}:`);
       for (const c of groupVisible) {
-        sections.push(`    ${helper.subcommandTerm(c).padEnd(28)}  ${helper.subcommandDescription(c)}`);
+        sections.push(renderRow(helper.subcommandTerm(c), helper.subcommandDescription(c), 4, TERM_COL - 2));
       }
     }
 
@@ -472,28 +527,25 @@ program.configureHelp({
 });
 
 function defaultFormatHelp(cmd: Command, helper: any): string {
-  // Minimal flat formatter for non-root commands. Commander's stock
-  // implementation pads more carefully but the visible difference is
-  // negligible for our subcommands.
+  // Minimal flat formatter for non-root commands. Uses the shared
+  // renderRow/wrapText helpers so column alignment + description reflow
+  // stay consistent with GroupedHelp.
   const sections: string[] = [];
   sections.push(`Usage: ${helper.commandUsage(cmd)}`);
   const desc = helper.commandDescription(cmd);
-  if (desc) sections.push('', desc);
+  if (desc) sections.push('', wrapText(desc, HELP_WIDTH, ''));
 
   const argList = helper.visibleArguments(cmd);
   if (argList.length > 0) {
     sections.push('', 'Arguments:');
     for (const arg of argList) {
-      sections.push(`  ${helper.argumentTerm(arg).padEnd(28)}  ${helper.argumentDescription(arg)}`);
+      sections.push(renderRow(helper.argumentTerm(arg), helper.argumentDescription(arg), 2));
     }
   }
 
   // Split options into Required (`.requiredOption(...)`, Commander sets
   // `mandatory = true`) and Options (everything else). Help-bearing flags
-  // like `-h, --help` stay in Options. Commander's stock layout lumps
-  // them together; on commands with 10+ flags it's hard to tell at a
-  // glance which ones the user MUST pass — especially for chained
-  // builder calls (`bb intents create --amount X --denom Y ...`).
+  // like `-h, --help` stay in Options.
   const optList = helper.visibleOptions(cmd);
   const requiredOpts = optList.filter((o: any) => o.mandatory);
   const optionalOpts = optList.filter((o: any) => !o.mandatory);
@@ -501,13 +553,13 @@ function defaultFormatHelp(cmd: Command, helper: any): string {
   if (requiredOpts.length > 0) {
     sections.push('', 'Required:');
     for (const opt of requiredOpts) {
-      sections.push(`  ${helper.optionTerm(opt).padEnd(28)}  ${helper.optionDescription(opt)}`);
+      sections.push(renderRow(helper.optionTerm(opt), helper.optionDescription(opt), 2));
     }
   }
   if (optionalOpts.length > 0) {
     sections.push('', 'Options:');
     for (const opt of optionalOpts) {
-      sections.push(`  ${helper.optionTerm(opt).padEnd(28)}  ${helper.optionDescription(opt)}`);
+      sections.push(renderRow(helper.optionTerm(opt), helper.optionDescription(opt), 2));
     }
   }
 
@@ -515,7 +567,7 @@ function defaultFormatHelp(cmd: Command, helper: any): string {
   if (subList.length > 0) {
     sections.push('', 'Commands:');
     for (const sub of subList) {
-      sections.push(`  ${helper.subcommandTerm(sub).padEnd(28)}  ${helper.subcommandDescription(sub)}`);
+      sections.push(renderRow(helper.subcommandTerm(sub), helper.subcommandDescription(sub), 2));
     }
   }
 

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -151,6 +151,19 @@ program
   .description('BitBadges CLI — flat verb-first surface for building, inspecting, and shipping token transactions')
   .version('0.1.0');
 
+// ── Policies disclaimer ──────────────────────────────────────────────────────
+//
+// Every `--help` invocation ends with a link to the published terms /
+// privacy / acceptable-use policies. Required for production CLIs that
+// emit user-attributable content (feedback submissions, on-chain txs,
+// hosted-API calls). Mirrored copy lives at bitbadges-frontend's
+// pages/policies.tsx.
+program.addHelpText(
+  'after',
+  '\nTerms, privacy, and acceptable-use policies: https://bitbadges.io/policies\n' +
+  'By using `bitbadges-cli` you agree to the policies linked above.\n'
+);
+
 // ── Global options ───────────────────────────────────────────────────────────
 //
 // --help-json is parsed below by inspecting argv directly (Commander

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -198,6 +198,13 @@ import { nftsCommand } from './commands/nfts.js';
 
 // Misc
 import { makeCompletionCommand } from './commands/completion.js';
+import { maybePrintFirstRunBanner } from './utils/first-run.js';
+
+// First-run policies + tab-completion banner. Runs before Commander parses
+// so the user sees it ahead of any actual output, even on `bb --help`.
+// Best-effort: never blocks, never throws. Suppressed via BB_QUIET=1 or
+// once `firstRunAcknowledgedAt` is set in ~/.bitbadges/config.json.
+maybePrintFirstRunBanner(process.argv);
 
 const program = new Command();
 

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -615,7 +615,22 @@ if (process.argv.includes('--help-json')) {
   const buf = Buffer.from(json, 'utf-8');
   let written = 0;
   while (written < buf.length) {
-    written += fs.writeSync(1, buf, written, buf.length - written);
+    try {
+      written += fs.writeSync(1, buf, written, buf.length - written);
+    } catch (err: any) {
+      // The parent (e.g. spawnSync, test harness) may not have drained
+      // its pipe buffer yet for a large JSON tree. EAGAIN means the
+      // pipe is momentarily full — yield once with a short sleep so
+      // the reader can catch up, then retry.
+      if (err?.code === 'EAGAIN') {
+        // Synchronous-yield via Atomics.wait so we don't fall through
+        // to the rest of the module before retrying.
+        const sab = new SharedArrayBuffer(4);
+        Atomics.wait(new Int32Array(sab), 0, 0, 10);
+        continue;
+      }
+      throw err;
+    }
   }
   process.exit(0);
 }

--- a/packages/bitbadgesjs-sdk/src/cli/integration/cli-build-pipeline.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/cli-build-pipeline.spec.ts
@@ -191,23 +191,43 @@ describe('cli build pipeline integration', () => {
       expect(out.json.value.amount[0].amount).toBe('1000000');
     });
 
-    it('0x address is auto-normalized to bb1', () => {
-      const out = runCli([
-        'build', 'send',
-        '--from', '0x0000000000000000000000000000000000000000',
-        '--to', RECIPIENT,
-        '--amount', '1', '--denom', 'BADGE'
-      ]);
+    it('0x address rejects strictly with a `bb account convert` hint', () => {
+      // Post-v2.1 strict mode: msg-emit address flags throw on 0x input.
+      const out = runCli(
+        [
+          'build', 'send',
+          '--from', '0x0000000000000000000000000000000000000000',
+          '--to', RECIPIENT,
+          '--amount', '1', '--denom', 'BADGE'
+        ],
+        { throwOnError: false, parseJson: false }
+      );
+      expect(out.exitCode).not.toBe(0);
+      expect(out.stderr).toMatch(/bb1\.\.\. address/);
+      expect(out.stderr).toMatch(/bb account convert/);
+    });
+
+    it('BB_ADDRESS_AUTO_CONVERT=1 restores lenient 0x→bb1 normalization', () => {
+      // Back-compat escape hatch for one release.
+      const out = runCli(
+        [
+          'build', 'send',
+          '--from', '0x0000000000000000000000000000000000000000',
+          '--to', RECIPIENT,
+          '--amount', '1', '--denom', 'BADGE'
+        ],
+        { env: { BB_ADDRESS_AUTO_CONVERT: '1' } }
+      );
       expect(out.json.value.fromAddress).toBe('bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv');
     });
 
-    it('rejects an unknown coin symbol with a clear error', () => {
+    it('rejects an unknown denom symbol with a clear error', () => {
       const out = runCli(
         ['build', 'send', '--from', CREATOR, '--to', RECIPIENT, '--amount', '1', '--denom', 'NOSUCHCOIN'],
         { throwOnError: false, parseJson: false }
       );
       expect(out.exitCode).not.toBe(0);
-      expect(out.stderr).toMatch(/Unknown coin/i);
+      expect(out.stderr).toMatch(/Unknown denom|Unknown coin/i);
     });
 
     it('rejects non-integer base-units amount', () => {

--- a/packages/bitbadgesjs-sdk/src/cli/utils/address.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/address.spec.ts
@@ -5,7 +5,7 @@
  * malformed input, stderr normalization notice gating).
  */
 
-import { tryBb1Address, requireBb1Address } from './address.js';
+import { tryBb1Address, requireBb1Address, requireBb1AddressStrict } from './address.js';
 
 // Zero-address pair — deterministic and stable across SDK versions.
 // 0x000...000 ↔ bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv.
@@ -78,5 +78,62 @@ describe('requireBb1Address', () => {
     requireBb1Address(ZERO_BB1, '<address>');
     const stderrCall = stderrSpy.mock.calls.map((c) => c[0]).join('');
     expect(stderrCall).not.toContain('Normalized');
+  });
+});
+
+describe('requireBb1AddressStrict', () => {
+  let exitSpy: jest.SpyInstance;
+  let stderrSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      throw new Error('process.exit');
+    }) as never);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.BB_ADDRESS_AUTO_CONVERT;
+  });
+
+  it('returns bb1 for valid bb1 input', () => {
+    expect(requireBb1AddressStrict(ZERO_BB1, '--creator')).toBe(ZERO_BB1);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('REJECTS 0x input with a bb account convert hint', () => {
+    expect(() => requireBb1AddressStrict(ZERO_ETH, '--creator')).toThrow('process.exit');
+    const stderrText = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderrText).toContain('--creator');
+    expect(stderrText).toContain('0x form');
+    expect(stderrText).toContain('bb account convert');
+    expect(stderrText).toContain('BB_ADDRESS_AUTO_CONVERT=1');
+  });
+
+  it('REJECTS empty input with a clear error', () => {
+    expect(() => requireBb1AddressStrict('', '--creator')).toThrow('process.exit');
+    const stderrText = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderrText).toContain('--creator requires a bb1... address');
+  });
+
+  it('rejects malformed bb1 input', () => {
+    expect(() => requireBb1AddressStrict('bb1garbage', '--creator')).toThrow('process.exit');
+    const stderrText = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderrText).toContain('invalid bb1 address');
+  });
+
+  it('honors BB_ADDRESS_AUTO_CONVERT=1 by delegating to requireBb1Address', () => {
+    process.env.BB_ADDRESS_AUTO_CONVERT = '1';
+    expect(requireBb1AddressStrict(ZERO_ETH, '--creator')).toBe(ZERO_BB1);
+    expect(exitSpy).not.toHaveBeenCalled();
+    const stderrText = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    // The lenient path emits a "Normalized X → Y" notice (unless BB_QUIET).
+    expect(stderrText).toContain('Normalized');
+  });
+
+  it('does NOT silently convert when env var is unset', () => {
+    expect(() => requireBb1AddressStrict(ZERO_ETH, '--creator')).toThrow('process.exit');
   });
 });

--- a/packages/bitbadgesjs-sdk/src/cli/utils/address.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/address.ts
@@ -1,9 +1,24 @@
 /**
- * Address-normalization helpers for the CLI. Indexer routes that key off
- * Cosmos addresses (e.g. `/account/:address/balances`, `/intents/:address`)
- * accept both 0x and bb1 forms server-side, but normalizing client-side
- * gives the user a clear canonical form back and lets the CLI fail fast
- * on truly malformed input instead of waiting for an HTTP 400.
+ * Address-normalization helpers for the CLI.
+ *
+ * TWO callsite classes, two helpers:
+ *
+ *   - {@link requireBb1Address} — lenient, auto-converts 0x → bb1 for
+ *     LOOKUP routes (`/account/:address/balances`, `/intents/:address`,
+ *     converters themselves). Server accepts both forms; client-side
+ *     conversion gives the user back a canonical form + fails fast on
+ *     malformed input. Keep using this for read-only / converter
+ *     commands.
+ *
+ *   - {@link requireBb1AddressStrict} — strict, REJECTS 0x at msg-emit
+ *     boundaries. Every tx that lands on chain ultimately stores the
+ *     creator / payer / verifier / recipient as bb1, and the FE always
+ *     surfaces bb1. Letting users pass 0x at the msg-emit boundary and
+ *     silently converting masks the conversion behind a hint they
+ *     might miss — the strict path throws and points them at the
+ *     `bb account convert` tool so they make the form change a
+ *     conscious step. Set `BB_ADDRESS_AUTO_CONVERT=1` to fall back to
+ *     the lenient behavior for one release while callers migrate.
  */
 
 import { convertToBitBadgesAddress } from '../../address-converter/converter.js';
@@ -43,4 +58,73 @@ export function requireBb1Address(address: string, usage: string): string {
     process.stderr.write(`Normalized ${address} → ${bb1}\n`);
   }
   return bb1;
+}
+
+/**
+ * Strict variant for msg-emit boundaries. Accepts bb1... only and
+ * throws on 0x / bbvaloper / any non-bb1 form with a hint pointing at
+ * `bb account convert`. Per the v2 input-validation polish (#0399 follow-up),
+ * the canonical on-chain form is bb1 and silent auto-conversion at the
+ * msg boundary masks the form change.
+ *
+ * Escape hatch: when `BB_ADDRESS_AUTO_CONVERT=1` is set in the env,
+ * falls back to {@link requireBb1Address} silent auto-convert path. We
+ * ship the strict path on by default and the env-var preserves the
+ * lenient v0.39 behavior for one release while callers migrate.
+ *
+ * @param address  - User-supplied address.
+ * @param flagName - Short flag label (e.g. `--creator`) folded into the
+ *                   error message. Pass without the leading `--` if the
+ *                   value comes from a positional argument.
+ */
+export function requireBb1AddressStrict(address: string, flagName: string): string {
+  // Env-var escape hatch — preserves v0.39 lenient behavior for one
+  // release. Documented in the migration note that ships alongside this
+  // change.
+  if (process.env.BB_ADDRESS_AUTO_CONVERT === '1') {
+    return requireBb1Address(address, flagName);
+  }
+
+  if (!address || typeof address !== 'string' || address.trim().length === 0) {
+    process.stderr.write(`Error: ${flagName} requires a bb1... address (got empty input).\n`);
+    process.exit(1);
+  }
+
+  // bb1 fast-path. The lenient helper would still validate the bech32
+  // shape via the converter; do the same here so a malformed `bb1xxx`
+  // doesn't sneak through.
+  if (address.startsWith('bb1')) {
+    const round = convertToBitBadgesAddress(address);
+    if (!round) {
+      process.stderr.write(
+        `Error: invalid bb1 address "${address}" for ${flagName} (failed bech32 decode).\n`
+      );
+      process.exit(1);
+    }
+    return round;
+  }
+
+  // Anything else — 0x..., bbvaloper..., other chain bech32, garbage —
+  // throws. We attempt a convert to figure out which chain form the
+  // input was, purely for the hint text. The throw itself happens
+  // regardless of whether the convert succeeded.
+  const converted = convertToBitBadgesAddress(address);
+  const sourceChain = address.startsWith('0x')
+    ? '0x'
+    : /^[a-z]+1[02-9ac-hj-np-z]+$/i.test(address) && !address.startsWith('bb1')
+    ? address.split('1', 1)[0] // e.g. cosmos / osmo / inj
+    : 'invalid';
+
+  if (converted) {
+    process.stderr.write(
+      `Error: ${flagName} expects a bb1... address, got ${sourceChain} form "${address}". ` +
+        `Run \`bb account convert ${address}\` to canonicalize, ` +
+        `or set BB_ADDRESS_AUTO_CONVERT=1 to keep the lenient v0.39 behavior for one release.\n`
+    );
+  } else {
+    process.stderr.write(
+      `Error: ${flagName} got malformed input "${address}". Expected a bb1... address.\n`
+    );
+  }
+  process.exit(1);
 }

--- a/packages/bitbadgesjs-sdk/src/cli/utils/amount.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/amount.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the shared amount-flex resolver.
+ */
+import { resolveAmount } from './amount.js';
+
+const ctx = { amountFlag: '--amount', denomFlag: '--denom' };
+
+describe('resolveAmount', () => {
+  it('converts a symbol amount to base units via the registry decimals', () => {
+    // BADGE has 9 decimals; 10 BADGE → 10_000_000_000 base units.
+    const out = resolveAmount('10', 'BADGE', false, ctx);
+    expect(out.denom).toBe('ubadge');
+    expect(out.amount).toBe('10000000000');
+  });
+
+  it('passes a base-denom (ubadge) amount through verbatim', () => {
+    const out = resolveAmount('100000000', 'ubadge', false, ctx);
+    expect(out.denom).toBe('ubadge');
+    expect(out.amount).toBe('100000000');
+  });
+
+  it('honors --base-units with a symbol denom (no decimal multiply)', () => {
+    // 100000000 ubadge worth, expressed as base units with --base-units.
+    const out = resolveAmount('100000000', 'BADGE', true, ctx);
+    expect(out.denom).toBe('ubadge');
+    expect(out.amount).toBe('100000000');
+  });
+
+  it('handles decimal-string symbol amounts (1.5 USDC → 1500000)', () => {
+    // USDC has 6 decimals; 1.5 USDC → 1_500_000 base units.
+    const out = resolveAmount('1.5', 'USDC', false, ctx);
+    expect(out.amount).toBe('1500000');
+  });
+
+  it('strips underscores and commas from amount input', () => {
+    const out = resolveAmount('1_000_000_000', 'ubadge', false, ctx);
+    expect(out.amount).toBe('1000000000');
+
+    const out2 = resolveAmount('1,000,000,000', 'ubadge', false, ctx);
+    expect(out2.amount).toBe('1000000000');
+  });
+
+  it('rejects negative amounts', () => {
+    expect(() => resolveAmount('-10', 'BADGE', false, ctx)).toThrow();
+  });
+
+  it('rejects non-integer amount when denom is a chain denom', () => {
+    expect(() => resolveAmount('1.5', 'ubadge', false, ctx)).toThrow(/non-negative integer/);
+  });
+
+  it('rejects non-integer amount when --base-units is set', () => {
+    expect(() => resolveAmount('1.5', 'BADGE', true, ctx)).toThrow(/non-negative integer/);
+  });
+
+  it('rejects an ibc/... amount that is non-integer', () => {
+    const fake = 'ibc/' + 'A'.repeat(64);
+    expect(() => resolveAmount('1.5', fake, false, ctx)).toThrow(/non-negative integer/);
+  });
+
+  it('REJECTS uusdc via requireBbDenom even on the amount path', () => {
+    expect(() => resolveAmount('10', 'uusdc', false, ctx)).toThrow(/not a valid BitBadges denom/);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/utils/amount.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/amount.ts
@@ -1,0 +1,100 @@
+/**
+ * Amount-flex helpers for CLI commands.
+ *
+ * Every msg-emit command that takes a `--amount / --price / --pay-amount /
+ * --receive-amount / --token-amount / --payment-amount` flag PAIRED with
+ * a `--denom` flag now accepts BOTH display-units (`10 BADGE` → auto-
+ * converted via the registry's decimals) AND base-units (`10000000
+ * ubadge`, with --base-units forcing base-units interpretation even for
+ * symbols).
+ *
+ * Auto-rule:
+ *   - registered symbol (BADGE, USDC, …) → display units; multiply by
+ *     10^decimals via toBaseUnits()
+ *   - canonical baseDenom (ubadge, ibc/<SHA>, factory/*, badges:*,
+ *     badgeslp:*) → base units; pass through verbatim
+ *   - --base-units flag → base-units interpretation regardless of denom
+ *     form
+ *
+ * Returns a `{ denom, amount }` pair ready to drop into msg construction.
+ * `denom` is always the canonical baseDenom; `amount` is always base
+ * units as a decimal string.
+ */
+import { resolveCoin, toBaseUnits } from '../../core/builders/shared.js';
+import { MAINNET_COINS_REGISTRY } from '../../common/constants.js';
+import { requireBbDenom } from './denom.js';
+
+export interface ResolvedAmount {
+  /** Canonical baseDenom (`ubadge`, `ibc/...`, etc.) */
+  denom: string;
+  /** Amount in base units, as a decimal string */
+  amount: string;
+}
+
+/**
+ * Resolve an `(amount, denom, baseUnits?)` triple into a canonical
+ * `{ denom, amount }` pair. See module docstring for the auto-rule.
+ *
+ * @throws Error with a CLI-friendly message on invalid input. Caller
+ *   should let it bubble through emitError / the top-level try/catch.
+ */
+export function resolveAmount(
+  rawAmount: string,
+  rawDenom: string,
+  baseUnits: boolean,
+  ctx: { amountFlag: string; denomFlag: string }
+): ResolvedAmount {
+  // Validate the denom first — same throw + hint behavior as everywhere
+  // else. `validated` is always the canonical baseDenom.
+  const validated = requireBbDenom(rawDenom, ctx.denomFlag);
+
+  // Strip underscores / commas commonly used as thousands separators
+  // in CLI input (`1_000_000`, `1,000,000`).
+  const cleaned = String(rawAmount).replace(/[_,]/g, '');
+
+  // Detect whether the user passed a symbol or a canonical baseDenom.
+  // The auto-rule: registered symbol → display units, canonical
+  // baseDenom → base units. We re-resolve via resolveCoin to get the
+  // decimals when display units are needed.
+  const trimmed = rawDenom.trim();
+  const isDirectBaseDenom =
+    !!MAINNET_COINS_REGISTRY[trimmed] || // ubadge, ibc/... already in registry
+    trimmed.startsWith('ibc/') ||
+    trimmed.startsWith('factory/') ||
+    trimmed.startsWith('badges:') ||
+    trimmed.startsWith('badgeslp:');
+
+  // --base-units flag wins. If set, the amount is already base units;
+  // we just validate the integer shape and pass through.
+  if (baseUnits) {
+    if (!/^\d+$/.test(cleaned)) {
+      throw new Error(
+        `${ctx.amountFlag} must be a non-negative integer when --base-units is set, got "${rawAmount}".`
+      );
+    }
+    return { denom: validated, amount: cleaned };
+  }
+
+  if (isDirectBaseDenom) {
+    // Canonical baseDenom + no --base-units → still base units (the
+    // user passed a chain denom so they're already speaking chain
+    // language). Same integer-shape requirement as --base-units.
+    if (!/^\d+$/.test(cleaned)) {
+      throw new Error(
+        `${ctx.amountFlag} must be a non-negative integer when ${ctx.denomFlag} is a chain denom (got "${rawAmount}"). Use --base-units to be explicit, or pass a symbol like BADGE / USDC to use display units.`
+      );
+    }
+    return { denom: validated, amount: cleaned };
+  }
+
+  // Symbol input → display units. resolveCoin gives us decimals; we
+  // accept decimal input (e.g. "1.5") and round to base units.
+  const resolved = resolveCoin(validated);
+  const num = Number(cleaned);
+  if (!Number.isFinite(num) || num < 0) {
+    throw new Error(
+      `${ctx.amountFlag} must be a non-negative number (got "${rawAmount}").`
+    );
+  }
+  return { denom: resolved.denom, amount: toBaseUnits(num, resolved.decimals) };
+}

--- a/packages/bitbadgesjs-sdk/src/cli/utils/api-client.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/api-client.ts
@@ -11,6 +11,7 @@ import {
   refreshSessionExpiry,
 } from './auth-store.js';
 import { getConfigApiKey, getConfigBaseUrl } from './config.js';
+import { bbError, BBErrorCode } from './envelope.js';
 
 export interface ApiRequestOptions {
   method: string;
@@ -85,7 +86,8 @@ export function resolveApiKey(explicit?: string, network?: 'mainnet' | 'testnet'
   const configKey = getConfigApiKey(network);
   if (configKey) return configKey;
 
-  throw new Error(
+  throw bbError(
+    BBErrorCode.MISSING_API_KEY,
     'No API key. Pass --api-key, run `bb settings set apiKey <key>`, or see `bb settings --help` for env-var alternatives.'
   );
 }

--- a/packages/bitbadgesjs-sdk/src/cli/utils/api-client.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/api-client.ts
@@ -86,7 +86,7 @@ export function resolveApiKey(explicit?: string, network?: 'mainnet' | 'testnet'
   if (configKey) return configKey;
 
   throw new Error(
-    'No API key provided. Set BITBADGES_API_KEY env var, pass --api-key <key>, or run `bitbadges-cli config set apiKey <key>`.'
+    'No API key. Pass --api-key, run `bb settings set apiKey <key>`, or see `bb settings --help` for env-var alternatives.'
   );
 }
 
@@ -173,8 +173,8 @@ export async function apiRequest(options: ApiRequestOptions): Promise<any> {
     // scoped wrong; re-login is the right next step either way.
     if (response.status === 401 || response.status === 403) {
       (err as any).hint = cookie
-        ? 'Session may be expired or scoped wrong — run `bitbadges-cli auth login` again.'
-        : 'This route requires user-scoped auth — run `bitbadges-cli auth login`, then retry with `--with-session`.';
+        ? 'Session may be expired or scoped wrong — run `bb auth login` again.'
+        : 'This route requires user-scoped auth — run `bb auth login`, then retry with `--with-session`.';
     }
     if (response.status === 404 && /\/collection\//.test(path)) {
       // /collection/:id 404 is the most common indexer-lag symptom: a tx

--- a/packages/bitbadgesjs-sdk/src/cli/utils/auth-store.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/auth-store.ts
@@ -181,7 +181,7 @@ export function setActive(network: Network, address: string): void {
   const store = loadAuthStore();
   const n = ensureNetwork(store, network);
   if (!n.sessions[address]) {
-    throw new Error(`No session stored for ${address} on ${network}; run \`bitbadges-cli auth login\` first.`);
+    throw new Error(`No session stored for ${address} on ${network}; run \`bb auth login\` first.`);
   }
   n.active = address;
   saveAuthStore(store);

--- a/packages/bitbadgesjs-sdk/src/cli/utils/auth-store.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/auth-store.ts
@@ -12,6 +12,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { bbError, BBErrorCode } from './envelope.js';
 
 export type Network = 'mainnet' | 'testnet' | 'local';
 
@@ -181,7 +182,10 @@ export function setActive(network: Network, address: string): void {
   const store = loadAuthStore();
   const n = ensureNetwork(store, network);
   if (!n.sessions[address]) {
-    throw new Error(`No session stored for ${address} on ${network}; run \`bb auth login\` first.`);
+    throw bbError(
+      BBErrorCode.NOT_AUTHENTICATED,
+      `No session stored for ${address} on ${network}; run \`bb auth login\` first.`
+    );
   }
   n.active = address;
   saveAuthStore(store);

--- a/packages/bitbadgesjs-sdk/src/cli/utils/build-alias.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/build-alias.ts
@@ -1,0 +1,52 @@
+/**
+ * Per-standard `build` alias factory.
+ *
+ * History: v2 of the CLI (commit 7 of #233) removed the per-standard
+ * `<standard> build` subcommand in favor of a single canonical
+ * `bb build <type>` family. That gave one obvious place to look but
+ * forced users coming from v1 muscle memory (or from the in-app FE)
+ * to context-switch when they wanted to build a vault while reading
+ * `bb smart-tokens --help`. This factory restores the per-standard
+ * alias as a thin delegate — invoking it forwards every arg to the
+ * canonical `bb build <subtype>` command.
+ *
+ * Usage: `parent.addCommand(makeBuildAlias('auction', buildCommand))`.
+ *
+ * Caveats:
+ * - `--help` flow is forwarded manually (Commander would otherwise
+ *   render help for the alias, which carries no flags of its own).
+ * - Errors thrown by the canonical builder are caught and re-emitted
+ *   on stderr with exit 1 so the alias surface stays uniform.
+ */
+
+import { Command } from 'commander';
+
+export function makeBuildAlias(buildSubtype: string, buildCommand: Command): Command {
+  const alias = new Command('build')
+    .description(
+      `Alias for \`bb build ${buildSubtype}\` — same flags, same output. Provided so muscle memory from in-app builders and v1 surveys keeps working.`
+    )
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
+    .helpOption(false)
+    .action(async (_opts, cmd) => {
+      const sub = buildCommand.commands.find((c) => c.name() === buildSubtype);
+      if (!sub) {
+        process.stderr.write(`Internal error: \`bb build ${buildSubtype}\` subcommand not registered.\n`);
+        process.exit(1);
+      }
+      // Forward --help to the canonical builder so users see real flags,
+      // not the alias's empty help block.
+      if (cmd.args.includes('-h') || cmd.args.includes('--help')) {
+        sub.help();
+        return;
+      }
+      try {
+        await sub.parseAsync(cmd.args, { from: 'user' });
+      } catch (err: any) {
+        process.stderr.write(`Error: ${err?.message ?? err}\n`);
+        process.exit(1);
+      }
+    });
+  return alias;
+}

--- a/packages/bitbadgesjs-sdk/src/cli/utils/burner.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/burner.ts
@@ -30,6 +30,7 @@ import {
   TYPE_URL_CREATE,
   TYPE_URL_UNIVERSAL
 } from './normalizeMsg.js';
+import { DEFAULT_FEE_DENOM } from './denom.js';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -176,7 +177,7 @@ export async function loadBurnerAdapter(record: BurnerWalletRecord): Promise<Gen
  * BitBadgesSigningClient because this is a read path that doesn't need a
  * signer bound to the balance's address.
  */
-export async function fetchBalance(nodeUrl: string, address: string, denom = 'ubadge'): Promise<bigint> {
+export async function fetchBalance(nodeUrl: string, address: string, denom: string = DEFAULT_FEE_DENOM): Promise<bigint> {
   const axios = (await import('axios')).default;
   try {
     const res = await axios.get(`${nodeUrl}/cosmos/bank/v1beta1/balances/${address}/by_denom`, {
@@ -469,7 +470,7 @@ export async function runBurnerCreate(
 
   const fee = {
     amount: opts.fee?.amount ?? '0',
-    denom: opts.fee?.denom ?? 'ubadge',
+    denom: opts.fee?.denom ?? DEFAULT_FEE_DENOM,
     gas: String(opts.gas ?? DEFAULT_GAS)
   };
 

--- a/packages/bitbadgesjs-sdk/src/cli/utils/config.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/config.ts
@@ -9,6 +9,10 @@ export interface Config {
   apiKeyLocal?: string;
   network?: 'mainnet' | 'testnet' | 'local';
   url?: string;
+  /** ms-since-epoch when the user first ran any `bb` command and saw the
+   *  policies / tab-completion banner. Used to suppress the banner on
+   *  subsequent invocations. See `maybePrintFirstRunBanner()`. */
+  firstRunAcknowledgedAt?: number;
 }
 
 // Resolved lazily — tests override via BITBADGES_CONFIG_DIR so they don't

--- a/packages/bitbadgesjs-sdk/src/cli/utils/denom.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/denom.spec.ts
@@ -36,6 +36,10 @@ describe('requireBbDenom', () => {
     expect(requireBbDenom('badges:49:chaosnet', 'place-bid')).toBe('badges:49:chaosnet');
   });
 
+  it('accepts badgeslp:* denoms (LP/prediction market deposit aliases)', () => {
+    expect(requireBbDenom('badgeslp:99:utoken', '--denom')).toBe('badgeslp:99:utoken');
+  });
+
   it('REJECTS uusdc with a clear hint', () => {
     expect(() => requireBbDenom('uusdc', 'place-bid')).toThrow(/not a valid BitBadges denom/);
     expect(() => requireBbDenom('uusdc', 'place-bid')).toThrow(/ibc/);

--- a/packages/bitbadgesjs-sdk/src/cli/utils/denom.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/denom.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the CLI denom validators.
+ *
+ * Two parallel validators — strict BitBadges-side and permissive Skip:Go
+ * cross-chain. The strict one is the one that prevents the most common
+ * user error: passing Noble's `uusdc` to a BitBadges auction bid.
+ */
+import { requireBbDenom, requireSkipGoDenom } from './denom.js';
+
+describe('requireBbDenom', () => {
+  it('accepts the BADGE symbol and returns ubadge', () => {
+    expect(requireBbDenom('BADGE', 'place-bid')).toBe('ubadge');
+    expect(requireBbDenom('badge', 'place-bid')).toBe('ubadge'); // case-insensitive
+  });
+
+  it('accepts the literal ubadge denom', () => {
+    expect(requireBbDenom('ubadge', 'place-bid')).toBe('ubadge');
+  });
+
+  it('resolves USDC symbol to its ibc/... canonical form', () => {
+    const out = requireBbDenom('USDC', 'place-bid');
+    expect(out.startsWith('ibc/')).toBe(true);
+    expect(out.length).toBe(4 + 64); // ibc/ + 64 hex chars
+  });
+
+  it('accepts an arbitrary ibc/<64-hex> form not in the registry', () => {
+    const fake = 'ibc/' + 'A'.repeat(64);
+    expect(requireBbDenom(fake, 'place-bid')).toBe(fake);
+  });
+
+  it('accepts a factory/... denom', () => {
+    expect(requireBbDenom('factory/bb1abc/myunit', 'place-bid')).toBe('factory/bb1abc/myunit');
+  });
+
+  it('accepts badges:* denoms', () => {
+    expect(requireBbDenom('badges:49:chaosnet', 'place-bid')).toBe('badges:49:chaosnet');
+  });
+
+  it('REJECTS uusdc with a clear hint', () => {
+    expect(() => requireBbDenom('uusdc', 'place-bid')).toThrow(/not a valid BitBadges denom/);
+    expect(() => requireBbDenom('uusdc', 'place-bid')).toThrow(/ibc/);
+  });
+
+  it('REJECTS uatom and uosmo similarly', () => {
+    expect(() => requireBbDenom('uatom', 'place-bid')).toThrow(/not a valid BitBadges denom/);
+    expect(() => requireBbDenom('uosmo', 'place-bid')).toThrow(/not a valid BitBadges denom/);
+  });
+
+  it('rejects empty and whitespace input', () => {
+    expect(() => requireBbDenom('', 'place-bid')).toThrow(/Missing denom/);
+    expect(() => requireBbDenom('   ', 'place-bid')).toThrow(/Missing denom/);
+  });
+
+  it('rejects unknown symbols with the registry list', () => {
+    expect(() => requireBbDenom('XYZ', 'place-bid')).toThrow(/Unknown denom/);
+    expect(() => requireBbDenom('XYZ', 'place-bid')).toThrow(/Supported symbols/);
+  });
+
+  it('rejects malformed ibc/ forms', () => {
+    expect(() => requireBbDenom('ibc/short', 'place-bid')).toThrow();
+    expect(() => requireBbDenom('ibc/' + 'Z'.repeat(64), 'place-bid')).toThrow(); // non-hex
+  });
+
+  it('includes the context label in error messages', () => {
+    try {
+      requireBbDenom('uusdc', '--denom for auction place-bid');
+    } catch (e: any) {
+      expect(e.message).toContain('--denom for auction place-bid');
+    }
+  });
+});
+
+describe('requireSkipGoDenom', () => {
+  it('accepts uusdc (Noble origin denom)', () => {
+    expect(requireSkipGoDenom('uusdc', 'swap')).toBe('uusdc');
+  });
+
+  it('accepts uatom (Hub origin denom)', () => {
+    expect(requireSkipGoDenom('uatom', 'swap')).toBe('uatom');
+  });
+
+  it('accepts ubadge (BitBadges-side denom)', () => {
+    expect(requireSkipGoDenom('ubadge', 'swap')).toBe('ubadge');
+  });
+
+  it('accepts ibc/... cross-chain denoms', () => {
+    const ibc = 'ibc/' + 'A'.repeat(64);
+    expect(requireSkipGoDenom(ibc, 'swap')).toBe(ibc);
+  });
+
+  it('rejects empty input', () => {
+    expect(() => requireSkipGoDenom('', 'swap')).toThrow(/Missing denom/);
+  });
+
+  it('rejects denoms with leading/trailing whitespace', () => {
+    expect(() => requireSkipGoDenom(' uusdc', 'swap')).toThrow(/whitespace/);
+    expect(() => requireSkipGoDenom('uusdc ', 'swap')).toThrow(/whitespace/);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/utils/denom.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/denom.ts
@@ -24,6 +24,13 @@
 import { resolveCoin } from '../../core/builders/shared.js';
 import { MAINNET_COINS_REGISTRY } from '../../common/constants.js';
 
+/**
+ * The canonical default fee denom for BitBadges-side transactions. `ubadge`
+ * is the only u-prefix denom valid on BitBadges (everything else lives as
+ * `ibc/<SHA>`). Centralized here so CLI verbs don't drift on the default.
+ */
+export const DEFAULT_FEE_DENOM = 'ubadge';
+
 const IBC_DENOM_RE = /^ibc\/[A-F0-9]{64}$/i;
 const FACTORY_DENOM_RE = /^factory\/[a-zA-Z0-9_:./-]+$/;
 const BADGES_DENOM_RE = /^badges:[a-zA-Z0-9_:.-]+$/;

--- a/packages/bitbadgesjs-sdk/src/cli/utils/denom.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/denom.ts
@@ -27,6 +27,7 @@ import { MAINNET_COINS_REGISTRY } from '../../common/constants.js';
 const IBC_DENOM_RE = /^ibc\/[A-F0-9]{64}$/i;
 const FACTORY_DENOM_RE = /^factory\/[a-zA-Z0-9_:./-]+$/;
 const BADGES_DENOM_RE = /^badges:[a-zA-Z0-9_:.-]+$/;
+const BADGESLP_DENOM_RE = /^badgeslp:[a-zA-Z0-9_:.-]+$/;
 const U_PREFIX_RE = /^u[a-z][a-z0-9]*$/;
 
 /**
@@ -37,6 +38,7 @@ const U_PREFIX_RE = /^u[a-z][a-z0-9]*$/;
  *   - the literal `ubadge`
  *   - `ibc/<64 hex chars>` IBC denoms
  *   - `badges:*` collection-token denoms
+ *   - `badgeslp:*` LP-token aliases (prediction market deposit denoms)
  *   - `factory/*` token-factory denoms
  *
  * REJECTS `u*`-prefix denoms other than `ubadge` (so `uusdc`, `uatom`,
@@ -72,6 +74,7 @@ export function requireBbDenom(input: string, ctx: string): string {
   if (IBC_DENOM_RE.test(trimmed)) return trimmed;
   if (FACTORY_DENOM_RE.test(trimmed)) return trimmed;
   if (BADGES_DENOM_RE.test(trimmed)) return trimmed;
+  if (BADGESLP_DENOM_RE.test(trimmed)) return trimmed;
 
   // The `u*` trap: anything starting with `u` followed by lowercase that
   // isn't `ubadge` is almost certainly an origin-chain native denom that

--- a/packages/bitbadgesjs-sdk/src/cli/utils/denom.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/denom.ts
@@ -23,6 +23,7 @@
  */
 import { resolveCoin } from '../../core/builders/shared.js';
 import { MAINNET_COINS_REGISTRY } from '../../common/constants.js';
+import { bbError, BBErrorCode } from './envelope.js';
 
 /**
  * The canonical default fee denom for BitBadges-side transactions. `ubadge`
@@ -58,7 +59,10 @@ const U_PREFIX_RE = /^u[a-z][a-z0-9]*$/;
  */
 export function requireBbDenom(input: string, ctx: string): string {
   if (!input || typeof input !== 'string' || input.trim().length === 0) {
-    throw new Error(`Missing denom for ${ctx}. Pass a symbol (BADGE, USDC, ATOM, …) or canonical denom (ubadge, ibc/...).`);
+    throw bbError(
+      BBErrorCode.UNKNOWN_TOKEN,
+      `Missing denom for ${ctx}. Pass a symbol (BADGE, USDC, ATOM, …) or canonical denom (ubadge, ibc/...).`
+    );
   }
   const trimmed = input.trim();
 
@@ -87,7 +91,8 @@ export function requireBbDenom(input: string, ctx: string): string {
   // isn't `ubadge` is almost certainly an origin-chain native denom that
   // a user mistakenly thinks works on BitBadges.
   if (U_PREFIX_RE.test(trimmed) && trimmed !== 'ubadge') {
-    throw new Error(
+    throw bbError(
+      BBErrorCode.UNKNOWN_TOKEN,
       `"${trimmed}" is not a valid BitBadges denom for ${ctx}. On BitBadges, only "ubadge" uses the u-prefix; other tokens (USDC, ATOM, …) are "ibc/<SHA>" IBC denoms. Try the display symbol (e.g. "USDC") or run \`bb assets show <symbol>\` to see the canonical form.`
     );
   }
@@ -98,7 +103,8 @@ export function requireBbDenom(input: string, ctx: string): string {
     .map((c) => c.symbol)
     .filter((s, i, a) => a.indexOf(s) === i)
     .join(', ');
-  throw new Error(
+  throw bbError(
+    BBErrorCode.UNKNOWN_TOKEN,
     `Unknown denom "${trimmed}" for ${ctx}. Supported symbols: ${supported}. Or pass a canonical denom (ubadge, ibc/<SHA>).`
   );
 }

--- a/packages/bitbadgesjs-sdk/src/cli/utils/denom.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/denom.ts
@@ -1,0 +1,119 @@
+/**
+ * Denom validators for CLI commands.
+ *
+ * Two parallel validators because BitBadges-side msg flows and Skip:Go
+ * cross-chain swap flows have DIFFERENT rules:
+ *
+ *   - {@link requireBbDenom} — strict on BitBadges-side flags. The only
+ *     `u*`-prefix denom valid on BitBadges is `ubadge`. Every other token
+ *     (USDC, ATOM, OSMO, …) lives as `ibc/<SHA>` because they're IBC'd in.
+ *     A user typing `--denom uusdc` for an auction bid is a category error
+ *     — `uusdc` is Noble's native USDC, NOT the form USDC takes on
+ *     BitBadges. We reject with a hint pointing at the canonical form.
+ *
+ *   - {@link requireSkipGoDenom} — permissive on `bb swap *` and any other
+ *     Skip:Go cross-chain command. Those commands accept the ORIGIN chain's
+ *     native denom (`uusdc` for Noble USDC, `uatom` for Hub ATOM, …)
+ *     because the swap is cross-chain by definition. We only check for
+ *     obvious malformations here (empty / whitespace) and let Skip resolve
+ *     the rest.
+ *
+ * Both delegate symbol→canonical-denom resolution to `resolveCoin()` so the
+ * registry stays the single source of truth.
+ */
+import { resolveCoin } from '../../core/builders/shared.js';
+import { MAINNET_COINS_REGISTRY } from '../../common/constants.js';
+
+const IBC_DENOM_RE = /^ibc\/[A-F0-9]{64}$/i;
+const FACTORY_DENOM_RE = /^factory\/[a-zA-Z0-9_:./-]+$/;
+const BADGES_DENOM_RE = /^badges:[a-zA-Z0-9_:.-]+$/;
+const U_PREFIX_RE = /^u[a-z][a-z0-9]*$/;
+
+/**
+ * Validate that `input` is a denom usable on BitBadges and return its
+ * canonical baseDenom form. Accepts:
+ *
+ *   - registered symbols (`BADGE`, `USDC`, `ATOM`, `OSMO`, `CHAOS`, …)
+ *   - the literal `ubadge`
+ *   - `ibc/<64 hex chars>` IBC denoms
+ *   - `badges:*` collection-token denoms
+ *   - `factory/*` token-factory denoms
+ *
+ * REJECTS `u*`-prefix denoms other than `ubadge` (so `uusdc`, `uatom`,
+ * `uosmo`, etc. throw with a hint to use the symbol or the canonical
+ * `ibc/...` form). The throw is loud on purpose — passing `uusdc` to a
+ * BitBadges-side msg flow yields a tx the chain will never recognize.
+ *
+ * @throws Error with a CLI-friendly message — the caller should let it
+ *   bubble to `emitError()` / the top-level try/catch.
+ */
+export function requireBbDenom(input: string, ctx: string): string {
+  if (!input || typeof input !== 'string' || input.trim().length === 0) {
+    throw new Error(`Missing denom for ${ctx}. Pass a symbol (BADGE, USDC, ATOM, …) or canonical denom (ubadge, ibc/...).`);
+  }
+  const trimmed = input.trim();
+
+  // Direct match against registry baseDenoms (catches ubadge, ibc/...
+  // entries, badges:* entries already registered, etc.).
+  if (MAINNET_COINS_REGISTRY[trimmed]) {
+    return MAINNET_COINS_REGISTRY[trimmed].baseDenom;
+  }
+
+  // Symbol lookup (case-insensitive) via resolveCoin — registry is the
+  // source of truth.
+  const upper = trimmed.toUpperCase();
+  for (const details of Object.values(MAINNET_COINS_REGISTRY)) {
+    if (details.symbol.toUpperCase() === upper) {
+      return details.baseDenom;
+    }
+  }
+
+  // Accept canonical forms even if not in the registry yet.
+  if (IBC_DENOM_RE.test(trimmed)) return trimmed;
+  if (FACTORY_DENOM_RE.test(trimmed)) return trimmed;
+  if (BADGES_DENOM_RE.test(trimmed)) return trimmed;
+
+  // The `u*` trap: anything starting with `u` followed by lowercase that
+  // isn't `ubadge` is almost certainly an origin-chain native denom that
+  // a user mistakenly thinks works on BitBadges.
+  if (U_PREFIX_RE.test(trimmed) && trimmed !== 'ubadge') {
+    throw new Error(
+      `"${trimmed}" is not a valid BitBadges denom for ${ctx}. On BitBadges, only "ubadge" uses the u-prefix; other tokens (USDC, ATOM, …) are "ibc/<SHA>" IBC denoms. Try the display symbol (e.g. "USDC") or run \`bb assets show <symbol>\` to see the canonical form.`
+    );
+  }
+
+  // Anything else — unknown symbol, malformed denom, etc. — throw with
+  // the registry-supported list. Mirrors resolveCoin's error shape.
+  const supported = Object.values(MAINNET_COINS_REGISTRY)
+    .map((c) => c.symbol)
+    .filter((s, i, a) => a.indexOf(s) === i)
+    .join(', ');
+  throw new Error(
+    `Unknown denom "${trimmed}" for ${ctx}. Supported symbols: ${supported}. Or pass a canonical denom (ubadge, ibc/<SHA>).`
+  );
+}
+
+/**
+ * Permissive validator for Skip:Go cross-chain swap denoms. The swap
+ * surface accepts ORIGIN chain denoms (Noble's `uusdc`, Cosmos Hub's
+ * `uatom`, Osmosis's `uosmo`, …) because the swap is by definition
+ * cross-chain. We only catch obvious malformations here — empty input,
+ * leading/trailing whitespace — and defer the rest to Skip's resolver,
+ * which knows about every chain's denom space.
+ *
+ * Use this on `bb swap *` and any other cross-chain command. Do NOT use
+ * on BitBadges-side msg flows — use {@link requireBbDenom} there.
+ */
+export function requireSkipGoDenom(input: string, ctx: string): string {
+  if (!input || typeof input !== 'string' || input.trim().length === 0) {
+    throw new Error(`Missing denom for ${ctx}.`);
+  }
+  const trimmed = input.trim();
+  if (trimmed !== input) {
+    throw new Error(`Denom "${input}" for ${ctx} has leading/trailing whitespace.`);
+  }
+  // Anything else — a u-prefix native denom, an ibc/... hash, a factory
+  // path, etc. — is the caller's responsibility. Skip's resolver will
+  // reject anything truly bogus.
+  return trimmed;
+}

--- a/packages/bitbadgesjs-sdk/src/cli/utils/envelope.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/envelope.spec.ts
@@ -11,7 +11,9 @@ import {
   successEnvelope,
   errorEnvelope,
   isQuiet,
-  writeJsonEnvelope
+  writeJsonEnvelope,
+  bbError,
+  BBErrorCode
 } from './envelope.js';
 import { Writable } from 'node:stream';
 
@@ -61,6 +63,39 @@ describe('errorEnvelope', () => {
   it('attaches hint when provided', () => {
     const e = errorEnvelope('X', 'msg', undefined, 'try this');
     expect(e.hint).toBe('try this');
+  });
+});
+
+describe('bbError', () => {
+  it('produces an Error carrying .code and .message', () => {
+    const err = bbError(BBErrorCode.UNKNOWN_TOKEN, 'bad denom');
+    expect(err).toBeInstanceOf(Error);
+    expect((err as any).code).toBe('unknown_token');
+    expect(err.message).toBe('bad denom');
+  });
+
+  it('accepts a hint and attaches as .hint', () => {
+    const err = bbError(BBErrorCode.MISSING_API_KEY, 'no key', 'pass --api-key');
+    expect((err as any).hint).toBe('pass --api-key');
+  });
+
+  it('accepts plain string codes (escape hatch for bespoke domains)', () => {
+    const err = bbError('burner_not_found', 'no burner');
+    expect((err as any).code).toBe('burner_not_found');
+  });
+});
+
+describe('BBErrorCode', () => {
+  it('exports the canonical taxonomy', () => {
+    expect(BBErrorCode.CLI_ERROR).toBe('cli_error');
+    expect(BBErrorCode.UNKNOWN_TOKEN).toBe('unknown_token');
+    expect(BBErrorCode.MISSING_API_KEY).toBe('missing_api_key');
+    expect(BBErrorCode.NOT_AUTHENTICATED).toBe('not_authenticated');
+    expect(BBErrorCode.INVALID_ADDRESS).toBe('invalid_address');
+    expect(BBErrorCode.INVALID_INPUT).toBe('invalid_input');
+    expect(BBErrorCode.NETWORK_ERROR).toBe('network_error');
+    expect(BBErrorCode.TX_VALIDATION_FAILED).toBe('tx_validation_failed');
+    expect(BBErrorCode.BROADCAST_FAILED).toBe('broadcast_failed');
   });
 });
 

--- a/packages/bitbadgesjs-sdk/src/cli/utils/envelope.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/envelope.ts
@@ -36,6 +36,58 @@ export interface EnvelopeError {
   details?: unknown;
 }
 
+/**
+ * Canonical error-code taxonomy for envelope.error.code.
+ *
+ * Most CLI commands previously emitted bespoke string codes
+ * (`cli_error`, `burner_not_found`, `invalid_input`, etc). Enumerating
+ * the common cross-cutting ones here keeps agents able to branch on a
+ * stable set without reverse-engineering each verb's codes.
+ *
+ * Conventions:
+ *   - Bespoke domain codes (e.g. `burner_not_found`, `sign_rejected`)
+ *     can still be passed as plain strings to `emitError({ code })`.
+ *   - When a code clearly maps to one of these buckets, prefer the
+ *     enum value so agents can dispatch on a finite set.
+ *   - The catch-all when no code is passed is {@link BBErrorCode.CLI_ERROR}.
+ */
+export const BBErrorCode = {
+  /** Catch-all. Default when `emitError()` is called without a code. */
+  CLI_ERROR: 'cli_error',
+  /** User passed a flag value that violates input validation. */
+  INVALID_INPUT: 'invalid_input',
+  /** Address rejected by `requireBb1Address[Strict]`. */
+  INVALID_ADDRESS: 'invalid_address',
+  /** Denom rejected by `requireBbDenom` (incl. the u-prefix trap). */
+  UNKNOWN_TOKEN: 'unknown_token',
+  /** Required API key absent (env / flag / config all empty). */
+  MISSING_API_KEY: 'missing_api_key',
+  /** User-scoped auth required but no session is loaded. */
+  NOT_AUTHENTICATED: 'not_authenticated',
+  /** Network call to indexer / chain RPC failed (transport / 5xx). */
+  NETWORK_ERROR: 'network_error',
+  /** Tx pre-flight validation failed (audit / simulate / dry-run). */
+  TX_VALIDATION_FAILED: 'tx_validation_failed',
+  /** Tx broadcast itself failed (chain rejected, gas, sequence). */
+  BROADCAST_FAILED: 'broadcast_failed'
+} as const;
+
+export type BBErrorCodeValue = (typeof BBErrorCode)[keyof typeof BBErrorCode];
+
+/**
+ * Build an `Error` that already carries `.code` so it flows through
+ * `emitError(err)` without the caller having to pass `{ code }`
+ * explicitly. Use this for validators and other deep helpers that
+ * want their thrown errors to surface a specific taxonomy code in
+ * the envelope.
+ */
+export function bbError(code: BBErrorCodeValue | string, message: string, hint?: string): Error {
+  const err = new Error(message) as Error & { code: string; hint?: string };
+  err.code = code;
+  if (hint) err.hint = hint;
+  return err;
+}
+
 export interface Envelope<T = unknown> {
   ok: boolean;
   data: T | null;
@@ -139,7 +191,10 @@ interface ApiErrorShape {
  * a generic `cli_error`. Callers passing a domain code should construct
  * the envelope directly via `errorEnvelope()` and write it themselves.
  */
-export function emitError(err: unknown, opts: EmitOptions & { exitCode?: number; code?: string } = {}): never {
+export function emitError(
+  err: unknown,
+  opts: EmitOptions & { exitCode?: number; code?: string | BBErrorCodeValue } = {}
+): never {
   const e = err as ApiErrorShape;
   const message = (() => {
     if (e?.response !== undefined) {
@@ -152,7 +207,7 @@ export function emitError(err: unknown, opts: EmitOptions & { exitCode?: number;
     }
     return e?.message ?? String(err);
   })();
-  const code = opts.code ?? e?.code ?? 'cli_error';
+  const code = opts.code ?? e?.code ?? BBErrorCode.CLI_ERROR;
   const env = errorEnvelope(code, message, e?.response, e?.hint);
   const text = opts.condensed
     ? JSON.stringify(env, bigIntReplacer)

--- a/packages/bitbadgesjs-sdk/src/cli/utils/first-run.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/first-run.ts
@@ -1,0 +1,44 @@
+/**
+ * First-run banner: prints the policies link + a tab-completion install
+ * tip to stderr the very first time the user runs any `bb` command, then
+ * marks `firstRunAcknowledgedAt` in ~/.bitbadges/config.json so subsequent
+ * invocations stay silent.
+ *
+ * Design notes:
+ * - Stderr only — keeps stdout clean for pipes, agents, scripts.
+ * - Best-effort: a failure to read or write the config file silently
+ *   skips the banner. Never blocks command execution.
+ * - Suppressed when `BB_QUIET=1` so users who don't want noise on
+ *   first run can opt out (also useful for CI / test harnesses).
+ * - Skipped on `--help-json` invocations so the machine-readable JSON
+ *   tree stays uncontaminated.
+ * - The policies footer on every `bb --help` provides ongoing visibility
+ *   independent of this one-time banner — both layers coexist.
+ */
+
+import { loadConfig, saveConfig } from './config.js';
+
+export function maybePrintFirstRunBanner(argv: readonly string[]): void {
+  if (process.env.BB_QUIET === '1') return;
+  if (argv.includes('--help-json')) return;
+  try {
+    const cfg = loadConfig();
+    if (cfg.firstRunAcknowledgedAt) return;
+    process.stderr.write(
+      '\n' +
+      'Welcome to the BitBadges CLI.\n' +
+      'Terms, privacy, and acceptable-use policies: https://bitbadges.io/policies\n' +
+      'By using `bb` you agree to the policies linked above.\n' +
+      '\n' +
+      'Tip — install tab completion for faster discovery:\n' +
+      '  bb completion bash >> ~/.bashrc        # bash\n' +
+      '  bb completion zsh  >> ~/.zshrc         # zsh\n' +
+      '\n' +
+      'This message is shown once. Suppress future banners by setting `BB_QUIET=1`.\n' +
+      '\n'
+    );
+    saveConfig({ ...cfg, firstRunAcknowledgedAt: Date.now() });
+  } catch {
+    // Best-effort — fail silent on missing HOME, locked config file, etc.
+  }
+}

--- a/packages/bitbadgesjs-sdk/src/cli/utils/indexer-options.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/indexer-options.ts
@@ -33,6 +33,7 @@
 import type { Command } from 'commander';
 import { apiRequest, resolveApiKey, resolveBaseUrl } from './api-client.js';
 import { emit, emitError } from './envelope.js';
+import { addUnifiedNetworkOptions } from './network-options.js';
 
 export interface IndexerNetworkFlags {
   testnet?: boolean;
@@ -49,26 +50,17 @@ export interface IndexerOutputFlags {
 export type IndexerFlags = IndexerNetworkFlags & IndexerOutputFlags;
 
 /**
- * Add the four standard network-selection flags every indexer-hitting
- * command should accept: `--testnet`, `--local`, `--url`, `--api-key`.
+ * Add the indexer-side network-selection flags.
  *
- * Note: this is the legacy 4-flag surface. The newer `addNetworkOptions`
- * helper in `./io.ts` adds `--network` / `--mainnet` shorthand on top,
- * but most indexer commands still use the legacy form — switching them
- * to the long-form would mean threading `--network` through
- * `resolveBaseUrl` (which only understands the booleans today). That
- * larger plumbing change is intentionally NOT in this sweep.
+ * @deprecated Use {@link addUnifiedNetworkOptions} from
+ *   `./network-options.js` directly — this is a thin compatibility
+ *   shim that delegates to it. Historically this helper exposed only
+ *   `--testnet` / `--local` / `--url` / `--api-key`; the unified
+ *   surface adds `--network <name>` / `--mainnet` on top so users can
+ *   pass the same flag style to every command.
  */
 export function addIndexerNetworkOptions(cmd: Command): Command {
-  cmd
-    .option('--testnet', 'Use testnet API', false)
-    .option('--local', 'Use local API (localhost:3001)', false)
-    .option('--url <url>', 'Custom API base URL (overrides --testnet/--local/config)')
-    .option('--api-key <key>', 'BitBadges API key (overrides BITBADGES_API_KEY env)');
-  for (const flag of ['--testnet', '--local', '--url', '--api-key']) {
-    (cmd as any)._findOption?.(flag)?.helpGroup('Network');
-  }
-  return cmd;
+  return addUnifiedNetworkOptions(cmd);
 }
 
 /**

--- a/packages/bitbadgesjs-sdk/src/cli/utils/io.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/io.ts
@@ -3,6 +3,7 @@ import type { Command } from 'commander';
 import { getConfigBaseUrl, getConfigApiKey } from './config.js';
 import { assertNetworkAvailable } from '../../signing/types.js';
 import { emit } from './envelope.js';
+import { addUnifiedNetworkOptions } from './network-options.js';
 
 /**
  * Read JSON input from multiple sources:
@@ -137,19 +138,15 @@ export function getApiKeyForNetwork(options: NetworkOptions): string | undefined
 }
 
 /**
- * Add the four network-selection options to a Command in one call.
- * Use this on every CLI command that makes an external API call so the
- * flag surface stays consistent: `--network`, `--testnet`, `--local`,
- * and `--url` all do the same job, with `--url` as the manual override.
+ * Add the burner/deploy-side network-selection options to a Command.
+ *
+ * @deprecated Use {@link addUnifiedNetworkOptions} from
+ *   `./network-options.js` directly — this is a thin compatibility
+ *   shim that delegates to it. Historically this helper omitted
+ *   `--api-key` (burner/deploy fell back to BITBADGES_API_KEY env);
+ *   the unified surface exposes it on every command so the same
+ *   override style works everywhere.
  */
 export function addNetworkOptions(cmd: Command): Command {
-  return cmd
-    .option(
-      '--network <name>',
-      'Network: mainnet | testnet | local. Picks the matching API base URL and config apiKey.'
-    )
-    .option('--mainnet', 'Shortcut for --network mainnet')
-    .option('--testnet', 'Shortcut for --network testnet')
-    .option('--local', 'Shortcut for --network local (http://localhost:3001)')
-    .option('--url <url>', 'Custom API base URL (overrides --network)');
+  return addUnifiedNetworkOptions(cmd);
 }

--- a/packages/bitbadgesjs-sdk/src/cli/utils/network-options.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/network-options.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'bun:test';
 import { Command } from 'commander';
 import { addUnifiedNetworkOptions } from './network-options.js';
 import { addIndexerNetworkOptions } from './indexer-options.js';

--- a/packages/bitbadgesjs-sdk/src/cli/utils/network-options.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/network-options.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'bun:test';
+import { Command } from 'commander';
+import { addUnifiedNetworkOptions } from './network-options.js';
+import { addIndexerNetworkOptions } from './indexer-options.js';
+import { addNetworkOptions } from './io.js';
+
+function flagNames(cmd: Command): string[] {
+  return cmd.options.map((o) => o.long ?? o.short ?? '');
+}
+
+describe('addUnifiedNetworkOptions', () => {
+  it('exposes the full union surface by default', () => {
+    const cmd = new Command();
+    addUnifiedNetworkOptions(cmd);
+    const flags = flagNames(cmd);
+    expect(flags).toContain('--network');
+    expect(flags).toContain('--mainnet');
+    expect(flags).toContain('--testnet');
+    expect(flags).toContain('--local');
+    expect(flags).toContain('--url');
+    expect(flags).toContain('--api-key');
+  });
+
+  it('omits --api-key when includeApiKey: false', () => {
+    const cmd = new Command();
+    addUnifiedNetworkOptions(cmd, { includeApiKey: false });
+    const flags = flagNames(cmd);
+    expect(flags).toContain('--testnet');
+    expect(flags).not.toContain('--api-key');
+  });
+
+  it('omits --network long form when includeNetworkFlag: false', () => {
+    const cmd = new Command();
+    addUnifiedNetworkOptions(cmd, { includeNetworkFlag: false });
+    const flags = flagNames(cmd);
+    expect(flags).toContain('--testnet');
+    expect(flags).not.toContain('--network');
+  });
+
+  it('returns the same Command for chaining', () => {
+    const cmd = new Command();
+    const ret = addUnifiedNetworkOptions(cmd);
+    expect(ret).toBe(cmd);
+  });
+});
+
+describe('legacy aliases delegate to unified helper', () => {
+  it('addIndexerNetworkOptions exposes the full surface', () => {
+    const cmd = new Command();
+    addIndexerNetworkOptions(cmd);
+    const flags = flagNames(cmd);
+    // Old surface (still there)
+    expect(flags).toContain('--testnet');
+    expect(flags).toContain('--local');
+    expect(flags).toContain('--url');
+    expect(flags).toContain('--api-key');
+    // New surface (now added by the alias)
+    expect(flags).toContain('--network');
+    expect(flags).toContain('--mainnet');
+  });
+
+  it('addNetworkOptions (io.ts) now exposes --api-key too', () => {
+    const cmd = new Command();
+    addNetworkOptions(cmd);
+    const flags = flagNames(cmd);
+    // Old surface (still there)
+    expect(flags).toContain('--network');
+    expect(flags).toContain('--mainnet');
+    expect(flags).toContain('--testnet');
+    expect(flags).toContain('--local');
+    expect(flags).toContain('--url');
+    // New surface (now added by the alias)
+    expect(flags).toContain('--api-key');
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/utils/network-options.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/network-options.ts
@@ -1,0 +1,115 @@
+/**
+ * Unified network-flag surface for every CLI command that touches an
+ * external service (indexer, chain RPC, or both).
+ *
+ * History: before this module existed there were TWO parallel helpers:
+ *
+ *   - `addIndexerNetworkOptions` in `./indexer-options.ts` (used by
+ *     ~28 commands) — emitted `--testnet`, `--local`, `--url`,
+ *     `--api-key` and grouped them under `helpGroup('Network')`.
+ *
+ *   - `addNetworkOptions` in `./io.ts` (used by ~6 commands: `auth`,
+ *     `burner`, `deploy`, `tx`, `simulate`, `preview`) — emitted
+ *     `--network`, `--mainnet`, `--testnet`, `--local`, `--url`. No
+ *     `--api-key` and no help-group styling.
+ *
+ * They drifted: indexer commands didn't accept `--network mainnet`,
+ * while the burner/deploy side didn't accept `--api-key` (instead
+ * relying on the BITBADGES_API_KEY env var). Users hit footguns when
+ * they piped `bb api ... --network local` into `bb deploy --network
+ * local` and one of the two flags errored.
+ *
+ * This module exports a single helper that unions BOTH surfaces:
+ *   --network <mainnet|testnet|local>   — canonical, long-form
+ *   --mainnet                            — equivalent to --network mainnet
+ *   --testnet                            — equivalent to --network testnet
+ *   --local                              — equivalent to --network local
+ *   --url <url>                          — manual base-URL override
+ *   --api-key <key>                      — manual API-key override
+ *
+ * The old helpers still exist as `@deprecated` aliases that delegate
+ * here, so the 34 existing call sites keep working during the
+ * transition. Migration to the unified helper happens incrementally
+ * (out-of-scope verbs can stay on the alias).
+ */
+import type { Command } from 'commander';
+
+export interface UnifiedNetworkFlags {
+  /** Canonical network selector — `mainnet` | `testnet` | `local`. */
+  network?: 'mainnet' | 'testnet' | 'local';
+  /** Boolean shortcut. Equivalent to `--network mainnet`. */
+  mainnet?: boolean;
+  /** Boolean shortcut. Equivalent to `--network testnet`. */
+  testnet?: boolean;
+  /** Boolean shortcut. Equivalent to `--network local`. */
+  local?: boolean;
+  /** Custom API base URL override. Wins over every other selector. */
+  url?: string;
+  /** API key override. Wins over `BITBADGES_API_KEY` env var. */
+  apiKey?: string;
+}
+
+/**
+ * Options for {@link addUnifiedNetworkOptions} — control which subset
+ * of the union surface a given command actually exposes.
+ *
+ * Defaults to the full surface. Pass `{ includeApiKey: false }` for
+ * commands that genuinely don't talk to the indexer (e.g. chain-RPC-only
+ * verbs like `bb tx <hash>`), so the `--api-key` flag doesn't show up
+ * in their help.
+ */
+export interface AddNetworkOptionsConfig {
+  /** Whether to expose `--api-key`. Default `true`. */
+  includeApiKey?: boolean;
+  /** Whether to expose long-form `--network <name>`. Default `true`. */
+  includeNetworkFlag?: boolean;
+  /** Whether to expose `--mainnet` boolean shortcut. Default `true`. */
+  includeMainnetFlag?: boolean;
+}
+
+/**
+ * Add the unified network-selection flags to a Command.
+ *
+ * All flags are optional. The defaults match the union of what
+ * `addIndexerNetworkOptions` + `addNetworkOptions` used to expose —
+ * passing no config gives every command both surfaces.
+ *
+ * Output grouping: all added flags are tagged with
+ * `helpGroup('Network')` so they cluster together in
+ * `--help` (matches the indexer-side styling).
+ */
+export function addUnifiedNetworkOptions(
+  cmd: Command,
+  config: AddNetworkOptionsConfig = {}
+): Command {
+  const includeApiKey = config.includeApiKey ?? true;
+  const includeNetworkFlag = config.includeNetworkFlag ?? true;
+  const includeMainnetFlag = config.includeMainnetFlag ?? true;
+
+  if (includeNetworkFlag) {
+    cmd.option(
+      '--network <name>',
+      'Network: mainnet | testnet | local. Picks the matching API base URL and config apiKey.'
+    );
+  }
+  if (includeMainnetFlag) {
+    cmd.option('--mainnet', 'Shortcut for --network mainnet');
+  }
+  cmd
+    .option('--testnet', 'Shortcut for --network testnet (use testnet API)', false)
+    .option('--local', 'Shortcut for --network local (http://localhost:3001)', false)
+    .option('--url <url>', 'Custom API base URL (overrides --network/--testnet/--local/config)');
+  if (includeApiKey) {
+    cmd.option('--api-key <key>', 'BitBadges API key (overrides BITBADGES_API_KEY env)');
+  }
+
+  // Help-group every added flag under "Network" so it clusters in
+  // --help. We tolerate missing entries — `helpGroup` is a no-op on
+  // older Commander versions and `_findOption` may be undefined on
+  // some commander forks.
+  const flags = ['--network', '--mainnet', '--testnet', '--local', '--url', '--api-key'];
+  for (const flag of flags) {
+    (cmd as any)._findOption?.(flag)?.helpGroup('Network');
+  }
+  return cmd;
+}

--- a/packages/bitbadgesjs-sdk/src/cli/utils/time.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/time.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the unified time-flag parser.
+ */
+import { parseTimeFlag } from './time.js';
+
+describe('parseTimeFlag', () => {
+  let nowSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  it('accepts raw ms-since-epoch (13-digit)', () => {
+    expect(parseTimeFlag('1748140800000', '--expiry')).toBe(1_748_140_800_000n);
+  });
+
+  it('accepts raw ms-since-epoch at the 10-digit boundary', () => {
+    expect(parseTimeFlag('1700000000', '--expiry')).toBe(1_700_000_000n);
+  });
+
+  it('parses 24h duration as delta from now', () => {
+    expect(parseTimeFlag('24h', '--expiry')).toBe(1_700_000_000_000n + 86_400_000n);
+  });
+
+  it('parses 7d duration', () => {
+    expect(parseTimeFlag('7d', '--expiry')).toBe(1_700_000_000_000n + 7n * 86_400_000n);
+  });
+
+  it('parses 30d duration', () => {
+    expect(parseTimeFlag('30d', '--expiry')).toBe(1_700_000_000_000n + 30n * 86_400_000n);
+  });
+
+  it('parses monthly keyword', () => {
+    expect(parseTimeFlag('monthly', '--expiry')).toBe(1_700_000_000_000n + 30n * 86_400_000n);
+  });
+
+  it('parses annually keyword', () => {
+    expect(parseTimeFlag('annually', '--expiry')).toBe(1_700_000_000_000n + 365n * 86_400_000n);
+  });
+
+  it('parses daily keyword', () => {
+    expect(parseTimeFlag('daily', '--expiry')).toBe(1_700_000_000_000n + 86_400_000n);
+  });
+
+  it('rejects short numeric input that could be confused for a bare-ms duration', () => {
+    // Pure 7 (< 10 digits) falls through to parseDuration which rejects
+    // unitless input. The user almost certainly meant "7d" or a real
+    // timestamp.
+    expect(() => parseTimeFlag('7', '--expiry')).toThrow();
+  });
+
+  it('rejects empty input', () => {
+    expect(() => parseTimeFlag('', '--expiry')).toThrow(/Missing time value/);
+  });
+
+  it('rejects garbage with a helpful hint', () => {
+    expect(() => parseTimeFlag('next week', '--expiry')).toThrow(/Invalid time value.*duration shorthand/s);
+  });
+
+  it('includes the context label in error messages', () => {
+    try {
+      parseTimeFlag('next week', '--valid-until');
+    } catch (e: any) {
+      expect(e.message).toContain('--valid-until');
+    }
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/utils/time.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/time.ts
@@ -1,0 +1,54 @@
+/**
+ * Time-flag parser for CLI commands.
+ *
+ * Every msg-emit command that takes an `--expiry / --valid-until /
+ * --deadline / --end-time / --start-time / --time` flag now accepts
+ * EITHER raw ms-since-epoch OR a duration shorthand (`24h`, `7d`,
+ * `monthly`). The duration form is delta-from-now → ms-since-epoch.
+ *
+ * Heuristic for raw-vs-duration detection: pure-digit input ≥ 10
+ * digits is treated as an absolute timestamp; anything else falls into
+ * the duration parser. 10-digit is the seconds-since-epoch threshold
+ * (Date.now() returns ms which is always 13 digits as of 2026, but the
+ * boundary at 10 avoids ambiguity with short numeric durations like
+ * "7d" — a bare `7` would be parsed as 7ms in the past, which is never
+ * what the user wanted).
+ */
+
+import { parseDuration } from '../../core/builders/shared.js';
+
+/**
+ * Parse a time flag value into ms-since-epoch as a bigint.
+ *
+ * Accepts:
+ *   - raw integer ms-since-epoch (pure digits, ≥ 10 chars)
+ *   - duration shorthand: `30d`, `7d`, `24h`, `1h`, `5m`, `monthly`,
+ *     `annually`, `daily`  → Date.now() + parsed-ms
+ *
+ * @throws Error with a CLI-friendly message on malformed input.
+ */
+export function parseTimeFlag(input: string, ctx: string): bigint {
+  if (!input || typeof input !== 'string' || input.trim().length === 0) {
+    throw new Error(`Missing time value for ${ctx}.`);
+  }
+  const trimmed = input.trim();
+
+  // Pure-digit input ≥ 10 chars → raw ms-since-epoch. Below 10 chars
+  // we treat as a bare numeric duration the user almost certainly
+  // didn't mean, so fall through to parseDuration which throws.
+  if (/^\d+$/.test(trimmed) && trimmed.length >= 10) {
+    return BigInt(trimmed);
+  }
+
+  // Otherwise — duration shorthand. parseDuration returns a string of
+  // milliseconds; add to now to get the absolute timestamp.
+  let deltaMs: bigint;
+  try {
+    deltaMs = BigInt(parseDuration(trimmed));
+  } catch (err: any) {
+    throw new Error(
+      `Invalid time value "${input}" for ${ctx}. Accepts: ms-since-epoch (e.g. 1748140800000) or duration shorthand (e.g. 24h, 7d, 30d, monthly). ${err?.message ?? ''}`
+    );
+  }
+  return BigInt(Date.now()) + deltaMs;
+}


### PR DESCRIPTION
## Summary

CLI consistency + ergonomics polish, two rounds against the v0.39 CLI v2 redesign:

**Round 1** (commits 1-8) handled strict denom/address validation, time-flag unification, amount flex, the `bb dev feedback` command, the policies disclaimer footer, and help-formatter polish.

**Round 2** (commits 9-15 + spillover fixes) handled the remaining quick wins (DEFAULT_FEE_DENOM constant, legacy `--json` removal, examples on every standards verb's `--help`), medium refactors (env-var jargon scrub, network-flag unification, error-code taxonomy), and the strategic first-run policies banner.

## Round 1 commits (8)

1. `feat(cli/utils): add requireBbDenom() denom validator` — strict on BitBadges-side flags. Rejects `uusdc`/`uatom`/`uosmo` with a hint at canonical `ibc/<SHA>`. Parallel `requireSkipGoDenom()` for Skip:Go swap commands.
2. `feat(cli): wire requireBbDenom into every BitBadges-side --denom flag` — ~28 callsites across 12 files. Help text consistently reads `--denom <symbol|denom>`.
3. `feat(cli/utils): strict bb1 address validation with bb account convert hint` — `requireBb1AddressStrict()` rejects non-`bb1` at msg-emit boundaries. `BB_ADDRESS_AUTO_CONVERT=1` escape hatch preserves v0.39 behavior for one release.
4. `feat(cli): apply strict bb1 to every msg-emit address flag + fix unvalidated callsites` — ~45 callsites + 8 audit-flagged unvalidated callsites.
5. `feat(cli): unified time-flag parser + extend --base-units to all action commands` — `parseTimeFlag` (`24h`, `7d`, `monthly`) + `resolveAmount` (display vs base units).
6. `feat(cli): add bb dev feedback — CLI mirror of the FE FeedbackWidget` — frictionless one-liner feedback path.
7. `feat(cli): show policies link at the foot of every bb --help` — small reminder on every help screen.
8. `feat(cli/help): clamp term column + reflow descriptions` — Commander help-formatter polish.

## Round 2 commits (10, including 2 spillover fixes)

9. `refactor(cli/utils): centralize DEFAULT_FEE_DENOM constant` — single export replaces 6 hardcoded `'ubadge'` sites.
10. `test(cli/integration): align build-send spec with v2.1 strict-mode` — integration test reflecting the strict bb1 rollout.
11. `refactor(cli): drop dead --json legacy alias + dedup output-flags` — pay-requests' unused `--json` removed; crowdfunds uses the shared `addIndexerOutputOptions`.
12. `feat(cli): add examples to every standards-action verb's --help` — `addHelpText('after', ...)` on every msg-emitting verb across 12 standards files. Read-only `list`/`show`/`status` skipped.
13. `fix(cli): scrub env-var jargon from inline error messages` — per `feedback_no_jargon`. `BITBADGES_API_KEY` no longer appears in thrown errors; `bitbadges-cli <cmd>` hints normalized to `bb <cmd>`. Env-var names still appear in `--help` blocks.
14. `fix(cli): retry fs.writeSync on EAGAIN in --help-json emit path` — handles pipe back-pressure when downstream readers haven't drained.
15. `refactor(cli/utils): unify network-flag surface` — `addUnifiedNetworkOptions` in `utils/network-options.ts` exposes `--network` / `--mainnet` / `--testnet` / `--local` / `--url` / `--api-key`. Old `addIndexerNetworkOptions` (28 callsites) and `addNetworkOptions` (6 callsites) become `@deprecated` thin aliases. Every command now accepts the same six flags.
16. `fix(cli): unify approval-id RNG width to 32-hex` — `bb subscriptions` uses `randomBytes(16).toString('hex')` like every other approval-creating verb.
17. `feat(cli): first-run policies + tab-completion banner` — prints once to stderr on the first `bb` invocation; marks `firstRunAcknowledgedAt` in `~/.bitbadges/config.json`; suppressible via `BB_QUIET=1`.
18. `feat(cli/envelope): canonical error-code taxonomy + bbError() helper` — `BBErrorCode` enum (`CLI_ERROR`, `INVALID_INPUT`, `INVALID_ADDRESS`, `UNKNOWN_TOKEN`, `MISSING_API_KEY`, `NOT_AUTHENTICATED`, `NETWORK_ERROR`, `TX_VALIDATION_FAILED`, `BROADCAST_FAILED`). Wired into load-bearing validators (`requireBbDenom`, `resolveApiKey`, `auth-store`).

## Breaking change

`bb cli` commands that previously silently auto-converted `0x` → `bb1` at msg-emit boundaries (~45 callsites) now reject `0x` with an actionable hint:

```
Error: --creator expects a bb1... address, got 0x form "0x1234…".
Run `bb account convert 0x1234…` to canonicalize, or set
BB_ADDRESS_AUTO_CONVERT=1 to keep the lenient v0.39 behavior for
one release.
```

The escape hatch is documented inline. Lookup-style commands keep the lenient auto-convert behavior — read-only flows don't need to change.

Suggested version bump: **0.40.0** (minor — strict address rejection + `uusdc` rejection are behavior changes; everything else is additive).

## Test plan

- [x] `bun run build` clean — no TS errors, no circular deps
- [x] `bun test src/cli/{commands,utils,auth}` — 434 pass / 0 fail (baseline 424; round 2 added 10 new tests for envelope error codes + network-options unification)
- [x] Smoke: `bitbadges-cli auctions place-bid 42 --creator 0x... --amount 10 --denom USDC` throws with the `bb account convert` hint
- [x] Smoke: `bitbadges-cli auctions place-bid 42 --creator bb1... --amount 10 --denom uusdc` throws with the canonical-form hint
- [x] Smoke: every standards-action verb's `--help` ends with an `Examples:` block
- [x] Smoke: no `BITBADGES_API_KEY` appears in thrown errors (only in `--help` text + the `doctor` diagnostic)
- [x] Smoke: `bb auctions place-bid --help` and `bb burner resume --help` both show the full unified network-flag surface (`--network` + `--api-key`)
- [x] Smoke: first-run banner prints once with fresh config dir, silent on second invocation; suppressed by `BB_QUIET=1`

## NOT included (deferred to follow-up)

- `bb examples`, `bb where`, `bb doctor --fix`, `--help-quick` (separate UX commands from the original audit's "strategic adds" list)
- Per-call-site migration from the deprecated aliases to `addUnifiedNetworkOptions` directly (the alias delegation means callsites work as-is)
- Output-envelope shape audit per verb-class (needs careful design work first)