### PR TITLE
feat(cli): flag consistency + error surface + completion v2

### DIFF
--- a/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
@@ -495,7 +495,7 @@ const sharedOpts = (cmd: Command) => {
     .option('--explain', 'Print a human-readable explanation of the output to stderr (in addition to the auto-review)')
     .option('--creator <address>', 'Creator/sender address (bb1... or 0x...)')
     .option('--manager <address>', 'Collection manager address (bb1...)')
-    .option('--simulate', 'Also simulate the tx against the BitBadges API and render gas + net changes (requires BITBADGES_API_KEY)')
+    .option('--simulate', 'After building, additionally call the BitBadges API simulate endpoint and render gas + net changes (requires BITBADGES_API_KEY). Distinct from `bb deploy --dry-run`, which simulates then exits without broadcasting.')
     .option('--events', 'When --simulate is set, dump the full raw chain events array (default: just the count)');
   // Network selection — only the --simulate path actually hits the
   // API, but we add the flags universally so `templates vault
@@ -1090,7 +1090,7 @@ sharedOpts(
     .option('--to <address>', 'Recipient address (bb1.../0x...)')
     .option('--amount <n>', 'Per-recipient amount (used when not precalculated)')
     .option('--token-ids <spec>', 'Token IDs (e.g. "1-5", "1,3,5", "all")')
-    .option('--yes', 'Non-interactive: skip all prompts. Picks no prioritized approvals, no precalc, default amount=1, default tokenIds=all valid. Use for scripts/CI.')
+    .option('-y, --yes', 'Non-interactive: skip all prompts. Picks no prioritized approvals, no precalc, default amount=1, default tokenIds=all valid. Use for scripts/CI.')
 ).action(async (opts) => {
   if (!process.env.BITBADGES_API_KEY) {
     // Fall through to runtime API-key resolution; the apiClient will

--- a/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/burner.ts
@@ -252,7 +252,7 @@ burnerCommand
   .usage('<selector>')
   .description('Delete the recovery file for a burner (the on-chain wallet still exists).')
   .argument('<selector>', 'Address or recovery file path')
-  .option('--yes', 'Skip confirmation prompt')
+  .option('-y, --yes', 'Skip confirmation prompt')
   .action(async (selector: string, opts: any) => {
     const rec = findBurner(selector);
     if (!rec || !rec.filePath) {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/completion.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/completion.spec.ts
@@ -1,13 +1,14 @@
 /**
  * Unit tests for completion.ts.
  *
- * Generates a bash/zsh completion script by walking a Commander program's
- * command tree. We construct a tiny synthetic program here so the test
- * stays decoupled from the real top-level CLI (which evolves with every
- * verb add/rename).
+ * The v2 generator walks the full Commander tree and emits a nested
+ * case-statement bash script. We construct a small synthetic program
+ * with two levels of nesting, an enum option (`argChoices`), a path-
+ * hinted option, and a short-flag option — then assert each gets a
+ * corresponding completion branch in the emitted script.
  */
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { makeCompletionCommand } from './completion.js';
 
 describe('makeCompletionCommand', () => {
@@ -47,38 +48,72 @@ describe('makeCompletionCommand', () => {
     sub.command('vault');
     sub.command('nft');
     root.command('flat-cmd');
+    // Enum option on root → triggers flag-value branch with the choices.
+    root.addOption(new Option('--shell <shell>', 'Target shell').choices(['bash', 'zsh']));
+    // Path-hinted option (longName ends with "-file") → triggers `compgen -f`.
+    root.option('--output-file <path>', 'Write output to file');
+    // Short-flag combo to verify both forms get a completion entry.
+    root.option('-q, --quiet', 'Quiet mode');
     return root;
   }
 
-  it('emits a bash-compatible script with top-level names + nested case entries', async () => {
+  function runCompletion(args: string[] = []): string {
     const program = makeFixtureProgram();
     const completion = makeCompletionCommand(program);
     const cap = captureStdout();
     try {
-      await completion.parseAsync([], { from: 'user' });
+      completion.parseAsync(args, { from: 'user' });
     } finally {
       cap.restore();
     }
-    const out = cap.chunks.join('');
-    // Top-level names enumerated
-    expect(out).toMatch(/build flat-cmd/);
-    // Nested subcommands for `build`
-    expect(out).toMatch(/build\)\s*COMPREPLY=.+vault nft/);
-    // Bash completion bookkeeping
-    expect(out).toMatch(/complete -F _bitbadges_cli_completions/);
+    return cap.chunks.join('');
+  }
+
+  it('registers completion against both `bitbadges-cli` and `bb`', () => {
+    const out = runCompletion();
+    expect(out).toMatch(/complete -F _bitbadges_cli_complete bitbadges-cli/);
+    expect(out).toMatch(/complete -F _bitbadges_cli_complete bb/);
   });
 
-  it('accepts bash and zsh shell hints', async () => {
+  it('emits a branch for the root (empty key) with top-level subcommands', () => {
+    const out = runCompletion();
+    // Root branch is keyed on the empty string. Top-level subcommands
+    // (`build`, `flat-cmd`) appear in the compgen -W list for the
+    // subcommand-completion fallback (the else branch under `if [[ "$cur" == -* ]]`).
+    expect(out).toMatch(/''\)[\s\S]*build flat-cmd/);
+  });
+
+  it('emits a nested branch for `build` listing its children (vault, nft)', () => {
+    const out = runCompletion();
+    expect(out).toMatch(/'build'\)[\s\S]*vault nft/);
+  });
+
+  it('emits enum value completion for options declared with .choices()', () => {
+    const out = runCompletion();
+    // The Option `--shell` was declared with choices(['bash', 'zsh']).
+    // The script should have a `--shell) COMPREPLY=( compgen -W 'bash zsh' )` line.
+    expect(out).toMatch(/--shell\)\s*COMPREPLY=\(\s*\$\(compgen -W 'bash zsh'/);
+  });
+
+  it('emits file completion for path-hinted options', () => {
+    const out = runCompletion();
+    // `--output-file` matches the path heuristic → defer to bash file completion.
+    expect(out).toMatch(/--output-file\)\s*COMPREPLY=\(\s*\$\(compgen -f/);
+  });
+
+  it('includes both short and long flag forms in the flag-name completion list', () => {
+    const out = runCompletion();
+    // `-q, --quiet` should put both `-q` and `--quiet` into the flag list.
+    const rootBranchMatch = out.match(/''\)[\s\S]*?return ;;/);
+    expect(rootBranchMatch).not.toBeNull();
+    expect(rootBranchMatch![0]).toMatch(/-q/);
+    expect(rootBranchMatch![0]).toMatch(/--quiet/);
+  });
+
+  it('accepts bash and zsh shell hints', () => {
     for (const shell of ['bash', 'zsh', 'BASH', 'ZSH']) {
-      const program = makeFixtureProgram();
-      const completion = makeCompletionCommand(program);
-      const cap = captureStdout();
-      try {
-        await completion.parseAsync([shell], { from: 'user' });
-      } finally {
-        cap.restore();
-      }
-      expect(cap.chunks.join('')).toMatch(/bitbadges-cli completion/);
+      const out = runCompletion([shell]);
+      expect(out).toMatch(/bitbadges-cli completion/);
     }
   });
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/completion.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/completion.spec.ts
@@ -103,11 +103,12 @@ describe('makeCompletionCommand', () => {
 
   it('includes both short and long flag forms in the flag-name completion list', () => {
     const out = runCompletion();
-    // `-q, --quiet` should put both `-q` and `--quiet` into the flag list.
-    const rootBranchMatch = out.match(/''\)[\s\S]*?return ;;/);
-    expect(rootBranchMatch).not.toBeNull();
-    expect(rootBranchMatch![0]).toMatch(/-q/);
-    expect(rootBranchMatch![0]).toMatch(/--quiet/);
+    // `-q, --quiet` should put both `-q` and `--quiet` into the same
+    // flag-name compgen -W list under the root case branch.
+    const flagListLine = out
+      .split('\n')
+      .find((line) => line.includes('compgen -W') && line.includes('-q') && line.includes('--quiet'));
+    expect(flagListLine).toBeDefined();
   });
 
   it('accepts bash and zsh shell hints', () => {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/completion.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/completion.ts
@@ -1,55 +1,182 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 
 /**
- * Build a bash/zsh completion script for whichever Commander program is
- * passed in. Walks the program's top-level commands and their immediate
- * subcommands so completions stay accurate after the command tree
- * changes — no hand-maintained list.
+ * Shell completion script generator for the BitBadges CLI.
+ *
+ * The v1 generator emitted a flat case-statement covering only top-level
+ * commands and their immediate children — anything deeper than two levels
+ * (`bb auctions create --...`, `bb dev tools call ...`) got no completion,
+ * and flag values (`--network mainnet|testnet|local`) were never offered.
+ *
+ * v2 walks the full Commander tree and emits a pure-bash script that:
+ *   1. Builds a "path key" from COMP_WORDS, skipping flag tokens.
+ *   2. Looks up that path in a generated nested case-statement.
+ *   3. Suggests:
+ *        - subcommand names if the cursor is on a fresh word,
+ *        - flag names if the word starts with `-`,
+ *        - flag values for enum-like options (`--shell bash|zsh`,
+ *          `--network mainnet|testnet|local`, etc) inferred from the
+ *          Commander Option's `argChoices`.
+ *   4. Falls back to bash's default file completion for path-shaped
+ *      flag values (`--output-file <path>`, `--metadata-file <path>`).
+ *
+ * No external dependencies — the emitted script is portable bash that
+ * works in zsh after `bashcompinit`.
  */
+
+interface OptionInfo {
+  flags: string[];
+  /** Long form without leading dashes, e.g. "output-file". */
+  longName: string;
+  takesValue: boolean;
+  choices?: readonly string[];
+  isPath: boolean;
+}
+
+interface CommandNode {
+  /** Path key including parent names, space-separated; root is "". */
+  key: string;
+  /** Visible (non-hidden) subcommand names. */
+  subs: string[];
+  options: OptionInfo[];
+}
+
+const PATH_HINT_RE = /(file|path|dir|directory|out|output|config|metadata)$/i;
+
+function extractOptions(cmd: Command): OptionInfo[] {
+  return cmd.options.map((o) => {
+    const opt = o as Option;
+    const longName = (opt.long ?? '').replace(/^--/, '');
+    const takesValue = !!opt.required || !!opt.optional;
+    return {
+      flags: [opt.short, opt.long].filter(Boolean) as string[],
+      longName,
+      takesValue,
+      choices: (opt as any).argChoices ?? undefined,
+      isPath: takesValue && PATH_HINT_RE.test(longName),
+    };
+  });
+}
+
+function collectNodes(cmd: Command, parentKey: string, out: CommandNode[]): void {
+  const key = parentKey ? `${parentKey} ${cmd.name()}` : cmd.name();
+  const visibleSubs = cmd.commands
+    .filter((c) => !(c as any)._hidden)
+    .map((c) => c.name());
+  out.push({ key, subs: visibleSubs, options: extractOptions(cmd) });
+  for (const sub of cmd.commands) {
+    if (!(sub as any)._hidden) collectNodes(sub, key, out);
+  }
+}
+
+function shellQuote(s: string): string {
+  // Wrap in single quotes; escape embedded single quotes the usual bash way.
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function renderNodeCase(node: CommandNode): string {
+  // For each node we emit one case branch that handles:
+  //   - flag-value completion driven by $prev
+  //   - flag-name completion when $cur starts with `-`
+  //   - subcommand completion otherwise
+  const flagValueBranches: string[] = [];
+  for (const opt of node.options) {
+    if (!opt.takesValue) continue;
+    if (opt.choices && opt.choices.length > 0) {
+      for (const flag of opt.flags) {
+        const choices = opt.choices.join(' ');
+        flagValueBranches.push(
+          `      ${flag}) COMPREPLY=( $(compgen -W ${shellQuote(choices)} -- "$cur") ); return ;;`
+        );
+      }
+    } else if (opt.isPath) {
+      for (const flag of opt.flags) {
+        flagValueBranches.push(`      ${flag}) COMPREPLY=( $(compgen -f -- "$cur") ); return ;;`);
+      }
+    }
+  }
+  const allFlags = node.options.flatMap((o) => o.flags).join(' ');
+  const allSubs = node.subs.join(' ');
+  const lines: string[] = [];
+  lines.push(`    ${shellQuote(node.key)})`);
+  if (flagValueBranches.length > 0) {
+    lines.push('      case "$prev" in');
+    for (const b of flagValueBranches) lines.push(b);
+    lines.push('      esac');
+  }
+  lines.push('      if [[ "$cur" == -* ]]; then');
+  lines.push(`        COMPREPLY=( $(compgen -W ${shellQuote(allFlags)} -- "$cur") )`);
+  lines.push('      else');
+  lines.push(`        COMPREPLY=( $(compgen -W ${shellQuote(allSubs)} -- "$cur") )`);
+  lines.push('      fi');
+  lines.push('      return ;;');
+  return lines.join('\n');
+}
+
 export function makeCompletionCommand(program: Command): Command {
   return new Command('completion')
-    .description('Generate shell completion script. Output is bash-compatible (works in zsh via `bashcompinit`).')
-    .argument('[shell]', 'Optional shell hint: bash | zsh. Currently informational only — the same script works for both.')
+    .description('Generate a bash/zsh completion script. Pipe into your shell rc file.')
+    .argument('[shell]', 'Optional shell hint: bash | zsh. The emitted script supports both via bashcompinit.')
     .action((shell?: string) => {
       if (shell && !['bash', 'zsh'].includes(shell.toLowerCase())) {
         process.stderr.write(`Unknown shell "${shell}". Supported: bash, zsh.\n`);
         process.exit(2);
       }
-      const topLevelNames = program.commands.map((c) => c.name()).join(' ');
+      const nodes: CommandNode[] = [];
+      // Strip the program's own name from each node key. COMP_WORDS[0]
+      // may be `bitbadges-cli`, `bb`, or any other symlink alias the
+      // user installed — instead of binding the case keys to one name,
+      // we emit them rooted at subcommand level (e.g. "auctions create"
+      // instead of "bitbadges-cli auctions create") and prepend the
+      // user's actual invocation name at runtime is unnecessary.
+      collectNodes(program, '', nodes);
+      const rootName = program.name();
+      for (const n of nodes) {
+        if (n.key === rootName) n.key = '';
+        else if (n.key.startsWith(`${rootName} `)) n.key = n.key.slice(rootName.length + 1);
+      }
 
-      const caseEntries = program.commands
-        .map((cmd) => {
-          const subs = cmd.commands?.map((s: any) => s.name()).join(' ');
-          if (!subs) return null;
-          return `      ${cmd.name()}) COMPREPLY=( $(compgen -W "${subs}" -- "$cur") ) ;;`;
-        })
-        .filter(Boolean)
-        .join('\n');
+      // Reverse-sort by key length so deeper paths match before their
+      // prefixes when emitted into one case block — bash case picks the
+      // first match, and a longer key is more specific.
+      nodes.sort((a, b) => b.key.length - a.key.length);
 
-      const script = `
-# bitbadges-cli completion — add to your .bashrc / .zshrc:
-#   eval "$(bitbadges-cli completion)"
+      const caseBranches = nodes.map(renderNodeCase).join('\n');
 
-_bitbadges_cli_completions() {
-  local cur prev
+      const script = `# bitbadges-cli completion — bash & zsh (via bashcompinit)
+# Install:
+#   bb completion bash >> ~/.bashrc
+#   bb completion zsh  >> ~/.zshrc      (then: autoload -U +X bashcompinit && bashcompinit)
+
+_bitbadges_cli_complete() {
+  local cur prev key i w
+  local -a path
+  COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
-  if [ "$COMP_CWORD" -eq 1 ]; then
-    COMPREPLY=( $(compgen -W "${topLevelNames}" -- "$cur") )
-    return
-  fi
+  # Reconstruct the resolved command path by walking COMP_WORDS,
+  # skipping flag tokens. Drop COMP_WORDS[0] (the binary name) so the
+  # case keys below are binary-agnostic — works for \`bb\`, \`bitbadges-cli\`,
+  # or any symlink the user installed.
+  path=()
+  for (( i=1; i<COMP_CWORD; i++ )); do
+    w="\${COMP_WORDS[i]}"
+    case "$w" in
+      -*) continue ;;
+    esac
+    path+=( "$w" )
+  done
+  key="\${path[*]}"
 
-  case "$prev" in
-${caseEntries}
+  case "$key" in
+${caseBranches}
   esac
 }
 
-complete -F _bitbadges_cli_completions bitbadges-cli
-
-# For zsh, also add:
-# autoload -U +X bashcompinit && bashcompinit
-`.trimStart();
+complete -F _bitbadges_cli_complete bitbadges-cli
+complete -F _bitbadges_cli_complete bb
+`;
 
       process.stdout.write(script);
     });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
@@ -347,7 +347,7 @@ export const deployCommand = new Command('deploy')
     '--wait-for-indexer [timeout-ms]',
     'After broadcast: poll the indexer until the created entity (collection / dynamic store) is visible, or until [timeout-ms] elapses (default 30000ms). Skipped when the tx has no recognizable entity id.'
   )
-  .option('--dry-run', 'Simulate the tx and print expected gas + balance changes; never broadcast.')
+  .option('--dry-run', 'Simulate the tx and print expected gas + balance changes; never broadcast. (Distinct from `bb build --simulate`, which augments build output but does not broadcast either way.)')
   // --message + --gen-payload: absorbed modes from the v1 standalone
   // `sign-with-browser` and `gen-tx-payload` commands (#0399). The former
   // hands an arbitrary message to a browser wallet for personal-sign;

--- a/packages/bitbadgesjs-sdk/src/cli/commands/dev-feedback.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/dev-feedback.ts
@@ -19,6 +19,7 @@ import {
   type IndexerNetworkFlags as NetworkFlags,
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
+import { bbError, BBErrorCode } from '../utils/envelope.js';
 
 type FeedbackFlags = NetworkFlags & OutputFlags & {
   type?: 'feedback' | 'feature-idea';
@@ -43,15 +44,15 @@ devFeedbackCommand
     try {
       const trimmed = (message ?? '').trim();
       if (!trimmed) {
-        throw new Error('Feedback message cannot be empty.');
+        throw bbError(BBErrorCode.INVALID_INPUT, 'Feedback message cannot be empty.');
       }
       if (trimmed.length > 2000) {
-        throw new Error(`Feedback message is ${trimmed.length} chars; the indexer limit is 2000.`);
+        throw bbError(BBErrorCode.INVALID_INPUT, `Feedback message is ${trimmed.length} chars; the indexer limit is 2000.`);
       }
 
       const type = opts.type ?? 'feedback';
       if (!FEEDBACK_TYPES.includes(type)) {
-        throw new Error(`--type must be one of: ${FEEDBACK_TYPES.join(', ')} (got "${type}")`);
+        throw bbError(BBErrorCode.INVALID_INPUT, `--type must be one of: ${FEEDBACK_TYPES.join(', ')} (got "${type}")`);
       }
 
       // Source-tag for the `page` field — mirrors the FE's `router.asPath`

--- a/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/gen-tx-payload.ts
@@ -28,7 +28,7 @@ import { NETWORK_CONFIGS } from '../../signing/types.js';
 import { createTransactionPayload } from '../../transactions/messages/base.js';
 import { encodeTokenizationMsgFromJson, supportedTokenizationTypeUrls } from '../../transactions/messages/bitbadges/tokenization/fromJson.js';
 import { evmToCosmosAddress } from '../../transactions/precompile/helpers.js';
-import { emit, emitError } from '../utils/envelope.js';
+import { emit, emitError, bbError, BBErrorCode } from '../utils/envelope.js';
 import { emitDeprecation } from '../utils/deprecation.js';
 import { requireBbDenom, DEFAULT_FEE_DENOM } from '../utils/denom.js';
 
@@ -50,12 +50,12 @@ function readMsgInput(opts: { input?: string; msgFile?: string; msgStdin?: boole
   } else if (!process.stdin.isTTY) {
     raw = fs.readFileSync(0, 'utf-8');
   } else {
-    throw new Error('No msg input. Pass a positional file/-, --msg-file, --msg-stdin, or pipe via stdin.');
+    throw bbError(BBErrorCode.INVALID_INPUT, 'No msg input. Pass a positional file/-, --msg-file, --msg-stdin, or pipe via stdin.');
   }
   try {
     return JSON.parse(raw);
   } catch (err: any) {
-    throw new Error(`Failed to parse msg JSON: ${err?.message || err}`);
+    throw bbError(BBErrorCode.INVALID_INPUT, `Failed to parse msg JSON: ${err?.message || err}`);
   }
 }
 
@@ -63,7 +63,7 @@ function normalizeMessages(input: unknown): MsgEntry[] {
   const arr = Array.isArray(input) ? input : [input];
   for (const m of arr) {
     if (!m || typeof m !== 'object' || typeof (m as any).typeUrl !== 'string' || !(m as any).value) {
-      throw new Error('Each message must be `{typeUrl: string, value: object}`. Received: ' + JSON.stringify(m));
+      throw bbError(BBErrorCode.INVALID_INPUT, 'Each message must be `{typeUrl: string, value: object}`. Received: ' + JSON.stringify(m));
     }
   }
   return arr as MsgEntry[];
@@ -89,12 +89,12 @@ async function fetchAccountInfo(baseUrl: string, apiKey: string | undefined, add
     body: JSON.stringify({ accountsToFetch: [{ address }] }),
   });
   if (!res.ok) {
-    throw new Error(`Failed to fetch account info for ${address}: HTTP ${res.status} ${await res.text()}`);
+    throw bbError(BBErrorCode.NETWORK_ERROR, `Failed to fetch account info for ${address}: HTTP ${res.status} ${await res.text()}`);
   }
   const body = await res.json();
   const acct = (body?.accounts ?? [])[0];
   if (!acct) {
-    throw new Error(`Indexer returned no account for ${address}. Has it been seen onchain yet?`);
+    throw bbError(BBErrorCode.NETWORK_ERROR, `Indexer returned no account for ${address}. Has it been seen onchain yet?`);
   }
   return {
     accountNumber: Number(acct.accountNumber ?? 0),

--- a/packages/bitbadgesjs-sdk/src/cli/commands/settings.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/settings.ts
@@ -7,6 +7,14 @@ import {
   type ConfigKey,
 } from '../utils/config.js';
 import { assertNetworkAvailable } from '../../signing/types.js';
+import {
+  addOutputOptions,
+  bbError,
+  BBErrorCode,
+  emit,
+  emitError,
+  type EmitOptions,
+} from '../utils/envelope.js';
 
 // CLI v2 (#0399) renamed `bb config` → `bb settings` to free the
 // `config` slot for the chain binary's client.toml management once the
@@ -14,6 +22,22 @@ import { assertNetworkAvailable } from '../../signing/types.js';
 // the public command name `settings` mirror the docs; the old top-level
 // `bb config ...` form is registered as a deprecated alias in
 // cli/index.ts for one release.
+//
+// Output contract: every subcommand emits a JSON envelope on stdout
+// (success path via `emit()`, error path via `emitError()`). This
+// supersedes the v1 plain-text print model. Humans pipe through
+// `jq -r` for the same human-readable shape they had before; agents
+// get a stable `{ok, data, error}` envelope they can parse like every
+// other `bb` verb.
+
+type OutputFlags = { condensed?: boolean; outputFile?: string };
+
+function emitOpts(opts: OutputFlags): EmitOptions {
+  return {
+    ...(opts.condensed ? { condensed: true } : {}),
+    ...(opts.outputFile ? { outputFile: opts.outputFile } : {}),
+  };
+}
 
 export const settingsCommand = new Command('settings').description(
   'Manage CLI settings (~/.bitbadges/config.json)'
@@ -21,86 +45,99 @@ export const settingsCommand = new Command('settings').description(
 
 // ── settings show ───────────────────────────────────────────────────────────
 
-settingsCommand
-  .command('show')
-  .description('Print current configuration')
-  .action(() => {
-    const config = loadConfig();
-    const configPath = getConfigPath();
+addOutputOptions(
+  settingsCommand
+    .command('show')
+    .description('Print current configuration')
+).action((opts: OutputFlags) => {
+  const config = loadConfig();
+  const configPath = getConfigPath();
 
-    console.log(`Config file: ${configPath}\n`);
-
-    if (Object.keys(config).length === 0) {
-      console.log('(no configuration set)');
-      return;
-    }
-
-    for (const [key, value] of Object.entries(config)) {
-      const display = key.startsWith('apiKey') && typeof value === 'string'
-        ? maskKey(value)
-        : value;
-      console.log(`  ${key} = ${display}`);
-    }
-  });
+  // Mask any apiKey* field so the envelope is safe to paste / log.
+  const masked: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    masked[key] =
+      key.startsWith('apiKey') && typeof value === 'string' ? maskKey(value) : value;
+  }
+  emit({ configPath, config: masked }, emitOpts(opts));
+});
 
 // ── settings set <key> <value> ─────────────────────────────────────────────────
 
-settingsCommand
-  .command('set <key> <value>')
-  .description(`Set a config value. Supported keys: ${SUPPORTED_CONFIG_KEYS.join(', ')}`)
-  .action((key: string, value: string) => {
-    if (!SUPPORTED_CONFIG_KEYS.includes(key as ConfigKey)) {
-      console.error(
+addOutputOptions(
+  settingsCommand
+    .command('set <key> <value>')
+    .description(`Set a config value. Supported keys: ${SUPPORTED_CONFIG_KEYS.join(', ')}`)
+).action((key: string, value: string, opts: OutputFlags) => {
+  if (!SUPPORTED_CONFIG_KEYS.includes(key as ConfigKey)) {
+    emitError(
+      bbError(
+        BBErrorCode.INVALID_INPUT,
         `Unknown config key "${key}". Supported keys: ${SUPPORTED_CONFIG_KEYS.join(', ')}`
+      ),
+      emitOpts(opts)
+    );
+  }
+
+  if (key === 'network' && !['mainnet', 'testnet', 'local'].includes(value)) {
+    emitError(
+      bbError(
+        BBErrorCode.INVALID_INPUT,
+        'Invalid network value. Must be one of: mainnet, testnet, local'
+      ),
+      emitOpts(opts)
+    );
+  }
+
+  // Fail fast if the user tries to persist a currently-disabled network
+  // (e.g. testnet is temporarily offline). This catches misconfiguration
+  // at config-write time rather than at every later command.
+  if (key === 'network') {
+    try {
+      assertNetworkAvailable(value);
+    } catch (err) {
+      emitError(
+        bbError(BBErrorCode.INVALID_INPUT, (err as Error).message),
+        emitOpts(opts)
       );
-      process.exitCode = 1;
-      return;
     }
+  }
 
-    if (key === 'network' && !['mainnet', 'testnet', 'local'].includes(value)) {
-      console.error('Invalid network value. Must be one of: mainnet, testnet, local');
-      process.exitCode = 1;
-      return;
-    }
-
-    // Fail fast if the user tries to persist a currently-disabled network
-    // (e.g. testnet is temporarily offline). This catches misconfiguration
-    // at config-write time rather than at every later command.
-    if (key === 'network') {
-      try {
-        assertNetworkAvailable(value);
-      } catch (err) {
-        console.error((err as Error).message);
-        process.exitCode = 1;
-        return;
-      }
-    }
-
-    const config = loadConfig();
-    (config as any)[key] = value;
-    saveConfig(config);
-    console.log(`Set ${key} = ${key.startsWith('apiKey') ? maskKey(value) : value}`);
-  });
+  const config = loadConfig();
+  (config as any)[key] = value;
+  saveConfig(config);
+  emit(
+    {
+      configPath: getConfigPath(),
+      key,
+      value: key.startsWith('apiKey') ? maskKey(value) : value,
+    },
+    emitOpts(opts)
+  );
+});
 
 // ── settings unset <key> ───────────────────────────────────────────────────────
 
-settingsCommand
-  .command('unset <key>')
-  .description('Remove a config value')
-  .action((key: string) => {
-    if (!SUPPORTED_CONFIG_KEYS.includes(key as ConfigKey)) {
-      console.error(
+addOutputOptions(
+  settingsCommand
+    .command('unset <key>')
+    .description('Remove a config value')
+).action((key: string, opts: OutputFlags) => {
+  if (!SUPPORTED_CONFIG_KEYS.includes(key as ConfigKey)) {
+    emitError(
+      bbError(
+        BBErrorCode.INVALID_INPUT,
         `Unknown config key "${key}". Supported keys: ${SUPPORTED_CONFIG_KEYS.join(', ')}`
-      );
-      process.exitCode = 1;
-      return;
-    }
+      ),
+      emitOpts(opts)
+    );
+  }
 
-    const config = loadConfig();
-    delete (config as any)[key];
-    saveConfig(config);
-    console.log(`Removed ${key}`);
-  });
+  const config = loadConfig();
+  delete (config as any)[key];
+  saveConfig(config);
+  emit({ configPath: getConfigPath(), removed: key }, emitOpts(opts));
+});
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/packages/bitbadgesjs-sdk/src/cli/commands/sign-with-browser.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/sign-with-browser.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import { Command } from 'commander';
 import { addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
 import { bridgeSign, resolveFrontendUrl } from '../auth/browser-bridge.js';
-import { emit, emitError, commentary } from '../utils/envelope.js';
+import { emit, emitError, commentary, bbError, BBErrorCode } from '../utils/envelope.js';
 import { emitDeprecation } from '../utils/deprecation.js';
 
 function readMessage(opts: { message?: string; messageFile?: string; positional?: string }): string {
@@ -33,7 +33,7 @@ function readMessage(opts: { message?: string; messageFile?: string; positional?
     return opts.positional;
   }
   if (!process.stdin.isTTY) return fs.readFileSync(0, 'utf-8');
-  throw new Error('No message provided. Pass --message <text>, --message-file <path>, a positional arg, or pipe via stdin.');
+  throw bbError(BBErrorCode.INVALID_INPUT, 'No message provided. Pass --message <text>, --message-file <path>, a positional arg, or pipe via stdin.');
 }
 
 /**

--- a/packages/bitbadgesjs-sdk/src/cli/commands/tool.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/tool.ts
@@ -5,10 +5,11 @@ import {
   loadSessionFromDisk,
   saveSessionToDisk
 } from '../../builder/session/fileStore.js';
+import { bbError, BBErrorCode } from '../utils/envelope.js';
 
 function parseArgs(argsJson: string | undefined, argsFile: string | undefined): any {
   if (argsJson && argsFile) {
-    throw new Error('Pass either --args or --args-file, not both');
+    throw bbError(BBErrorCode.INVALID_INPUT, 'Pass either --args or --args-file, not both');
   }
   if (argsFile) {
     const raw = fs.readFileSync(argsFile, 'utf-8');
@@ -18,7 +19,7 @@ function parseArgs(argsJson: string | undefined, argsFile: string | undefined): 
     try {
       return JSON.parse(argsJson);
     } catch (err) {
-      throw new Error(`--args is not valid JSON: ${(err as Error).message}`);
+      throw bbError(BBErrorCode.INVALID_INPUT, `--args is not valid JSON: ${(err as Error).message}`);
     }
   }
   return {};

--- a/packages/bitbadgesjs-sdk/src/cli/commands/tx.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/tx.ts
@@ -12,6 +12,8 @@ import { addNetworkOptions, resolveNetwork, type NetworkOptions } from '../utils
 import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
 import {
   addOutputOptions,
+  bbError,
+  BBErrorCode,
   errorEnvelope,
   successEnvelope,
   writeJsonEnvelope
@@ -74,7 +76,7 @@ async function fetchCosmosTx(nodeUrl: string, hash: string): Promise<FetchResult
   try {
     res = await fetch(url);
   } catch (err: any) {
-    throw new Error(`Failed to reach chain RPC at ${nodeUrl}: ${err?.message || err}`);
+    throw bbError(BBErrorCode.NETWORK_ERROR, `Failed to reach chain RPC at ${nodeUrl}: ${err?.message || err}`);
   }
   const text = await res.text();
   let body: any;
@@ -114,7 +116,7 @@ async function fetchEvmTx(evmRpcUrl: string, hash: string): Promise<FetchResult>
       body: JSON.stringify(reqBody)
     });
   } catch (err: any) {
-    throw new Error(`Failed to reach EVM RPC at ${evmRpcUrl}: ${err?.message || err}`);
+    throw bbError(BBErrorCode.NETWORK_ERROR, `Failed to reach EVM RPC at ${evmRpcUrl}: ${err?.message || err}`);
   }
   const text = await res.text();
   let body: any;

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -199,6 +199,7 @@ import { nftsCommand } from './commands/nfts.js';
 // Misc
 import { makeCompletionCommand } from './commands/completion.js';
 import { maybePrintFirstRunBanner } from './utils/first-run.js';
+import { enableSuggestionsTreeWide } from './utils/suggestions.js';
 
 // First-run policies + tab-completion banner. Runs before Commander parses
 // so the user sees it ahead of any actual output, even on `bb --help`.
@@ -508,6 +509,13 @@ const cliAliasCommand = new Command('cli')
     await program.parseAsync(args, { from: 'user' });
   });
 program.addCommand(cliAliasCommand);
+
+// ── "Did you mean?" for typos ───────────────────────────────────────────────
+//
+// Levenshtein suggestions on unknown subcommands AND unknown flags. Toggle
+// has to be applied to every Command in the tree (Commander does not
+// inherit it), so we run after all top-level + alias registration.
+enableSuggestionsTreeWide(program);
 
 // ── Grouped --help override ─────────────────────────────────────────────────
 //

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -237,9 +237,9 @@ program.addHelpText(
 // `isQuiet()` without reading commander state.
 
 program.option('--help-json', 'Output all commands as structured JSON (for LLMs)');
-program.option('--quiet', 'Silence stderr commentary (auto-review banners, "Written to" notices, etc). Errors still emit. Equivalent to BB_QUIET=1.');
+program.option('-q, --quiet', 'Silence stderr commentary (auto-review banners, "Written to" notices, etc). Errors still emit. Equivalent to BB_QUIET=1.');
 
-if (process.argv.includes('--quiet')) {
+if (process.argv.includes('--quiet') || process.argv.includes('-q')) {
   process.env.BB_QUIET = '1';
 }
 
@@ -697,7 +697,7 @@ process.on('unhandledRejection', reportFatal);
 // agents and humans both reach for the long form (commands + groups).
 // Detect "no positional args + no help-json + no quiet-only" and route
 // through `outputHelp()` which uses our custom grouped formatter.
-const onlyGlobalFlags = process.argv.slice(2).every((a) => a === '--quiet');
+const onlyGlobalFlags = process.argv.slice(2).every((a) => a === '--quiet' || a === '-q');
 if (process.argv.length <= 2 || onlyGlobalFlags) {
   program.outputHelp();
   process.exit(0);

--- a/packages/bitbadgesjs-sdk/src/cli/integration/cli-local-state.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/cli-local-state.spec.ts
@@ -33,50 +33,68 @@ function envWithCfgDir(): Record<string, string> {
 // ── bb config ────────────────────────────────────────────────────────────────
 
 describe('bb config', () => {
-  it('show prints "no configuration" on a fresh tmpdir', () => {
-    const out = runCli(['config', 'show'], { env: envWithCfgDir(), parseJson: false });
+  // `bb config` is the deprecated v1 alias forwarding to `bb settings`
+  // (see cli/index.ts). The settings command now emits a JSON envelope
+  // on stdout instead of plaintext, so each assertion below reads the
+  // parsed `{ok, data, error}` shape. The deprecation banner that the
+  // alias prints lives on stderr and is not under test here.
+  //
+  // runCli auto-unwraps the envelope: `out.json` is `envelope.data` and
+  // `out.envelope` is the full envelope including ok/error/warnings.
+
+  it('show emits an empty config envelope on a fresh tmpdir', () => {
+    const out = runCli(['config', 'show'], { env: envWithCfgDir() });
     expect(out.exitCode).toBe(0);
-    expect(out.stdout).toMatch(/no configuration set/);
+    expect(out.envelope?.ok).toBe(true);
+    expect(out.json?.config).toEqual({});
+    expect(typeof out.json?.configPath).toBe('string');
   });
 
   it('set persists a value and show reads it back', () => {
     const apiKey = 'sk_test_abcd1234efgh5678';
     const setOut = runCli(['config', 'set', 'apiKey', apiKey], {
       env: envWithCfgDir(),
-      parseJson: false
     });
     expect(setOut.exitCode).toBe(0);
+    expect(setOut.envelope?.ok).toBe(true);
     // Masked echo: first 4 + asterisks + last 4
-    expect(setOut.stdout).toContain('sk_t');
-    expect(setOut.stdout).toContain('5678');
+    expect(setOut.json?.value).toContain('sk_t');
+    expect(setOut.json?.value).toContain('5678');
 
-    const showOut = runCli(['config', 'show'], { env: envWithCfgDir(), parseJson: false });
-    expect(showOut.stdout).toContain('apiKey');
-    expect(showOut.stdout).toContain('sk_t');
+    const showOut = runCli(['config', 'show'], { env: envWithCfgDir() });
+    expect(showOut.json?.config?.apiKey).toContain('sk_t');
+    expect(showOut.json?.config?.apiKey).toContain('5678');
   });
 
   it('set rejects an unknown key', () => {
     const out = runCli(['config', 'set', 'bogusKey', 'value'], {
-      env: envWithCfgDir(), throwOnError: false, parseJson: false
+      env: envWithCfgDir(),
+      throwOnError: false,
     });
     expect(out.exitCode).not.toBe(0);
-    expect(out.stderr).toMatch(/Unknown config key/);
+    expect(out.envelope?.ok).toBe(false);
+    expect(out.envelope?.error?.code).toBe('invalid_input');
+    expect(out.envelope?.error?.message).toMatch(/Unknown config key/);
   });
 
   it('set rejects an invalid network value', () => {
     const out = runCli(['config', 'set', 'network', 'bogus'], {
-      env: envWithCfgDir(), throwOnError: false, parseJson: false
+      env: envWithCfgDir(),
+      throwOnError: false,
     });
     expect(out.exitCode).not.toBe(0);
-    expect(out.stderr).toMatch(/Invalid network value/);
+    expect(out.envelope?.ok).toBe(false);
+    expect(out.envelope?.error?.code).toBe('invalid_input');
+    expect(out.envelope?.error?.message).toMatch(/Invalid network value/);
   });
 
   it('unset removes a previously set key', () => {
-    runCli(['config', 'set', 'apiKey', 'sk_xxxxxxxx'], { env: envWithCfgDir(), parseJson: false });
-    const unsetOut = runCli(['config', 'unset', 'apiKey'], { env: envWithCfgDir(), parseJson: false });
+    runCli(['config', 'set', 'apiKey', 'sk_xxxxxxxx'], { env: envWithCfgDir() });
+    const unsetOut = runCli(['config', 'unset', 'apiKey'], { env: envWithCfgDir() });
     expect(unsetOut.exitCode).toBe(0);
-    const showOut = runCli(['config', 'show'], { env: envWithCfgDir(), parseJson: false });
-    expect(showOut.stdout).toMatch(/no configuration set/);
+    expect(unsetOut.json?.removed).toBe('apiKey');
+    const showOut = runCli(['config', 'show'], { env: envWithCfgDir() });
+    expect(showOut.json?.config).toEqual({});
   });
 });
 

--- a/packages/bitbadgesjs-sdk/src/cli/integration/cli-misc.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/cli-misc.spec.ts
@@ -21,10 +21,20 @@ describe('bb completion', () => {
   it('emits a bash-compatible completion script', () => {
     const out = runCli(['completion'], { parseJson: false });
     expect(out.exitCode).toBe(0);
-    // Must include the function definition + at least one subcommand name.
-    expect(out.stdout).toContain('_bitbadges_cli_completions()');
+    // Must include the function definition + at least one subcommand name +
+    // the registrations for both binary names.
+    expect(out.stdout).toContain('_bitbadges_cli_complete()');
     expect(out.stdout).toContain('build');
     expect(out.stdout).toContain('compgen');
+    expect(out.stdout).toContain('complete -F _bitbadges_cli_complete bitbadges-cli');
+    expect(out.stdout).toContain('complete -F _bitbadges_cli_complete bb');
+  });
+
+  it('emits a nested case branch for at least one multi-level command path', () => {
+    // v2 of the generator walks the full tree, so `auctions create` (or
+    // any other 2-level subcommand) should appear as a quoted case key.
+    const out = runCli(['completion'], { parseJson: false });
+    expect(out.stdout).toMatch(/'(auctions|bounties|subscriptions|crowdfunds|smart-tokens|nfts) [a-z-]+'\)/);
   });
 });
 

--- a/packages/bitbadgesjs-sdk/src/cli/utils/denom.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/denom.ts
@@ -122,11 +122,11 @@ export function requireBbDenom(input: string, ctx: string): string {
  */
 export function requireSkipGoDenom(input: string, ctx: string): string {
   if (!input || typeof input !== 'string' || input.trim().length === 0) {
-    throw new Error(`Missing denom for ${ctx}.`);
+    throw bbError(BBErrorCode.UNKNOWN_TOKEN, `Missing denom for ${ctx}.`);
   }
   const trimmed = input.trim();
   if (trimmed !== input) {
-    throw new Error(`Denom "${input}" for ${ctx} has leading/trailing whitespace.`);
+    throw bbError(BBErrorCode.UNKNOWN_TOKEN, `Denom "${input}" for ${ctx} has leading/trailing whitespace.`);
   }
   // Anything else — a u-prefix native denom, an ibc/... hash, a factory
   // path, etc. — is the caller's responsibility. Skip's resolver will

--- a/packages/bitbadgesjs-sdk/src/cli/utils/suggestions.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/suggestions.spec.ts
@@ -1,0 +1,71 @@
+import { Command } from 'commander';
+import { enableSuggestionsTreeWide } from './suggestions.js';
+
+/**
+ * `enableSuggestionsTreeWide` is a defensive helper — Commander 14 already
+ * defaults `_showSuggestionAfterError = true` on every Command, but we
+ * explicitly set it everywhere so a future Commander default change (or
+ * a subtree that gets the flag flipped off elsewhere) doesn't silently
+ * disable "did you mean?" suggestions.
+ *
+ * These tests assert the post-call state (true everywhere) and that the
+ * walk doesn't skip nested levels.
+ */
+describe('enableSuggestionsTreeWide', () => {
+  function getFlag(cmd: Command): boolean {
+    return (cmd as any)._showSuggestionAfterError === true;
+  }
+
+  it('leaves suggestions enabled on the root command', () => {
+    const root = new Command('root');
+    enableSuggestionsTreeWide(root);
+    expect(getFlag(root)).toBe(true);
+  });
+
+  it('keeps the flag set on every nested subcommand', () => {
+    const root = new Command('root');
+    const child = root.command('child');
+    const grandchild = child.command('grandchild');
+    enableSuggestionsTreeWide(root);
+    expect(getFlag(root)).toBe(true);
+    expect(getFlag(child)).toBe(true);
+    expect(getFlag(grandchild)).toBe(true);
+  });
+
+  it('explicitly re-enables suggestions on a subtree that previously turned them off', () => {
+    const root = new Command('root');
+    const child = root.command('child');
+    const grandchild = child.command('grandchild');
+    // Simulate some other plumbing turning suggestions off on a subtree.
+    child.showSuggestionAfterError(false);
+    grandchild.showSuggestionAfterError(false);
+    expect(getFlag(child)).toBe(false);
+    expect(getFlag(grandchild)).toBe(false);
+
+    enableSuggestionsTreeWide(root);
+
+    expect(getFlag(root)).toBe(true);
+    expect(getFlag(child)).toBe(true);
+    expect(getFlag(grandchild)).toBe(true);
+  });
+
+  it('handles a deep / wide tree without skipping nodes', () => {
+    const root = new Command('root');
+    for (let i = 0; i < 5; i++) {
+      const sub = root.command(`sub${i}`);
+      // Turn off the flag on every sub so the walk has to flip it on.
+      sub.showSuggestionAfterError(false);
+      for (let j = 0; j < 3; j++) {
+        const leaf = sub.command(`leaf${j}`);
+        leaf.showSuggestionAfterError(false);
+      }
+    }
+    enableSuggestionsTreeWide(root);
+    for (const sub of root.commands) {
+      expect(getFlag(sub)).toBe(true);
+      for (const leaf of sub.commands) {
+        expect(getFlag(leaf)).toBe(true);
+      }
+    }
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/utils/suggestions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/suggestions.ts
@@ -1,0 +1,23 @@
+/**
+ * "Did you mean?" wiring for unknown commands and unknown flags.
+ *
+ * Commander ships a `showSuggestionAfterError(true)` toggle that enables
+ * Levenshtein-based suggestions for BOTH unknown subcommands and unknown
+ * options — but only on the Command instance it's called on. Settings do
+ * NOT inherit down the subcommand tree, so a `bb collections crreate`
+ * typo (where the unknown lives at depth 2) gets no suggestion unless
+ * `collections` itself has the toggle on.
+ *
+ * `enableSuggestionsTreeWide` walks the full command tree and flips the
+ * toggle on every Command, so the suggestion fires regardless of which
+ * subcommand level the typo lands at. Call once at the bottom of CLI
+ * wiring AFTER all commands (including aliases) are registered.
+ */
+import type { Command } from 'commander';
+
+export function enableSuggestionsTreeWide(root: Command): void {
+  root.showSuggestionAfterError(true);
+  for (const sub of root.commands) {
+    enableSuggestionsTreeWide(sub);
+  }
+}

--- a/packages/bitbadgesjs-sdk/src/cli/utils/suggestions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/suggestions.ts
@@ -1,17 +1,20 @@
 /**
  * "Did you mean?" wiring for unknown commands and unknown flags.
  *
- * Commander ships a `showSuggestionAfterError(true)` toggle that enables
- * Levenshtein-based suggestions for BOTH unknown subcommands and unknown
- * options — but only on the Command instance it's called on. Settings do
- * NOT inherit down the subcommand tree, so a `bb collections crreate`
- * typo (where the unknown lives at depth 2) gets no suggestion unless
- * `collections` itself has the toggle on.
+ * Commander 14 defaults `_showSuggestionAfterError` to `true` on every
+ * Command, and the toggle DOES propagate down the tree via
+ * `copyInheritedSettings`. So in practice suggestions fire out of the
+ * box for both unknown subcommands and unknown options at any depth.
  *
- * `enableSuggestionsTreeWide` walks the full command tree and flips the
- * toggle on every Command, so the suggestion fires regardless of which
- * subcommand level the typo lands at. Call once at the bottom of CLI
- * wiring AFTER all commands (including aliases) are registered.
+ * `enableSuggestionsTreeWide` is a defensive helper: it walks the full
+ * command tree and explicitly sets the toggle on every node. Today this
+ * is a no-op (the flag is already true). Tomorrow, if a Commander upgrade
+ * changes the default or a subtree gets the flag turned off by some
+ * other plumbing (e.g. a future `addCommand` hijack), this guarantees
+ * suggestions stay on.
+ *
+ * Call once at the bottom of CLI wiring AFTER all commands (including
+ * deprecated aliases) are registered.
  */
 import type { Command } from 'commander';
 

--- a/packages/bitbadgesjs-sdk/src/cli/utils/time.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/time.spec.ts
@@ -68,4 +68,18 @@ describe('parseTimeFlag', () => {
       expect(e.message).toContain('--valid-until');
     }
   });
+
+  it('tags thrown errors with BBErrorCode.INVALID_INPUT', () => {
+    // Both the empty-input and the unparseable-duration paths should
+    // carry the canonical envelope code so agents can dispatch on it
+    // (instead of falling back to the catch-all cli_error).
+    for (const bad of ['', 'next week']) {
+      try {
+        parseTimeFlag(bad, '--expiry');
+        throw new Error('expected throw');
+      } catch (e: any) {
+        expect(e.code).toBe('invalid_input');
+      }
+    }
+  });
 });

--- a/packages/bitbadgesjs-sdk/src/cli/utils/time.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/time.ts
@@ -16,6 +16,7 @@
  */
 
 import { parseDuration } from '../../core/builders/shared.js';
+import { bbError, BBErrorCode } from './envelope.js';
 
 /**
  * Parse a time flag value into ms-since-epoch as a bigint.
@@ -29,7 +30,7 @@ import { parseDuration } from '../../core/builders/shared.js';
  */
 export function parseTimeFlag(input: string, ctx: string): bigint {
   if (!input || typeof input !== 'string' || input.trim().length === 0) {
-    throw new Error(`Missing time value for ${ctx}.`);
+    throw bbError(BBErrorCode.INVALID_INPUT, `Missing time value for ${ctx}.`);
   }
   const trimmed = input.trim();
 
@@ -46,7 +47,8 @@ export function parseTimeFlag(input: string, ctx: string): bigint {
   try {
     deltaMs = BigInt(parseDuration(trimmed));
   } catch (err: any) {
-    throw new Error(
+    throw bbError(
+      BBErrorCode.INVALID_INPUT,
       `Invalid time value "${input}" for ${ctx}. Accepts: ms-since-epoch (e.g. 1748140800000) or duration shorthand (e.g. 24h, 7d, 30d, monthly). ${err?.message ?? ''}`
     );
   }


### PR DESCRIPTION
## Summary
Ergonomics + agent-readability polish across three workstreams the user picked from the audit:

**Flag consistency**
- `-q` short alias added to the global `--quiet` flag (was long-form only).
- `-y` short alias added to `bb burner forget --yes` and `bb build --yes`.
- `--simulate` (on `bb build`) vs `--dry-run` (on `bb deploy`) help text sharpened — they are semantically distinct (`--simulate` adds an extra API call after building; `--dry-run` simulates and exits without broadcasting) and users were conflating them.

**Error surface**
- `enableSuggestionsTreeWide(program)` walks the full command tree and explicitly enables Commander's `_showSuggestionAfterError`. Commander 14 already defaults to `true`, so this is a defensive guard against future Commander default changes or sub-tree opt-outs. Verified suggestions fire end-to-end (`bb auction` → "Did you mean auctions?", `bb bouties` → "Did you mean bounties?").
- `bbError(code, message)` adopted across the remaining raw-throw sites so envelope consumers see a stable taxonomy code instead of the catch-all `cli_error`. Sweep: `utils/time.ts` (INVALID_INPUT), `utils/denom.ts` requireSkipGoDenom (UNKNOWN_TOKEN), `dev-feedback.ts` (INVALID_INPUT), `gen-tx-payload.ts` (INVALID_INPUT + NETWORK_ERROR), `sign-with-browser.ts` (INVALID_INPUT), `tool.ts` (INVALID_INPUT), `tx.ts` (NETWORK_ERROR).
- `bb settings show / set / unset` was the last data-emitting verb still writing raw plaintext to stdout — migrated to the universal `{ok, data, warnings, error}` envelope. Humans piping through `jq -r` get the same display; agents now see a parseable shape on every settings call.

**Tab completion quality**
- Full rewrite of `bb completion`. v1 emitted a flat case-statement covering only top-level commands and their direct children. v2 walks the entire Commander tree and emits one case branch per node with:
  - Subcommand-name completion at every depth.
  - Flag-name completion when the current word starts with `-`.
  - Enum value completion for options declared with `.choices(...)` (e.g. `--shell bash|zsh`).
  - Bash file completion for options whose long name ends with `file`/`path`/`dir`/`output`/`metadata`.
- Registers for both `bitbadges-cli` and `bb`, binary-agnostic case keys. No external dependencies — pure bash, works in zsh after `bashcompinit`.

## Test plan
- [x] `npm test` — 2988/2988 unit tests pass (132 suites incl. new `suggestions.spec.ts`, rebuilt `completion.spec.ts`, updated `time.spec.ts`)
- [x] `npm run test:integration` — 177/177 integration tests pass (19 suites incl. updated `cli-misc.spec.ts` completion assertion + flipped `cli-local-state.spec.ts` settings assertions to envelope shape)
- [x] `npm run build` — clean, no circular deps
- [x] `bb auction` and `bb bouties` produce "Did you mean ...?" suggestions live
- [x] `bb completion` emits a script registering both binary names and contains nested case keys (`'auctions create')`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)