### PR TITLE
fix(builders): deterministic approval ids (drop Math.random/uniqueId)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/core/builders/auction.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/auction.ts
@@ -38,7 +38,6 @@ export function buildAuction(params: AuctionParams): any {
   const bidDeadlineTs = durationToTimestamp(params.bidDeadline || '7d');
   const acceptEndTs = String(Number(bidDeadlineTs) + Number(parseDuration(params.acceptWindow || '7d')));
   const sellerAddr = params.seller || params.creator || '';
-  const randomId = () => Math.random().toString(16).slice(2, 18);
 
   // Mint the auction NFT (1x token 1) on settlement. The frontend
   // AuctionRegistry calls this `mintToSellerBalances`, but the actual
@@ -76,7 +75,7 @@ export function buildAuction(params: AuctionParams): any {
       fromListId: 'Mint',
       toListId: 'All',
       initiatedByListId: sellerAddr,
-      approvalId: `auction-mint-to-winner-${randomId()}`,
+      approvalId: 'auction-mint-to-winner',
       ...approvalMetadata(
         'Accept Bid',
         'Seller mints the NFT directly to the winning bidder during the accept window'
@@ -109,7 +108,7 @@ export function buildAuction(params: AuctionParams): any {
       fromListId: '!Mint',
       toListId: BURN_ADDRESS,
       initiatedByListId: 'All',
-      approvalId: `auction-burn-${randomId()}`,
+      approvalId: 'auction-burn',
       ...approvalMetadata('Burn', 'Burn the auction token'),
       transferTimes: FOREVER,
       tokenIds: [{ start: '1', end: '1' }],

--- a/packages/bitbadgesjs-sdk/src/core/builders/bid.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/bid.ts
@@ -11,7 +11,7 @@ import {
   resolveCoin,
   toBaseUnits,
   durationToTimestamp,
-  uniqueId,
+  stableHashId,
   buildUserApprovalMsg,
   approvalMetadata
 } from './shared.js';
@@ -37,7 +37,18 @@ export function buildBid(params: BidParams): any {
   const coin = resolveCoin(params.denom);
   const basePrice = toBaseUnits(params.price, coin.decimals);
   const expirationTs = durationToTimestamp(params.expiration || '7d');
-  const id = uniqueId('bid');
+  // Deterministic id so re-running the same bid is replayable/diff-able.
+  // Seeded on the shorthand params (not the resolved expiration
+  // timestamp, which is Date.now()-based); distinct bids on the same
+  // collection still get distinct ids because the seed differs.
+  const id = stableHashId('bid', {
+    address: params.address,
+    collectionId: params.collectionId,
+    tokenIds: params.tokenIds,
+    price: params.price,
+    denom: params.denom,
+    expiration: params.expiration || '7d'
+  });
   const tokenIds = parseTokenIdRange(params.tokenIds);
 
   const approval = {

--- a/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
@@ -36,6 +36,32 @@ function verifyBuilder(msg: any) {
   return verifyStandardsCompliance({ messages: [msg] });
 }
 
+/** Every approvalId + amountTrackerId in a built msg, in document order. */
+function trackedIds(msg: any): string[] {
+  const v = msg.value ?? msg;
+  const approvals = [
+    ...(v.collectionApprovals ?? []),
+    ...(v.incomingApprovals ?? []),
+    ...(v.outgoingApprovals ?? [])
+  ];
+  const ids: string[] = [];
+  for (const a of approvals) {
+    if (a?.approvalId) ids.push(a.approvalId);
+    const t = a?.approvalCriteria?.maxNumTransfers?.amountTrackerId;
+    if (t) ids.push(t);
+  }
+  return ids;
+}
+
+/**
+ * Asserts the verifier returns zero violations of any kind (not just the
+ * builder's own standard). Surfaces the violation list on failure.
+ */
+function expectCleanVerification(msg: any) {
+  const vr = verifyBuilder(msg);
+  expect({ valid: vr.valid, violations: vr.violations }).toEqual({ valid: true, violations: [] });
+}
+
 /** Required metadata fields for collection-style builders (post-#0371). */
 const META = { name: 'Test', description: 'Test description for the spec.', image: 'ipfs://test-image' };
 
@@ -110,8 +136,9 @@ describe('vault builder', () => {
   test('has deposit and withdrawal approvals', () => {
     expect(r.collectionApprovals.length).toBe(2);
     const ids = r.collectionApprovals.map((a: any) => a.approvalId);
-    // Vault uses `vault-deposit` + a randomized `vault-withdraw-<hex>`
-    // id to match VaultApprovalRegistry's collision-avoidance pattern.
+    // Vault uses `vault-deposit` + a deterministic `vault-withdraw-<hex>`
+    // id. The `vault-withdraw-` prefix is required: the frontend's
+    // `isVaultWithdrawalTier` does `startsWith('vault-withdraw-')`.
     expect(ids).toContain('vault-deposit');
     expect(ids.some((id: string) => id.startsWith('vault-withdraw-'))).toBe(true);
   });
@@ -123,8 +150,8 @@ describe('vault builder', () => {
     }
   });
 
-  // Helper: the withdraw approval has a random suffix, so tests find it
-  // by prefix rather than exact match.
+  // The withdraw approval has a deterministic hash suffix, so tests find
+  // it by the (FE-required) `vault-withdraw-` prefix, not exact match.
   const findWithdraw = (approvals: any[]) =>
     approvals.find((a: any) => typeof a.approvalId === 'string' && a.approvalId.startsWith('vault-withdraw-'));
 
@@ -149,10 +176,21 @@ describe('vault builder', () => {
     expect(migration.toListId).toBe('bb1recovery');
   });
 
-  test('passes verification', () => {
-    const vr = verifyBuilder(msg);
-    expect(vr.violations.filter((vi: any) => vi.standard === 'Vault')).toEqual([]);
-    expect(vr.violations.filter((vi: any) => vi.standard === 'Smart Token')).toEqual([]);
+  test('deterministic — identical params produce a byte-identical msg', () => {
+    expect(buildVault({ backingCoin: 'USDC', ...META })).toEqual(
+      buildVault({ backingCoin: 'USDC', ...META })
+    );
+  });
+
+  test('withdraw id is a stable hash, not Math.random', () => {
+    const a = findWithdraw(val(buildVault({ backingCoin: 'USDC', ...META })).collectionApprovals);
+    const b = findWithdraw(val(buildVault({ backingCoin: 'USDC', ...META })).collectionApprovals);
+    expect(a.approvalId).toBe(b.approvalId);
+    expect(a.approvalId.startsWith('vault-withdraw-')).toBe(true);
+  });
+
+  test('passes verification with zero violations', () => {
+    expectCleanVerification(msg);
   });
 });
 
@@ -332,8 +370,16 @@ describe('auction builder', () => {
     const mint = r.collectionApprovals.find((a: any) => a.fromListId === 'Mint');
     expect(mint.approvalCriteria.maxNumTransfers.overallMaxNumTransfers).toBe('1');
   });
-  test('passes verification', () => {
-    expect(verifyBuilder(msg).violations.filter((vi: any) => vi.standard === 'Auction')).toEqual([]);
+  test('deterministic approval ids — no Math.random', () => {
+    // transferTimes are Date.now()-relative (pre-existing, out of scope),
+    // so assert id determinism rather than full-msg deep-equal.
+    expect(trackedIds(buildAuction({ ...META }))).toEqual(trackedIds(buildAuction({ ...META })));
+    expect(r.collectionApprovals.map((a: any) => a.approvalId)).toEqual([
+      'auction-mint-to-winner', 'auction-burn'
+    ]);
+  });
+  test('passes verification with zero violations', () => {
+    expectCleanVerification(msg);
   });
 });
 
@@ -353,8 +399,21 @@ describe('product-catalog builder', () => {
       expect(p.approvalCriteria.coinTransfers[0].to).toBe('bb1store');
     }
   });
-  test('passes verification', () => {
-    expect(verifyBuilder(msg).violations.filter((vi: any) => vi.standard === 'Products')).toEqual([]);
+  test('deterministic — identical params produce a byte-identical msg', () => {
+    const p = {
+      products: [{ name: 'T-Shirt', price: 25, denom: 'USDC' }, { name: 'Mug', price: 15, denom: 'USDC', maxSupply: 50 }],
+      storeAddress: 'bb1store',
+      ...META
+    };
+    expect(buildProductCatalog(p)).toEqual(buildProductCatalog(p));
+  });
+  test('purchase ids are 1-based index, burn id is stable', () => {
+    expect(r.collectionApprovals.map((a: any) => a.approvalId)).toEqual([
+      'product-purchase-1', 'product-purchase-2', 'product-burn'
+    ]);
+  });
+  test('passes verification with zero violations', () => {
+    expectCleanVerification(msg);
   });
 });
 
@@ -372,8 +431,19 @@ describe('prediction-market builder', () => {
   test('settlement voting challenges', () => {
     expect(r.collectionApprovals.filter((a: any) => a.approvalCriteria?.votingChallenges?.length > 0).length).toBeGreaterThanOrEqual(2);
   });
-  test('passes verification', () => {
-    expect(verifyBuilder(msg).violations.filter((vi: any) => vi.standard === 'Prediction Market')).toEqual([]);
+  test('deterministic — identical params produce a byte-identical msg', () => {
+    expect(buildPredictionMarket({ verifier: 'bb1verifier', ...META })).toEqual(
+      buildPredictionMarket({ verifier: 'bb1verifier', ...META })
+    );
+  });
+  test('seven distinct pm-<role>-<hash> approval ids, stable across calls', () => {
+    const ids = r.collectionApprovals.map((a: any) => a.approvalId);
+    expect(ids.length).toBe(7);
+    expect(new Set(ids).size).toBe(7);
+    expect(ids.every((id: string) => /^pm-(mint|transfer|redeem|settle-(yes|no|push-yes|push-no))-[0-9a-f]{16}$/.test(id))).toBe(true);
+  });
+  test('passes verification with zero violations', () => {
+    expectCleanVerification(msg);
   });
 });
 
@@ -495,6 +565,21 @@ describe('bid builder', () => {
     expect(ct.overrideToWithInitiator).toBe(true);
   });
   test('auto-deletes', () => { expect(msg.value.incomingApprovals[0].approvalCriteria.autoDeletionOptions.afterOneUse).toBe(true); });
+
+  test('deterministic approval id — no Math.random/uniqueId', () => {
+    const p = { address: 'bb1bidder', collectionId: '1', tokenIds: '3', price: 25, denom: 'BADGE' };
+    const a = buildBid({ ...p }).value.incomingApprovals[0];
+    const b = buildBid({ ...p }).value.incomingApprovals[0];
+    expect(a.approvalId).toBe(b.approvalId);
+    expect(a.approvalId.startsWith('bid-')).toBe(true);
+    // amountTrackerId stays in lockstep with approvalId
+    expect(a.approvalCriteria.maxNumTransfers.amountTrackerId).toBe(a.approvalId);
+    // distinct bids on the same collection get distinct ids
+    expect(buildBid({ ...p, price: 26 }).value.incomingApprovals[0].approvalId).not.toBe(a.approvalId);
+  });
+  test('passes verification with zero violations', () => {
+    expectCleanVerification(msg);
+  });
 });
 
 describe('pm-sell-intent builder', () => {

--- a/packages/bitbadgesjs-sdk/src/core/builders/prediction-market.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/prediction-market.ts
@@ -14,7 +14,8 @@ import {
   tokenMetadataEntry,
   metadataFromFlat,
   MetadataMissingError,
-  approvalMetadata
+  approvalMetadata,
+  stableHashId
 } from './shared.js';
 
 export interface PredictionMarketParams {
@@ -33,18 +34,30 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
   const yesTokenIds = [{ start: '1', end: '1' }];
   const noTokenIds = [{ start: '2', end: '2' }];
 
-  const randomId = () => Math.random().toString(16).slice(2, 18);
-  const mintId = randomId();
-  const transferId = randomId();
-  const redeemId = randomId();
-  const settleYesId = randomId();
-  const settleNoId = randomId();
-  const settlePushYesId = randomId();
-  const settlePushNoId = randomId();
+  // Deterministic, replayable ids derived from the market's params. The
+  // `pm-<role>-` prefix shape matches the frontend PredictionMarketRegistry
+  // and the review-ux known-prefix list; only the suffix changed (was
+  // Math.random). Each role keeps a distinct prefix so the seven ids stay
+  // distinct within the collection.
+  const pmSeed = {
+    verifier: params.verifier,
+    denom: coin.denom,
+    uri: params.uri || '',
+    name: params.name || '',
+    description: params.description || '',
+    image: params.image || ''
+  };
+  const mintId = stableHashId('pm-mint', pmSeed);
+  const transferId = stableHashId('pm-transfer', pmSeed);
+  const redeemId = stableHashId('pm-redeem', pmSeed);
+  const settleYesId = stableHashId('pm-settle-yes', pmSeed);
+  const settleNoId = stableHashId('pm-settle-no', pmSeed);
+  const settlePushYesId = stableHashId('pm-settle-push-yes', pmSeed);
+  const settlePushNoId = stableHashId('pm-settle-push-no', pmSeed);
 
   // 1. Paired Mint — mint both YES and NO by depositing USDC
   const pairedMint = {
-    approvalId: `pm-mint-${mintId}`,
+    approvalId: mintId,
     ...approvalMetadata(
       'Deposit',
       'Deposit to receive equal YES and NO outcome tokens'
@@ -83,7 +96,7 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
 
   // 2. Free transfer — tokens are freely transferable
   const freeTransfer = {
-    approvalId: `pm-transfer-${transferId}`,
+    approvalId: transferId,
     ...approvalMetadata(
       'Transferable',
       'Freely trade YES and NO tokens between any addresses'
@@ -100,7 +113,7 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
 
   // 3. Pre-Settlement Redeem — burn both YES+NO to get USDC back
   const preRedeem = {
-    approvalId: `pm-redeem-${redeemId}`,
+    approvalId: redeemId,
     ...approvalMetadata(
       'Redeem Pair',
       'Burn equal YES and NO tokens to reclaim your deposit before settlement'
@@ -138,7 +151,7 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
         perToAddressMaxNumTransfers: '0',
         perFromAddressMaxNumTransfers: '0',
         perInitiatedByAddressMaxNumTransfers: '0',
-        amountTrackerId: `pm-redeem-${redeemId}`,
+        amountTrackerId: redeemId,
         resetTimeIntervals: { startTime: '0', intervalLength: '0' }
       },
       // No overrides: holder self-initiates their own pair burn and
@@ -230,22 +243,22 @@ export function buildPredictionMarket(params: PredictionMarketParams): any {
 
   // Win: burn 1 token → 1 coin. Push: burn 2 tokens → 1 coin.
   const settleYes = settlementApproval(
-    `pm-settle-yes-${settleYesId}`, yesTokenIds, `pm-settle-yes-${settleYesId}`, '1', '1',
+    settleYesId, yesTokenIds, settleYesId, '1', '1',
     'YES wins',
     'Burn YES tokens to claim full payout after YES outcome is confirmed'
   );
   const settleNo = settlementApproval(
-    `pm-settle-no-${settleNoId}`, noTokenIds, `pm-settle-no-${settleNoId}`, '1', '1',
+    settleNoId, noTokenIds, settleNoId, '1', '1',
     'NO wins',
     'Burn NO tokens to claim full payout after NO outcome is confirmed'
   );
   const settlePushYes = settlementApproval(
-    `pm-settle-push-yes-${settlePushYesId}`, yesTokenIds, `pm-settle-push-yes-${settlePushYesId}`, '2', '1',
+    settlePushYesId, yesTokenIds, settlePushYesId, '2', '1',
     'Push (YES side)',
     'Burn YES tokens to claim half payout after push (draw) outcome'
   );
   const settlePushNo = settlementApproval(
-    `pm-settle-push-no-${settlePushNoId}`, noTokenIds, `pm-settle-push-no-${settlePushNoId}`, '2', '1',
+    settlePushNoId, noTokenIds, settlePushNoId, '2', '1',
     'Push (NO side)',
     'Burn NO tokens to claim half payout after push (draw) outcome'
   );

--- a/packages/bitbadgesjs-sdk/src/core/builders/product-catalog.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/product-catalog.ts
@@ -42,14 +42,13 @@ export interface ProductCatalogParams {
 
 export function buildProductCatalog(params: ProductCatalogParams): any {
   const { products, storeAddress } = params;
-  const randomId = () => Math.random().toString(16).slice(2, 18);
 
   const purchaseApprovals = products.map((product, i) => {
     const idx = i + 1;
     const coin = resolveCoin(product.denom);
     const basePrice = toBaseUnits(product.price, coin.decimals);
     const tokenIds = [{ start: String(idx), end: String(idx) }];
-    const approvalId = `product-purchase-${randomId()}`;
+    const approvalId = `product-purchase-${idx}`;
 
     const predeterminedBalances = {
       ...mintToBurnBalances(),
@@ -101,7 +100,7 @@ export function buildProductCatalog(params: ProductCatalogParams): any {
 
   // Burn approval: anyone can burn their tokens
   const burnApproval = {
-    approvalId: `product-burn-${randomId()}`,
+    approvalId: 'product-burn',
     ...approvalMetadata('Burn', 'Burn product token'),
     fromListId: '!Mint',
     toListId: BURN_ADDRESS,

--- a/packages/bitbadgesjs-sdk/src/core/builders/shared.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/shared.ts
@@ -107,6 +107,20 @@ export function uniqueId(prefix?: string): string {
   return prefix ? `${prefix}-${rand}` : rand;
 }
 
+/**
+ * Deterministic id derived from a seed: identical seeds always yield the
+ * identical id. Use this — never `Math.random()` or `uniqueId()` — for
+ * any approval/tracker id, so two builder calls with the same params
+ * produce byte-identical, diff-able, replayable on-chain artifacts.
+ * Distinct seeds yield distinct ids, so multiple instances targeting the
+ * same collection don't collide.
+ */
+export function stableHashId(prefix: string, seed: string | object): string {
+  const data = typeof seed === 'string' ? seed : JSON.stringify(seed);
+  const hash = crypto.createHash('sha256').update(data).digest('hex').slice(0, 16);
+  return `${prefix}-${hash}`;
+}
+
 // ── Common builder helpers ───────────────────────────────────────────────────
 
 /**

--- a/packages/bitbadgesjs-sdk/src/core/builders/vault.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/vault.ts
@@ -18,7 +18,8 @@ import {
   tokenMetadataEntry,
   metadataFromFlat,
   MetadataMissingError,
-  approvalMetadata
+  approvalMetadata,
+  stableHashId
 } from './shared.js';
 
 export interface VaultParams {
@@ -73,7 +74,18 @@ export function buildVault(params: VaultParams): any {
       fromListId: '!Mint',
       toListId: backingAddr,
       initiatedByListId: 'All',
-      approvalId: `vault-withdraw-${Math.random().toString(16).slice(2, 10)}`,
+      // Deterministic suffix (not Math.random) for replayable, diff-able
+      // builds. The `vault-withdraw-` prefix is load-bearing: the
+      // frontend's `isVaultWithdrawalTier` does
+      // `approvalId.startsWith('vault-withdraw-')`, so a bare constant
+      // would make the website fail to classify CLI-built vaults.
+      approvalId: stableHashId('vault-withdraw', {
+        backing: coin.denom,
+        symbol,
+        dailyWithdrawLimit: params.dailyWithdrawLimit || 0,
+        require2fa: params.require2fa || '',
+        emergencyRecovery: params.emergencyRecovery || ''
+      }),
       ...approvalMetadata(
         'Withdrawal',
         'Burn vault tokens to withdraw backing coins.'


### PR DESCRIPTION
## Summary

Five SDK builders generated approval ids with `Math.random()` (auction, vault, product-catalog, prediction-market) or `uniqueId()` (bid). Two builder calls with identical params produced different on-chain artifacts — non-replayable, non-diffable, and collision-risky on scripted/agent retries.

Closes autopilot backlog **0405** (vault) and **0406 item 6.2** (the remaining Math.random sites).

## Approach — align each builder to its canonical reference, change only the nondeterministic suffix

| Builder | Before | After | Why |
|---|---|---|---|
| auction | `auction-mint-to-winner-<rand>` | `auction-mint-to-winner` (bare) | matches `builder/presets/auction.ts` incl. its bare `amountTrackerId`; no FE classifier |
| product-catalog | `product-purchase-<rand>`, `product-burn-<rand>` | `product-purchase-${idx}`, `product-burn` | matches `builder/presets/products.ts` exactly |
| prediction-market | `pm-<role>-<rand>` ×7 | `pm-<role>-<stable hash>` | preserves FE `PredictionMarketRegistry` shape; renaming would be an out-of-scope shape change |
| vault | `vault-withdraw-<Math.random>` | `vault-withdraw-<stable hash>` | **kept the `vault-withdraw-` prefix**: FE `isVaultWithdrawalTier` does `startsWith('vault-withdraw-')`, so 0405's bare-constant recommendation would break the website's vault rendering |
| bid | `uniqueId('bid')` | `stableHashId('bid', {params})` | existing-collection builder; distinct bids still get distinct ids, identical bids are replayable |

New shared helper `stableHashId(prefix, seed)` — sha256, 16 hex chars.

**Deliberate deviation from 0405:** the ticket recommended a bare `vault-withdraw` constant. The frontend's `isVaultWithdrawalTier` (`src/utils/VaultApprovalRegistry.ts`) requires the trailing-hyphen prefix; a bare constant would make CLI-built vaults invisible to the website's withdrawal-tier UI. The deterministic-suffix form satisfies 0405's acceptance (two `buildVault(p)` calls are byte-identical) while preserving FE interop.

## Test plan

- [x] Per-builder **determinism** test: identical params → byte-identical msg (or identical ids where `transferTimes` are `Date.now()`-relative — auction/bid, pre-existing & out of scope)
- [x] Per-builder **zero-violation** `verifyStandardsCompliance` assertion (no warnings of any standard, incl. common checks)
- [x] `vault-withdraw-` / `pm-<role>-` prefix shapes asserted (FE-interop guards)
- [x] Full SDK unit suite green: 133 suites / 2997 tests
- [x] `npm run build` clean (tsc, no circular deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)