### PR TITLE
refactor(cli): standardized deploy-flags interface (DRY)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
@@ -15,6 +15,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1AddressStrict } from '../utils/address.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import { resolveAmount } from '../utils/amount.js';
 import {
   doesCollectionFollowAuctionProtocol,
@@ -134,6 +135,7 @@ addOutputFlags(
   } catch (err) { emitError(err); }
 });
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     auctionsCommand
@@ -146,7 +148,7 @@ addOutputFlags(
       .option('--base-units', 'Treat --amount as already-in-base-units')
       .option('--approval-id <id>', 'Approval id for the bid (random by default)')
   )
-).action(
+)).action(
   async (
     collectionId: string,
     opts: NetworkFlags & OutputFlags & { creator: string; amount: string; denom: string; baseUnits?: boolean; approvalId?: string }
@@ -179,10 +181,10 @@ addOutputFlags(
         transferTimes,
         approvalId
       });
-      emit({
+      await runEmitOrDeploy({
         typeUrl: '/tokenization.MsgSetIncomingApproval',
         value: { creator, collectionId: String(collectionId), approval }
-      }, opts);
+      }, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
     } catch (err) { emitError(err); }
   }
 ).addHelpText('after', `
@@ -191,6 +193,7 @@ Examples:
   $ bb auctions place-bid 42 --creator bb1abc...xyz --amount 25000000 --denom USDC --base-units | bb deploy
 `);
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     auctionsCommand
@@ -200,19 +203,20 @@ addOutputFlags(
       .argument('<approval-id>', 'Bid approval id to cancel')
       .requiredOption('--creator <address>', 'Bidder address (bb1.../0x — auto-normalized)')
   )
-).action(async (collectionId: string, approvalId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
+)).action(async (collectionId: string, approvalId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   try {
     const creator = requireBb1AddressStrict(opts.creator, '--creator');
-    emit({
+    await runEmitOrDeploy({
       typeUrl: '/tokenization.MsgDeleteIncomingApproval',
       value: { creator, collectionId: String(collectionId), approvalId }
-    }, opts);
+    }, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
   } catch (err) { emitError(err); }
 }).addHelpText('after', `
 Examples:
   $ bb auctions cancel-bid 42 a1b2c3d4e5f6 --creator bb1abc...xyz | bb deploy
 `);
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     auctionsCommand
@@ -223,7 +227,7 @@ addOutputFlags(
       .requiredOption('--creator <address>', 'Seller address (bb1.../0x — auto-normalized)')
       .requiredOption('--bidder <address>', 'Bidder address (the bid approval\'s owner)')
   )
-).action(
+)).action(
   async (
     collectionId: string,
     bidApprovalId: string,
@@ -244,9 +248,10 @@ addOutputFlags(
           `Warning: --creator ${seller} does not match seller ${details.sellerAddress}. The mint approval will reject this tx.\n`
         );
       }
-      emit(
+      await runEmitOrDeploy(
         buildAcceptAuctionBidMsg(seller, String(collectionId), bidApprovalId, bidder, details.mintApproval.approvalId),
-        opts
+        opts,
+        { emit: (m) => emit(m, opts), expectedAddress: seller }
       );
     } catch (err) { emitError(err); }
   }

--- a/packages/bitbadgesjs-sdk/src/cli/commands/bounties.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/bounties.ts
@@ -29,6 +29,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import {
   doesCollectionFollowBountyProtocol,
   validateBountyCollection,
@@ -260,15 +261,17 @@ Examples:
 
 // ── bounties claim-refund ────────────────────────────────────────────────
 
-addOutputFlags(
-  addNetworkFlags(
-    bountiesCommand
-      .command('claim-refund')
-      .description(
-        'Post-deadline refund: emit MsgTransferTokens against the expire approval. Pipe to `bb deploy`. The bounty is callable by anyone after the window closes, but funds always flow to the submitter.'
-      )
-      .argument('<collection-id>', 'Bounty collection ID')
-      .requiredOption('--creator <address>', 'Address signing the refund tx (bb1.../0x — auto-normalized)')
+addDeployOptions(
+  addOutputFlags(
+    addNetworkFlags(
+      bountiesCommand
+        .command('claim-refund')
+        .description(
+          'Post-deadline refund: MsgTransferTokens against the expire approval. Emit (pipe to `bb deploy`) or broadcast inline with --browser/--burner. Callable by anyone after the window closes; funds always flow to the submitter.'
+        )
+        .argument('<collection-id>', 'Bounty collection ID')
+        .requiredOption('--creator <address>', 'Address signing the refund tx (bb1.../0x — auto-normalized)')
+    )
   )
 ).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   try {
@@ -286,7 +289,7 @@ addOutputFlags(
       process.stderr.write('Warning: the expire approval has already been executed. Submitting again will be rejected on-chain.\n');
     }
     const msg = buildBountyRefundMsg(creator, String(collectionId), details.expireApproval);
-    emit(msg, opts);
+    await runEmitOrDeploy(msg, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
   } catch (err) {
     emitError(err);
   }

--- a/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
@@ -1,11 +1,10 @@
 import { Command } from 'commander';
-import { readJsonInput, addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
+import { readJsonInput, addNetworkOptions } from '../utils/io.js';
 import { emit as emitEnvelope, isQuiet, type EnvelopeWarning } from '../utils/envelope.js';
 import { tagHelpGroups } from '../utils/help-groups.js';
 import { renderReview, renderValidate, renderResolvedMetadata, renderSimulate, collectResolvedEntries, type ResolvedEntry } from '../utils/terminal.js';
 import { isCollectionMsg, normalizeToCreateOrUpdate } from '../utils/normalizeMsg.js';
-import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
-import { runBurnerCreate, pickBurner, type BurnerNetwork } from '../utils/burner.js';
+import { addDeployOptions, isDeployRequested, executeDeploy } from '../utils/deploy-options.js';
 import { requireBbDenom, DEFAULT_FEE_DENOM } from '../utils/denom.js';
 import { requireBb1AddressStrict } from '../utils/address.js';
 
@@ -340,135 +339,15 @@ async function emit(
     meta: Object.keys(meta).length > 0 ? meta : undefined
   });
 
-  // ── --deploy-with-browser ───────────────────────────────────────────────
-  // Composes build + browser-bridge broadcast in one step. Equivalent
-  // to piping the JSON output to `bb cli deploy --browser --msg-stdin
-  // --manager <addr>`. The connected wallet on /sign page signs and
-  // broadcasts; account number / sequence / gas / fees are auto-handled
-  // frontend-side by TxModal.
-  if (opts.deployWithBrowser) {
-    if (opts.deployWithBurner) {
-      process.stderr.write(
-        '\nError: --deploy-with-browser and --deploy-with-burner are mutually exclusive.\n'
-      );
-      process.exit(2);
-    }
-    const networkName = resolveNetwork(opts);
-    const apiUrl = getApiUrl(opts);
-    const apiKey = getApiKeyForNetwork(opts);
-    const { bridgeSign, resolveFrontendUrl } = await import('../auth/browser-bridge.js');
-    const frontendUrl = resolveFrontendUrl(networkName, opts.frontendUrl);
-    const expectedAddress = opts.expectedAddress ?? opts.manager ?? opts.creator;
-    const requestedTimeoutSec = opts.timeout ? Math.min(1800, Math.max(60, Number(opts.timeout))) : 300;
-    process.stderr.write(`\nOpening browser to ${frontendUrl}/sign for wallet signature + broadcast...\n`);
-    try {
-      const result = await bridgeSign({
-        mode: 'tx',
-        payload: {
-          chain: 'cosmos',
-          txsInfo: [{ type: outData.typeUrl, msg: outData.value }],
-          expectedAddress,
-          signOnly: !!opts.signOnly,
-        },
-        baseUrl: apiUrl,
-        frontendUrl,
-        apiKey,
-        timeoutMs: requestedTimeoutSec * 1000,
-        noOpen: opts.open === false,
-      });
-      if (result.error) {
-        process.stderr.write(`Browser broadcast cancelled or rejected: ${result.error}\n`);
-        process.exit(1);
-      }
-      const payload: any = opts.signOnly
-        ? {
-            success: !!result.signedTx,
-            path: 'browser',
-            mode: 'sign-only',
-            signedTx: result.signedTx ?? null,
-            chain: result.chain ?? 'cosmos',
-          }
-        : {
-            success: !!result.hash,
-            path: 'browser',
-            mode: 'sign-and-broadcast',
-            txHash: result.hash ?? null,
-            chain: result.chain ?? 'cosmos',
-          };
-      process.stdout.write('\n' + JSON.stringify(payload, null, 2) + '\n');
-      if (!payload.success) process.exit(1);
-      return;
-    } catch (err: any) {
-      process.stderr.write(`Browser broadcast failed: ${err?.message || err}\n`);
-      process.exit(1);
-    }
-  }
-
-  // ── --deploy-with-burner ────────────────────────────────────────────────
-  // Composes the build + burner-deploy pipeline into one step.
-  // Equivalent to piping the JSON output to `bb cli deploy --burner
-  // --msg-stdin --manager <addr>`. CREATE-ONLY: the burner flow rejects
-  // updates, transfers, approvals — runBurnerCreate throws a clear error
-  // if the resolved msg isn't MsgCreateCollection (or
-  // MsgUniversalUpdateCollection with collectionId=0).
-  if (opts.deployWithBurner) {
-    if (!opts.manager) {
-      process.stderr.write(
-        '\nError: --deploy-with-burner requires --manager <bb1...>. The burner is a throwaway signer; the manager address captures lasting collection ownership.\n'
-      );
-      process.exit(2);
-    }
-
-    const networkName = resolveNetwork(opts);
-    const network: BurnerNetwork = networkName as NetworkMode;
-    const apiUrl = getApiUrl(opts);
-    const nodeUrl = (opts as any).nodeUrl || NETWORK_CONFIGS[network].nodeUrl;
-    const apiKey = getApiKeyForNetwork(opts);
-
-    if ((opts.fund ?? 'faucet') === 'faucet' && !apiKey && network !== 'local') {
-      process.stderr.write(
-        'Warning: --fund faucet requires an API key on non-local networks. Pass --api-key or run `bb settings set apiKey <key>`.\n'
-      );
-    }
-
-    const choice = await pickBurner({
-      network,
-      nodeUrl,
-      forceNew: Boolean(opts.new),
-      reuseSelector: opts.reuse
+  // Optionally broadcast the just-built msg inline. The envelope above
+  // is always emitted first (so `bb build … | bb deploy` and review
+  // tooling are unaffected); a deploy flag additionally executes the
+  // shared browser/burner path. Flags + executor live in
+  // cli/utils/deploy-options.ts and are identical across every command.
+  if (isDeployRequested(opts as any)) {
+    await executeDeploy(outData, opts as any, {
+      expectedAddress: opts.expectedAddress ?? opts.manager ?? opts.creator
     });
-
-    try {
-      const result = await runBurnerCreate({
-        msg: outData,
-        network,
-        apiUrl,
-        nodeUrl,
-        manager: opts.manager,
-        fund: opts.fund === 'manual' ? 'manual' : 'faucet',
-        apiKey,
-        fee: { amount: String(opts.fee ?? '0'), denom: requireBbDenom(String(opts.feeDenom ?? DEFAULT_FEE_DENOM), '--fee-denom') },
-        gas: Number(opts.gas ?? 400000),
-        reuseRecord: choice.kind === 'reuse' ? choice.record : undefined,
-        nonInteractive: Boolean(opts.nonInteractive) || !process.stdout.isTTY,
-        pollTimeoutMs: Number(opts.pollTimeout ?? 60) * 1000
-      });
-
-      const payload = {
-        success: result.success,
-        ephemeralAddress: result.ephemeralAddress,
-        recoveryPath: result.recoveryPath,
-        txHash: result.txHash,
-        collectionId: result.collectionId ?? null,
-        paused: result.paused,
-        error: result.error
-      };
-      process.stdout.write('\n' + JSON.stringify(payload, null, 2) + '\n');
-      if (!result.success && !result.paused) process.exit(1);
-    } catch (err: any) {
-      process.stderr.write(`Burner deploy failed: ${err?.message || err}\n`);
-      process.exit(1);
-    }
   }
 }
 
@@ -513,30 +392,14 @@ const sharedOpts = (cmd: Command) => {
   addOptionIfMissing(cmd, '--name <name>', 'Mode 2: collection name (required with --image + --description if --uri not set)');
   addOptionIfMissing(cmd, '--description <text>', 'Mode 2: collection description (required with --name + --image if --uri not set)');
   addOptionIfMissing(cmd, '--image <url>', 'Mode 2: collection image URI (required with --name + --description if --uri not set)');
-  // --deploy-with-burner — collapses the build + burner-deploy
-  // pipeline into a single command. CREATE-ONLY: rejects updates,
-  // transfers, approvals (the burner is a one-shot signer; ownership
-  // lives on --manager). Equivalent to:
-  //   bb cli build <preset> ... | bb cli deploy --burner --msg-stdin --manager <addr>
-  cmd.option('--deploy-with-burner', 'After building, broadcast via the throwaway burner flow (CREATE-ONLY). Requires --manager.');
-  cmd.option('--deploy-with-browser', 'After building, hand off to the BitBadges /sign page for wallet signature + broadcast. Pairs with your connected wallet (Keplr, MetaMask, etc.).');
-  cmd.option('--sign-only', 'With --deploy-with-browser: have the wallet sign but not broadcast — returns the signed tx bytes for caller-controlled broadcast.');
-  cmd.option('--frontend-url <url>', 'With --deploy-with-browser: override the frontend base URL.');
-  cmd.option('--no-open', 'With --deploy-with-browser: print the sign URL instead of auto-launching the browser.');
-  cmd.option('--timeout <seconds>', 'With --deploy-with-browser: how long to wait for the wallet to confirm (default 300, max 1800).');
-  cmd.option('--expected-address <addr>', 'With --deploy-with-browser: bb1.../0x... that the connected wallet must match. Defaults to --manager / --creator.');
-  cmd.option('--fund <mode>', 'With --deploy-with-burner: funding source for the burner (faucet | manual)', 'faucet');
-  cmd.option('--fee <amount>', 'When deploying: fee amount in base units', '0');
-  cmd.option('--fee-denom <symbol|denom>', 'When deploying: fee denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...)', DEFAULT_FEE_DENOM);
-  cmd.option('--gas <number>', 'When deploying: gas limit', '400000');
-  cmd.option('--new', 'With --deploy-with-burner: skip the burner picker and always create a fresh wallet');
-  cmd.option('--reuse <selector>', 'With --deploy-with-burner: reuse a specific saved burner by address or recovery file path');
-  cmd.option('--non-interactive', 'With --deploy-with-burner: never prompt; on any prompt point save state and exit for later resume');
-  cmd.option('--poll-timeout <seconds>', 'With --deploy-with-burner: seconds to wait for funding to land before prompting/exiting', '60');
+  // Standardized deploy flags (--browser / --burner / …) + their
+  // "Deploy" help-group tags. Identical across every tx-emitting
+  // command — see cli/utils/deploy-options.ts.
+  addDeployOptions(cmd);
 
-  // Tag every shared flag with a help group so --help renders them in
-  // categories under "Options:" (per-command flags stay ungrouped at the
-  // top). See cli/utils/help-groups.ts for the rendered order.
+  // Tag the remaining shared flags with a help group so --help renders
+  // them in categories under "Options:" (per-command flags stay
+  // ungrouped at the top). Deploy flags are tagged by addDeployOptions.
   tagHelpGroups(cmd, {
     '--uri': 'Metadata',
     '--name': 'Metadata',
@@ -555,22 +418,7 @@ const sharedOpts = (cmd: Command) => {
     '--creator': 'Builder',
     '--manager': 'Builder',
     '--simulate': 'Builder',
-    '--events': 'Builder',
-    '--deploy-with-burner': 'Deploy',
-    '--deploy-with-browser': 'Deploy',
-    '--sign-only': 'Deploy',
-    '--frontend-url': 'Deploy',
-    '--no-open': 'Deploy',
-    '--timeout': 'Deploy',
-    '--expected-address': 'Deploy',
-    '--fund': 'Deploy',
-    '--fee': 'Deploy',
-    '--fee-denom': 'Deploy',
-    '--gas': 'Deploy',
-    '--new': 'Deploy',
-    '--reuse': 'Deploy',
-    '--non-interactive': 'Deploy',
-    '--poll-timeout': 'Deploy'
+    '--events': 'Builder'
   });
 
   return cmd;

--- a/packages/bitbadgesjs-sdk/src/cli/commands/credit-tokens.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/credit-tokens.ts
@@ -22,6 +22,7 @@ import {
 } from '../utils/indexer-options.js';
 import { requireBb1AddressStrict } from '../utils/address.js';
 import { resolveNetwork } from '../utils/io.js';
+import { addDeployOptions, runEmitOrDeploy, type DeployOpts } from '../utils/deploy-options.js';
 import {
   doesCollectionFollowCreditTokenProtocol,
   extractCreditTokenTiers,
@@ -103,37 +104,34 @@ addOutputFlags(
   }
 });
 
-addOutputFlags(
-  addNetworkFlags(
-    creditTokensCommand
-      .command('purchase')
-      .description(
-        'Buy N units from ANY Credit Token collection by paying the payment denom. The standard is ' +
-        'generic — anyone can deploy one; pass its <collection-id>. As a convenience, --api-credits ' +
-        "targets BitBadges' OWN API-credits collection (one real example). Emits MsgTransferTokens to " +
-        'pipe to `bb deploy`, or use --deploy-with-browser for a one-shot. Credits are ' +
-        'NON-TRANSFERABLE: sign with the wallet that should hold them — there is no burner path.'
-      )
-      .argument('[collection-id]', 'Credit Token collection ID. Omit and pass --api-credits to use BitBadges’ own API-credits collection.')
-      .requiredOption('--creator <address>', 'Buyer address — the wallet that will HOLD the (non-transferable) credits (bb1.../0x)')
-      .requiredOption('--units <n>', 'Number of units to purchase (integer)')
-      .option(
-        '--tier <approvalId>',
-        'Tier approval id (default: the credit-scaled tier; required if only legacy per-tier approvals exist)'
-      )
-      .option('--api-credits', "Shortcut for BitBadges’ OWN API-credits collection on this network (mainnet/local; not on testnet). Mutually exclusive with <collection-id>. Any Credit Token collection works via the positional arg — this is just BitBadges’ real instance.")
-      .option('--deploy-with-browser', 'After building, hand off to the BitBadges /sign page for wallet signature + broadcast. Sign with the --creator wallet (credits are non-transferable).')
-      .option('--sign-only', 'With --deploy-with-browser: have the wallet sign but not broadcast — returns the signed tx bytes.')
-      .option('--frontend-url <url>', 'With --deploy-with-browser: override the frontend base URL.')
-      .option('--no-open', 'With --deploy-with-browser: print the sign URL instead of auto-launching the browser.')
-      .option('--timeout <seconds>', 'With --deploy-with-browser: how long to wait for the wallet to confirm (default 300, max 1800).')
+addDeployOptions(
+  addOutputFlags(
+    addNetworkFlags(
+      creditTokensCommand
+        .command('purchase')
+        .description(
+          'Buy N units from ANY Credit Token collection by paying the payment denom. The standard is ' +
+          'generic — anyone can deploy one; pass its <collection-id>. As a convenience, --api-credits ' +
+          "targets BitBadges' OWN API-credits collection (one real example). Emits MsgTransferTokens to " +
+          'pipe to `bb deploy`, or broadcast inline with --browser. Credits are NON-TRANSFERABLE: sign ' +
+          'with the wallet that should hold them (--browser pins the signer to --creator). --burner is ' +
+          'CREATE-ONLY so it is rejected here anyway.'
+        )
+        .argument('[collection-id]', 'Credit Token collection ID. Omit and pass --api-credits to use BitBadges’ own API-credits collection.')
+        .requiredOption('--creator <address>', 'Buyer address — the wallet that will HOLD the (non-transferable) credits (bb1.../0x)')
+        .requiredOption('--units <n>', 'Number of units to purchase (integer)')
+        .option(
+          '--tier <approvalId>',
+          'Tier approval id (default: the credit-scaled tier; required if only legacy per-tier approvals exist)'
+        )
+        .option('--api-credits', "Shortcut for BitBadges’ OWN API-credits collection on this network (mainnet/local; not on testnet). Mutually exclusive with <collection-id>. Any Credit Token collection works via the positional arg — this is just BitBadges’ real instance.")
+    )
   )
 ).action(
   async (
     collectionIdArg: string | undefined,
-    opts: NetworkFlags & OutputFlags & {
+    opts: NetworkFlags & OutputFlags & DeployOpts & {
       creator: string; units: string; tier?: string; apiCredits?: boolean;
-      deployWithBrowser?: boolean; signOnly?: boolean; frontendUrl?: string; open?: boolean; timeout?: string;
     }
   ) => {
     try {
@@ -191,54 +189,16 @@ addOutputFlags(
       }
       const purchaseMsg = buildPurchaseCreditTokenMsg(creator, String(collectionId), tier, units);
 
-      // One-shot browser-sign path. Credits are non-transferable, so the
-      // signer MUST be the wallet that should hold them — we pin
-      // expectedAddress to --creator and deliberately offer NO burner
-      // path (a throwaway signer would mint credits it can never move
-      // out, permanently stranding the payment). Mirrors the
-      // build.ts --deploy-with-browser bridge flow.
-      if (opts.deployWithBrowser) {
-        const { getApiUrl, getApiKeyForNetwork, resolveNetwork } = await import('../utils/io.js');
-        const { bridgeSign, resolveFrontendUrl } = await import('../auth/browser-bridge.js');
-        const networkName = resolveNetwork(opts as any);
-        const frontendUrl = resolveFrontendUrl(networkName, opts.frontendUrl);
-        const timeoutSec = opts.timeout ? Math.min(1800, Math.max(60, Number(opts.timeout))) : 300;
-        process.stderr.write(
-          `\nOpening ${frontendUrl}/sign — sign with ${creator} (credits are non-transferable; ` +
-          `they land in whatever wallet signs)...\n`
-        );
-        try {
-          const result = await bridgeSign({
-            mode: 'tx',
-            payload: {
-              chain: 'cosmos',
-              txsInfo: [{ type: purchaseMsg.typeUrl, msg: purchaseMsg.value }],
-              expectedAddress: creator,
-              signOnly: !!opts.signOnly,
-            },
-            baseUrl: getApiUrl(opts as any),
-            frontendUrl,
-            apiKey: getApiKeyForNetwork(opts as any),
-            timeoutMs: timeoutSec * 1000,
-            noOpen: opts.open === false,
-          });
-          if (result.error) {
-            process.stderr.write(`Browser broadcast cancelled or rejected: ${result.error}\n`);
-            process.exit(1);
-          }
-          const payload: any = opts.signOnly
-            ? { success: !!result.signedTx, path: 'browser', mode: 'sign-only', signedTx: result.signedTx ?? null, chain: result.chain ?? 'cosmos' }
-            : { success: !!result.hash, path: 'browser', mode: 'sign-and-broadcast', txHash: result.hash ?? null, chain: result.chain ?? 'cosmos' };
-          process.stdout.write('\n' + JSON.stringify(payload, null, 2) + '\n');
-          if (!payload.success) process.exit(1);
-          return;
-        } catch (err: any) {
-          process.stderr.write(`Browser broadcast failed: ${err?.message || err}\n`);
-          process.exit(1);
-        }
-      }
-
-      emit(purchaseMsg, opts);
+      // No deploy flag → emit JSON (pipe to `bb deploy`). --browser →
+      // broadcast inline; expectedAddress pinned to --creator because
+      // credits are non-transferable (they land in whatever wallet
+      // signs). --burner is CREATE-ONLY so the shared executor rejects
+      // it for this MsgTransferTokens — which is also what we want
+      // (a burner would strand the credits).
+      await runEmitOrDeploy(purchaseMsg, opts, {
+        emit: (m) => emit(m, opts),
+        expectedAddress: creator
+      });
     } catch (err) {
       emitError(err);
     }
@@ -249,12 +209,13 @@ Examples:
   $ bb credit-tokens purchase 42 --creator bb1buyer...xyz --units 10 | bb deploy
   $ bb credit-tokens purchase 42 --creator bb1buyer...xyz --units 10 --tier premium-tier | bb deploy
   # BitBadges' own API-credits collection (one real example), id resolved per network:
-  $ bb credit-tokens purchase --api-credits --creator bb1buyer...xyz --units 10 --deploy-with-browser
+  $ bb credit-tokens purchase --api-credits --creator bb1buyer...xyz --units 10 --browser
 
 Credits are NON-TRANSFERABLE: whatever wallet signs is where they live.
-With --deploy-with-browser, sign with the --creator wallet. There is
-intentionally no burner deploy path. The --api-credits shortcut is just
-a convenience for BitBadges' own API — it is NOT the only credit token.
+With --browser the signer is pinned to --creator. --burner is
+CREATE-ONLY so it's rejected here (and would strand the credits anyway).
+The --api-credits shortcut is just a convenience for BitBadges' own API
+— it is NOT the only credit token; the standard is generic.
 `);
 
 // Per-standard `build` subcommand removed in CLI v2 (#0399).

--- a/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/crowdfunds.ts
@@ -11,6 +11,7 @@
 import { Command } from 'commander';
 import { apiRequest, resolveApiKey, resolveBaseUrl } from '../utils/api-client.js';
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import { resolveAmount } from '../utils/amount.js';
 import { emit, emitError } from '../utils/envelope.js';
 import { addIndexerOutputOptions as addOutputFlags } from '../utils/indexer-options.js';
@@ -199,6 +200,7 @@ addOutputFlags(
   } catch (err) { emitError(err); }
 });
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     crowdfundsCommand
@@ -209,7 +211,7 @@ addOutputFlags(
       .requiredOption('--amount <n>', 'Amount to contribute. Display units when the crowdfund\'s deposit denom is a registered symbol; base units when it\'s a chain denom. Use --base-units to force base-units.')
       .option('--base-units', 'Treat --amount as already-in-base-units')
   )
-).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string; baseUnits?: boolean }) => {
+)).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string; baseUnits?: boolean }) => {
   try {
     const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
@@ -222,8 +224,8 @@ addOutputFlags(
       { amountFlag: '--amount', denomFlag: 'crowdfund deposit denom' }
     );
     const tx = buildContributeCrowdfundTx(creator, String(collectionId), details, BigInt(amountStr));
-    // Single-msg per the helper output; bb deploy will accept either shape.
-    emit(tx.messages[0], opts);
+    // Single-msg per the helper output.
+    await runEmitOrDeploy(tx.messages[0], opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
   } catch (err) { emitError(err); }
 }).addHelpText('after', `
 Examples:
@@ -267,6 +269,7 @@ Examples:
   $ bb crowdfunds withdraw 7 --creator bb1crowdfunder...xyz | bb deploy
 `);
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     crowdfundsCommand
@@ -277,7 +280,7 @@ addOutputFlags(
       .requiredOption('--amount <n>', 'Amount to refund. Display units when the crowdfund\'s deposit denom is a registered symbol; base units when it\'s a chain denom. Use --base-units to force base-units.')
       .option('--base-units', 'Treat --amount as already-in-base-units')
   )
-).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string; baseUnits?: boolean }) => {
+)).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string; baseUnits?: boolean }) => {
   try {
     const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
@@ -293,7 +296,7 @@ addOutputFlags(
     if (now <= details.deadlineTime) {
       process.stderr.write(`Warning: deadline not yet passed (deadline=${details.deadlineTime}, now=${now}). Refund will be rejected.\n`);
     }
-    emit(buildRefundCrowdfundMsg(creator, String(collectionId), details, BigInt(amountStr)), opts);
+    await runEmitOrDeploy(buildRefundCrowdfundMsg(creator, String(collectionId), details, BigInt(amountStr)), opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
   } catch (err) { emitError(err); }
 }).addHelpText('after', `
 Examples:

--- a/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
@@ -33,7 +33,8 @@ import * as crypto from 'node:crypto';
 
 import { addNetworkOptions, getApiUrl, getApiKeyForNetwork, resolveNetwork } from '../utils/io.js';
 import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
-import { runBurnerCreate, pickBurner, type BurnerNetwork } from '../utils/burner.js';
+import { type BurnerNetwork } from '../utils/burner.js';
+import { browserBroadcast, burnerBroadcast } from '../utils/deploy-options.js';
 import { buildKeyringCommand, buildKeyringMultiCommand } from '../utils/keyring-command.js';
 import {
   extractEntityFromEvents,
@@ -41,7 +42,7 @@ import {
   type ExtractedEntity,
   type WaitForIndexerResult
 } from '../utils/wait-for-indexer.js';
-import { requireBbDenom, DEFAULT_FEE_DENOM } from '../utils/denom.js';
+import { DEFAULT_FEE_DENOM } from '../utils/denom.js';
 
 /**
  * Parse the `--wait-for-indexer` flag value. The flag is optional and may
@@ -563,46 +564,14 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
     if (!isMultiMsg && msg && msg.value && opts.manager && !msg.value.manager) {
       msg.value.manager = opts.manager;
     }
-    const { bridgeSign, resolveFrontendUrl } = await import('../auth/browser-bridge.js');
-    const frontendUrl = resolveFrontendUrl(networkName, opts.frontendUrl);
-    const expectedAddress = opts.expectedAddress ?? opts.manager;
-    const requestedTimeoutSec = opts.timeout ? Math.min(1800, Math.max(60, Number(opts.timeout))) : 300;
-    process.stderr.write(`\nOpening browser to ${frontendUrl}/sign for wallet signature + broadcast...\n`);
     try {
-      const result = await bridgeSign({
-        mode: 'tx',
-        payload: {
-          chain: 'cosmos',
-          txsInfo: messages.map((m: any) => ({ type: m.typeUrl, msg: m.value })),
-          expectedAddress,
-          signOnly: !!opts.signOnly,
-        },
-        baseUrl: apiUrl,
-        frontendUrl,
-        apiKey,
-        timeoutMs: requestedTimeoutSec * 1000,
-        noOpen: opts.open === false,
-        port: opts.port ? Number(opts.port) : undefined,
+      // Shared broadcast primitive (single source of truth for the
+      // bridgeSign handoff — see cli/utils/deploy-options.ts). deploy.ts
+      // keeps the richer post-processing below (--wait-for-indexer).
+      const { payload, result } = await browserBroadcast(messages, opts, {
+        expectedAddress: opts.expectedAddress ?? opts.manager
       });
-      if (result.error) {
-        process.stderr.write(`Browser broadcast cancelled or rejected: ${result.error}\n`);
-        process.exit(1);
-      }
-      const payload: any = opts.signOnly
-        ? {
-            success: !!result.signedTx,
-            path: 'browser',
-            mode: 'sign-only',
-            signedTx: result.signedTx ?? null,
-            chain: result.chain ?? 'cosmos',
-          }
-        : {
-            success: !!result.hash,
-            path: 'browser',
-            mode: 'sign-and-broadcast',
-            txHash: result.hash ?? null,
-            chain: result.chain ?? 'cosmos',
-          };
+      if (payload.error) process.exit(1); // browserBroadcast wrote the cancel notice
 
       // Optional: hold the CLI open until the indexer surfaces whatever
       // the tx created. Browser flow doesn't return tx events inline, so
@@ -835,30 +804,11 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
     process.exit(2);
   }
 
-  // 3. Wallet picker (interactive on TTY, bypassed otherwise or via flags)
-  const choice = await pickBurner({
-    network,
-    nodeUrl,
-    forceNew: Boolean(opts.new),
-    reuseSelector: opts.reuse
-  });
-
-  // 4. Drive the orchestrator
+  // Shared burner broadcast primitive (single source of truth for
+  // pickBurner + runBurnerCreate — see cli/utils/deploy-options.ts).
+  // deploy.ts keeps the dust-recovery hint + --wait-for-indexer below.
   try {
-    const result = await runBurnerCreate({
-      msg,
-      network,
-      apiUrl,
-      nodeUrl,
-      manager: opts.manager,
-      fund: opts.fund === 'manual' ? 'manual' : 'faucet',
-      apiKey,
-      fee: { amount: String(opts.fee), denom: requireBbDenom(String(opts.feeDenom || DEFAULT_FEE_DENOM), '--fee-denom') },
-      gas: Number(opts.gas),
-      reuseRecord: choice.kind === 'reuse' ? choice.record : undefined,
-      nonInteractive: Boolean(opts.nonInteractive) || !process.stdout.isTTY,
-      pollTimeoutMs: Number(opts.pollTimeout) * 1000
-    });
+    const { payload, result } = await burnerBroadcast(msg, opts);
 
     // Targeted hint:" — when the burner failed because the hot wallet
     // came up short on dust (faucet refused, manual funding too small,
@@ -895,16 +845,7 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
       }
     }
 
-    const payload: any = {
-      success: result.success,
-      ephemeralAddress: result.ephemeralAddress,
-      recoveryPath: result.recoveryPath,
-      txHash: result.txHash,
-      collectionId: result.collectionId ?? null,
-      paused: result.paused,
-      error: result.error,
-      ...(hint ? { hint } : {})
-    };
+    if (hint) (payload as any).hint = hint;
     if (waited) {
       payload.waited = {
         entity: waited.entity,

--- a/packages/bitbadgesjs-sdk/src/cli/commands/dynamic-stores.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/dynamic-stores.ts
@@ -38,6 +38,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 
 function fail(code: number, msg: string): never {
   process.stderr.write(`Error: ${msg}\n`);
@@ -63,6 +64,8 @@ export const dynamicStoresCommand = new Command('dynamic-stores').description(
 
 // ── create ───────────────────────────────────────────────────────────────────
 
+addDeployOptions(
+addNetworkFlags(
 addOutputFlags(
   dynamicStoresCommand
     .command('create')
@@ -71,10 +74,10 @@ addOutputFlags(
     .option('--default-value <bool>', 'Default value for addresses not explicitly set. true|false (default false)', 'false')
     .option('--uri <uri>', 'Optional metadata URI')
     .option('--custom-data <text>', 'Optional custom data string')
-).action((opts: OutputFlags & { creator: string; defaultValue: string; uri?: string; customData?: string }) => {
+))).action(async (opts: NetworkFlags & OutputFlags & { creator: string; defaultValue: string; uri?: string; customData?: string }) => {
   const creator = requireBb1AddressStrict(opts.creator, '--creator');
   const defaultValue = parseBool(opts.defaultValue, '--default-value');
-  emit(
+  await runEmitOrDeploy(
     {
       typeUrl: '/tokenization.MsgCreateDynamicStore',
       value: {
@@ -84,7 +87,8 @@ addOutputFlags(
         ...(opts.customData !== undefined ? { customData: opts.customData } : {})
       }
     },
-    opts
+    opts as any,
+    { emit: (m) => emit(m, opts), expectedAddress: creator }
   );
 }).addHelpText('after', `
 Examples:
@@ -94,6 +98,8 @@ Examples:
 
 // ── update ───────────────────────────────────────────────────────────────────
 
+addDeployOptions(
+addNetworkFlags(
 addOutputFlags(
   dynamicStoresCommand
     .command('update')
@@ -104,10 +110,10 @@ addOutputFlags(
     .option('--global-enabled <bool>', 'Kill-switch state (true=enabled, false=halted)')
     .option('--uri <uri>', 'New metadata URI')
     .option('--custom-data <text>', 'New custom data')
-).action(
-  (
+))).action(
+  async (
     storeId: string,
-    opts: OutputFlags & { creator: string; defaultValue?: string; globalEnabled?: string; uri?: string; customData?: string }
+    opts: NetworkFlags & OutputFlags & { creator: string; defaultValue?: string; globalEnabled?: string; uri?: string; customData?: string }
   ) => {
     const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const value: Record<string, unknown> = { creator, storeId: String(storeId) };
@@ -115,7 +121,7 @@ addOutputFlags(
     if (opts.globalEnabled !== undefined) value.globalEnabled = parseBool(opts.globalEnabled, '--global-enabled');
     if (opts.uri !== undefined) value.uri = opts.uri;
     if (opts.customData !== undefined) value.customData = opts.customData;
-    emit({ typeUrl: '/tokenization.MsgUpdateDynamicStore', value }, opts);
+    await runEmitOrDeploy({ typeUrl: '/tokenization.MsgUpdateDynamicStore', value }, opts as any, { emit: (m) => emit(m, opts), expectedAddress: creator });
   }
 ).addHelpText('after', `
 Examples:
@@ -125,20 +131,23 @@ Examples:
 
 // ── delete ───────────────────────────────────────────────────────────────────
 
+addDeployOptions(
+addNetworkFlags(
 addOutputFlags(
   dynamicStoresCommand
     .command('delete')
     .description('Emit MsgDeleteDynamicStore.')
     .argument('<store-id>', 'Dynamic store ID')
     .requiredOption('--creator <address>', 'Tx creator')
-).action((storeId: string, opts: OutputFlags & { creator: string }) => {
+))).action(async (storeId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   const creator = requireBb1AddressStrict(opts.creator, '--creator');
-  emit(
+  await runEmitOrDeploy(
     {
       typeUrl: '/tokenization.MsgDeleteDynamicStore',
       value: { creator, storeId: String(storeId) }
     },
-    opts
+    opts as any,
+    { emit: (m) => emit(m, opts), expectedAddress: creator }
   );
 }).addHelpText('after', `
 Examples:
@@ -147,6 +156,8 @@ Examples:
 
 // ── set-value (single) ───────────────────────────────────────────────────────
 
+addDeployOptions(
+addNetworkFlags(
 addOutputFlags(
   dynamicStoresCommand
     .command('set-value')
@@ -155,17 +166,18 @@ addOutputFlags(
     .argument('<address>', 'Target address (bb1.../0x — auto-normalized)')
     .argument('<value>', 'Boolean value (true|false)')
     .requiredOption('--creator <address>', 'Tx creator')
-).action(
-  (storeId: string, address: string, valueStr: string, opts: OutputFlags & { creator: string }) => {
+))).action(
+  async (storeId: string, address: string, valueStr: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
     const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const target = requireBb1AddressStrict(address, '<address> argument');
     const value = parseBool(valueStr, 'value');
-    emit(
+    await runEmitOrDeploy(
       {
         typeUrl: '/tokenization.MsgSetDynamicStoreValue',
         value: { creator, storeId: String(storeId), address: target, value }
       },
-      opts
+      opts as any,
+      { emit: (m) => emit(m, opts), expectedAddress: creator }
     );
   }
 ).addHelpText('after', `

--- a/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
@@ -31,6 +31,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import { requireBbDenom } from '../utils/denom.js';
 import { resolveAmount } from '../utils/amount.js';
 import { parseTimeFlag } from '../utils/time.js';
@@ -157,6 +158,7 @@ addOutputFlags(
 
 // ── intents create ────────────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addCollectionFlag(
     addNetworkFlags(
@@ -178,7 +180,7 @@ addOutputFlags(
         .option('--approval-id <id>', 'Override the auto-generated approval id (random hex by default)')
     )
   )
-).action(
+)).action(
   async (
     opts: NetworkFlags &
       OutputFlags &
@@ -228,7 +230,7 @@ addOutputFlags(
         approvalId
       });
 
-      emit(
+      await runEmitOrDeploy(
         {
           typeUrl: '/tokenization.MsgSetOutgoingApproval',
           value: {
@@ -237,7 +239,8 @@ addOutputFlags(
             approval
           }
         },
-        opts
+        opts,
+        { emit: (m) => emit(m, opts), expectedAddress: creator }
       );
     } catch (err) {
       emitError(err);
@@ -311,6 +314,7 @@ Examples:
 
 // ── intents cancel ────────────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addCollectionFlag(
     addNetworkFlags(
@@ -323,7 +327,7 @@ addOutputFlags(
         .requiredOption('--creator <address>', 'Address that owns the intent (bb1.../0x — auto-normalized)')
     )
   )
-).action(
+)).action(
   async (
     approvalId: string,
     opts: NetworkFlags & OutputFlags & CollectionFlag & { creator: string }
@@ -331,7 +335,7 @@ addOutputFlags(
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collectionId = resolveCollectionId(opts);
-      emit(
+      await runEmitOrDeploy(
         {
           typeUrl: '/tokenization.MsgDeleteOutgoingApproval',
           value: {
@@ -340,7 +344,8 @@ addOutputFlags(
             approvalId
           }
         },
-        opts
+        opts,
+        { emit: (m) => emit(m, opts), expectedAddress: creator }
       );
     } catch (err) {
       emitError(err);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
@@ -26,6 +26,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import { requireBbDenom } from '../utils/denom.js';
 import { resolveAmount } from '../utils/amount.js';
 import { parseTimeFlag } from '../utils/time.js';
@@ -43,6 +44,7 @@ export const nftsCommand = new Command('nfts').description(
 
 // ── bid (token-id OR collection-wide) ────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     nftsCommand
@@ -61,7 +63,7 @@ addOutputFlags(
       .option('--approval-id <id>', 'Override the random approval id')
       .option('--max-fills <n>', 'Cap on partial fills (default 1)', '1')
   )
-).action(
+)).action(
   async (
     collectionId: string,
     opts: NetworkFlags & OutputFlags & {
@@ -89,7 +91,7 @@ addOutputFlags(
         approvalId,
         maxNumTransfers: BigInt(opts.maxFills ?? '1')
       });
-      emit({ typeUrl: '/tokenization.MsgSetIncomingApproval', value: { creator, collectionId: String(collectionId), approval } }, opts);
+      await runEmitOrDeploy({ typeUrl: '/tokenization.MsgSetIncomingApproval', value: { creator, collectionId: String(collectionId), approval } }, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
     } catch (err) { emitError(err); }
   }
 ).addHelpText('after', `
@@ -100,6 +102,7 @@ Examples:
 
 // ── list (sell-side outgoing approval) ───────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     nftsCommand
@@ -116,7 +119,7 @@ addOutputFlags(
       .option('--expiry <when>', 'Listing expiry: ms-since-epoch or duration (7d, 30d, monthly). Default 30d.')
       .option('--approval-id <id>', 'Override the random approval id')
   )
-).action(
+)).action(
   async (
     collectionId: string,
     opts: NetworkFlags & OutputFlags & {
@@ -144,7 +147,7 @@ addOutputFlags(
         approvalId,
         maxNumTransfers: BigInt(opts.maxSales ?? '1')
       });
-      emit({ typeUrl: '/tokenization.MsgSetOutgoingApproval', value: { creator, collectionId: String(collectionId), approval } }, opts);
+      await runEmitOrDeploy({ typeUrl: '/tokenization.MsgSetOutgoingApproval', value: { creator, collectionId: String(collectionId), approval } }, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
     } catch (err) { emitError(err); }
   }
 ).addHelpText('after', `
@@ -155,6 +158,7 @@ Examples:
 
 // ── cancel ───────────────────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     nftsCommand
@@ -165,7 +169,7 @@ addOutputFlags(
       .requiredOption('--creator <address>', 'Order owner address (bb1.../0x — auto-normalized)')
       .requiredOption('--side <bid|listing>', 'Whether the approval is a bid (incoming) or listing (outgoing)')
   )
-).action(
+)).action(
   async (
     collectionId: string,
     approvalId: string,
@@ -180,7 +184,7 @@ addOutputFlags(
       const typeUrl = opts.side === 'bid'
         ? '/tokenization.MsgDeleteIncomingApproval'
         : '/tokenization.MsgDeleteOutgoingApproval';
-      emit({ typeUrl, value: { creator, collectionId: String(collectionId), approvalId } }, opts);
+      await runEmitOrDeploy({ typeUrl, value: { creator, collectionId: String(collectionId), approvalId } }, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
     } catch (err) { emitError(err); }
   }
 ).addHelpText('after', `
@@ -191,6 +195,7 @@ Examples:
 
 // ── buy (fill a listing) ─────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     nftsCommand
@@ -203,7 +208,7 @@ addOutputFlags(
       .requiredOption('--seller <address>', 'Listing owner address')
       .option('--token-amount <n>', 'How many to buy (default 1)', '1')
   )
-).action(
+)).action(
   async (
     collectionId: string,
     tokenId: string,
@@ -212,14 +217,15 @@ addOutputFlags(
     try {
       const buyer = requireBb1AddressStrict(opts.creator, '--creator');
       const seller = requireBb1AddressStrict(opts.seller, '--seller');
-      emit(
+      await runEmitOrDeploy(
         buildFillListingMsg(buyer, String(collectionId), {
           approvalId: opts.approvalId,
           approverAddress: seller,
           tokenId: BigInt(tokenId),
           tokenAmount: BigInt(opts.tokenAmount ?? '1')
         }),
-        opts
+        opts,
+        { emit: (m) => emit(m, opts), expectedAddress: buyer }
       );
     } catch (err) { emitError(err); }
   }
@@ -230,6 +236,7 @@ Examples:
 
 // ── sell (fill a bid) ────────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     nftsCommand
@@ -242,7 +249,7 @@ addOutputFlags(
       .requiredOption('--bidder <address>', 'Bid owner address')
       .option('--token-amount <n>', 'How many to sell (default 1)', '1')
   )
-).action(
+)).action(
   async (
     collectionId: string,
     tokenId: string,
@@ -251,14 +258,15 @@ addOutputFlags(
     try {
       const seller = requireBb1AddressStrict(opts.creator, '--creator');
       const bidder = requireBb1AddressStrict(opts.bidder, '--bidder');
-      emit(
+      await runEmitOrDeploy(
         buildFillBidMsg(seller, String(collectionId), {
           approvalId: opts.approvalId,
           approverAddress: bidder,
           tokenId: BigInt(tokenId),
           tokenAmount: BigInt(opts.tokenAmount ?? '1')
         }),
-        opts
+        opts,
+        { emit: (m) => emit(m, opts), expectedAddress: seller }
       );
     } catch (err) { emitError(err); }
   }

--- a/packages/bitbadgesjs-sdk/src/cli/commands/pay-requests.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/pay-requests.ts
@@ -29,6 +29,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import {
   doesCollectionFollowPaymentRequestProtocol,
   validatePaymentRequestCollection,
@@ -186,17 +187,18 @@ addOutputFlags(
 
 // ── pay-requests pay ──────────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     payRequestsCommand
       .command('pay')
       .description(
-        'Emit MsgTransferTokens targeting the pay approval. Pipe the output to `bb deploy` to sign + broadcast.'
+        'MsgTransferTokens targeting the pay approval. Emit (pipe to `bb deploy`) or broadcast inline with --browser/--burner.'
       )
       .argument('<collection-id>', 'PaymentRequest collection ID')
       .requiredOption('--creator <address>', 'Payer address (bb1.../0x — auto-normalized)')
   )
-).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
+)).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   try {
     const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
@@ -208,7 +210,7 @@ addOutputFlags(
       );
     }
     const msg = buildPaymentRequestPayMsg(creator, String(collectionId), details.payApproval);
-    emit(msg, opts);
+    await runEmitOrDeploy(msg, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
   } catch (err) {
     emitError(err);
   }
@@ -219,17 +221,18 @@ Examples:
 
 // ── pay-requests deny ─────────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     payRequestsCommand
       .command('deny')
       .description(
-        'Emit MsgTransferTokens targeting the deny approval. Pipe the output to `bb deploy` to sign + broadcast.'
+        'MsgTransferTokens targeting the deny approval. Emit (pipe to `bb deploy`) or broadcast inline with --browser/--burner.'
       )
       .argument('<collection-id>', 'PaymentRequest collection ID')
       .requiredOption('--creator <address>', 'Payer address (bb1.../0x — auto-normalized)')
   )
-).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
+)).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string }) => {
   try {
     const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
@@ -241,7 +244,7 @@ addOutputFlags(
       );
     }
     const msg = buildPaymentRequestDenyMsg(creator, String(collectionId), details.denyApproval);
-    emit(msg, opts);
+    await runEmitOrDeploy(msg, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
   } catch (err) {
     emitError(err);
   }

--- a/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
@@ -25,6 +25,7 @@ import {
 } from '../utils/indexer-options.js';
 import { requireBb1AddressStrict } from '../utils/address.js';
 import { bbError, BBErrorCode } from '../utils/envelope.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import { resolveAmount } from '../utils/amount.js';
 import { parseTimeFlag } from '../utils/time.js';
 import {
@@ -213,7 +214,7 @@ function buyAction(side: 'yes' | 'no') {
         transferTimes: UintRangeArray.From([{ start: 1n, end }]),
         approvalId
       });
-      emit({ typeUrl: '/tokenization.MsgSetIncomingApproval', value: { creator, collectionId: String(collectionId), approval } }, opts);
+      await runEmitOrDeploy({ typeUrl: '/tokenization.MsgSetIncomingApproval', value: { creator, collectionId: String(collectionId), approval } }, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
     } catch (err) { emitError(err); }
   };
 }
@@ -244,7 +245,7 @@ function sellAction(side: 'yes' | 'no') {
         transferTimes: UintRangeArray.From([{ start: 1n, end }]),
         approvalId
       });
-      emit({ typeUrl: '/tokenization.MsgSetOutgoingApproval', value: { creator, collectionId: String(collectionId), approval } }, opts);
+      await runEmitOrDeploy({ typeUrl: '/tokenization.MsgSetOutgoingApproval', value: { creator, collectionId: String(collectionId), approval } }, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
     } catch (err) { emitError(err); }
   };
 }
@@ -263,26 +264,27 @@ const tradeOpts = (cmd: Command, side: 'yes' | 'no', dir: 'buy' | 'sell') =>
     .option('--expiry <when>', 'Approval expiry: ms-since-epoch or duration (24h, 7d). Default 24h.')
     .option('--approval-id <id>', 'Override the random approval id');
 
-addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('buy-yes'), 'yes', 'buy'))).action(buyAction('yes')).addHelpText('after', `
+addDeployOptions(addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('buy-yes'), 'yes', 'buy')))).action(buyAction('yes')).addHelpText('after', `
 Examples:
   $ bb prediction-markets buy-yes 55 --creator bb1trader...xyz --token-amount 100 --payment-amount 40 --denom USDC | bb deploy
   $ bb prediction-markets buy-yes 55 --creator bb1trader...xyz --token-amount 100 --payment-amount 40 --denom USDC --expiry 7d | bb deploy
 `);
-addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('buy-no'), 'no', 'buy'))).action(buyAction('no')).addHelpText('after', `
+addDeployOptions(addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('buy-no'), 'no', 'buy')))).action(buyAction('no')).addHelpText('after', `
 Examples:
   $ bb prediction-markets buy-no 55 --creator bb1trader...xyz --token-amount 100 --payment-amount 60 --denom USDC | bb deploy
 `);
-addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('sell-yes'), 'yes', 'sell'))).action(sellAction('yes')).addHelpText('after', `
+addDeployOptions(addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('sell-yes'), 'yes', 'sell')))).action(sellAction('yes')).addHelpText('after', `
 Examples:
   $ bb prediction-markets sell-yes 55 --creator bb1trader...xyz --token-amount 50 --payment-amount 25 --denom USDC | bb deploy
 `);
-addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('sell-no'), 'no', 'sell'))).action(sellAction('no')).addHelpText('after', `
+addDeployOptions(addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('sell-no'), 'no', 'sell')))).action(sellAction('no')).addHelpText('after', `
 Examples:
   $ bb prediction-markets sell-no 55 --creator bb1trader...xyz --token-amount 50 --payment-amount 30 --denom USDC | bb deploy
 `);
 
 // ── Cancel ───────────────────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     predictionMarketsCommand
@@ -293,7 +295,7 @@ addOutputFlags(
       .requiredOption('--creator <address>', 'Order owner (bb1.../0x — auto-normalized)')
       .requiredOption('--side <buy|sell>', 'Whether the order is a buy (incoming approval) or sell (outgoing approval)')
   )
-).action(async (collectionId: string, approvalId: string, opts: NetworkFlags & OutputFlags & { creator: string; side: string }) => {
+)).action(async (collectionId: string, approvalId: string, opts: NetworkFlags & OutputFlags & { creator: string; side: string }) => {
   try {
     const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const isBuy = opts.side === 'buy';
@@ -301,10 +303,10 @@ addOutputFlags(
       process.stderr.write(`Error: --side must be "buy" or "sell" (got "${opts.side}").\n`);
       process.exit(2);
     }
-    emit({
+    await runEmitOrDeploy({
       typeUrl: isBuy ? '/tokenization.MsgDeleteIncomingApproval' : '/tokenization.MsgDeleteOutgoingApproval',
       value: { creator, collectionId: String(collectionId), approvalId }
-    }, opts);
+    }, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
   } catch (err) { emitError(err); }
 }).addHelpText('after', `
 Examples:
@@ -314,6 +316,7 @@ Examples:
 
 // ── Deposit ──────────────────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     predictionMarketsCommand
@@ -323,7 +326,7 @@ addOutputFlags(
       .requiredOption('--creator <address>', 'Depositor address (bb1.../0x — auto-normalized)')
       .requiredOption('--amount <n>', 'Number of YES+NO pairs to mint (in base units of the deposit denom)')
   )
-).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string }) => {
+)).action(async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; amount: string }) => {
   try {
     const creator = requireBb1AddressStrict(opts.creator, '--creator');
     const collection = await fetchCollection(collectionId, opts);
@@ -333,7 +336,7 @@ addOutputFlags(
       process.stderr.write('Error: no mint approval found on this prediction market.\n');
       process.exit(2);
     }
-    emit(buildPredictionMarketDepositMsg(creator, String(collectionId), BigInt(opts.amount), settle.mintApprovalId), opts);
+    await runEmitOrDeploy(buildPredictionMarketDepositMsg(creator, String(collectionId), BigInt(opts.amount), settle.mintApprovalId), opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
   } catch (err) { emitError(err); }
 }).addHelpText('after', `
 Examples:

--- a/packages/bitbadgesjs-sdk/src/cli/commands/products.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/products.ts
@@ -14,6 +14,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1AddressStrict } from '../utils/address.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import {
   doesCollectionFollowProductCatalogProtocol,
   validateProductCatalogCollection,
@@ -107,14 +108,16 @@ addOutputFlags(
   }
 });
 
-addOutputFlags(
-  addNetworkFlags(
-    productsCommand
-      .command('purchase')
-      .description('Emit MsgTransferTokens that buys 1 unit of a product. Pipe to `bb deploy`.')
-      .argument('<collection-id>', 'Product Catalog collection ID')
-      .requiredOption('--creator <address>', 'Buyer address (bb1.../0x — auto-normalized)')
-      .requiredOption('--token-id <n>', 'Product token ID to purchase')
+addDeployOptions(
+  addOutputFlags(
+    addNetworkFlags(
+      productsCommand
+        .command('purchase')
+        .description('Buy 1 unit of a product. Emits MsgTransferTokens (pipe to `bb deploy`) or broadcast inline with --browser/--burner.')
+        .argument('<collection-id>', 'Product Catalog collection ID')
+        .requiredOption('--creator <address>', 'Buyer address (bb1.../0x — auto-normalized)')
+        .requiredOption('--token-id <n>', 'Product token ID to purchase')
+    )
   )
 ).action(
   async (
@@ -140,7 +143,10 @@ addOutputFlags(
         );
         process.exit(2);
       }
-      emit(buildPurchaseProductMsg(creator, String(collectionId), product), opts);
+      await runEmitOrDeploy(buildPurchaseProductMsg(creator, String(collectionId), product), opts, {
+        emit: (m) => emit(m, opts),
+        expectedAddress: creator
+      });
     } catch (err) {
       emitError(err);
     }

--- a/packages/bitbadgesjs-sdk/src/cli/commands/smart-tokens.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/smart-tokens.ts
@@ -27,6 +27,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1AddressStrict } from '../utils/address.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import {
   doesCollectionFollowSmartTokenProtocol,
   validateSmartTokenCollection,
@@ -162,6 +163,7 @@ addOutputFlags(
 
 // ── smart-tokens deposit ─────────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     smartTokensCommand
@@ -178,7 +180,7 @@ addOutputFlags(
       )
       .option('--base-units', 'Treat --amount as already-in-base-units')
   )
-).action(
+)).action(
   async (
     collectionId: string,
     opts: NetworkFlags & OutputFlags & { creator: string; amount: string; baseUnits?: boolean }
@@ -205,7 +207,7 @@ addOutputFlags(
         amount,
         details
       });
-      emit(msg, opts);
+      await runEmitOrDeploy(msg, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
     } catch (err) {
       emitError(err);
     }
@@ -218,6 +220,7 @@ Examples:
 
 // ── smart-tokens withdraw ────────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     smartTokensCommand
@@ -234,7 +237,7 @@ addOutputFlags(
       )
       .option('--base-units', 'Treat --amount as already-in-base-units')
   )
-).action(
+)).action(
   async (
     collectionId: string,
     opts: NetworkFlags & OutputFlags & { creator: string; amount: string; baseUnits?: boolean }
@@ -261,7 +264,7 @@ addOutputFlags(
         amount,
         details
       });
-      emit(msg, opts);
+      await runEmitOrDeploy(msg, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
     } catch (err) {
       emitError(err);
     }

--- a/packages/bitbadgesjs-sdk/src/cli/commands/subscriptions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/subscriptions.ts
@@ -30,6 +30,7 @@ import {
   type IndexerOutputFlags as OutputFlags,
 } from '../utils/indexer-options.js';
 import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import {
   doesCollectionFollowSubscriptionProtocol,
   isSubscriptionFaucetApproval,
@@ -305,6 +306,7 @@ addOutputFlags(
 
 // ── subscriptions claim ──────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     subscriptionsCommand
@@ -316,14 +318,14 @@ addOutputFlags(
       .requiredOption('--creator <address>', 'Subscriber address (bb1.../0x — auto-normalized)')
       .option('--tier <approvalId>', 'Which faucet to claim from (required for multi-tier collections)')
   )
-).action(
+)).action(
   async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; tier?: string }) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
       const collection = await fetchCollection(collectionId, opts);
       validateOrExit(collection, 'subscriptions claim');
       const faucet = pickFaucet(listFaucets(collection), opts.tier, 'subscriptions claim');
-      emit(buildClaimMsg(creator, String(collectionId), faucet), opts);
+      await runEmitOrDeploy(buildClaimMsg(creator, String(collectionId), faucet), opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
     } catch (err) {
       emitError(err);
     }
@@ -336,6 +338,7 @@ Examples:
 
 // ── subscriptions enable-renewal ─────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     subscriptionsCommand
@@ -348,7 +351,7 @@ addOutputFlags(
       .option('--tier <approvalId>', 'Which faucet to renew (required for multi-tier collections)')
       .option('--tip <ubadge>', 'Optional tip per interval on top of the base subscription amount (in base denom units)', '0')
   )
-).action(
+)).action(
   async (
     collectionId: string,
     opts: NetworkFlags & OutputFlags & { creator: string; tier?: string; tip?: string }
@@ -382,9 +385,10 @@ addOutputFlags(
       }
       const otherApprovals = existing.filter((a: any) => !isUserRecurringApproval(a, faucet));
 
-      emit(
+      await runEmitOrDeploy(
         buildUpdateApprovalsMsg(creator, String(collectionId), [...otherApprovals, newApproval]),
-        opts
+        opts,
+        { emit: (m) => emit(m, opts), expectedAddress: creator }
       );
     } catch (err) {
       emitError(err);
@@ -398,6 +402,7 @@ Examples:
 
 // ── subscriptions cancel ─────────────────────────────────────────────────
 
+addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
     subscriptionsCommand
@@ -409,7 +414,7 @@ addOutputFlags(
       .requiredOption('--creator <address>', 'Subscriber address (bb1.../0x — auto-normalized)')
       .option('--tier <approvalId>', 'Which faucet to cancel (required for multi-tier collections)')
   )
-).action(
+)).action(
   async (collectionId: string, opts: NetworkFlags & OutputFlags & { creator: string; tier?: string }) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
@@ -425,7 +430,7 @@ addOutputFlags(
           'Warning: no matching user recurring approval found for this tier — cancel is a no-op.\n'
         );
       }
-      emit(buildUpdateApprovalsMsg(creator, String(collectionId), remaining), opts);
+      await runEmitOrDeploy(buildUpdateApprovalsMsg(creator, String(collectionId), remaining), opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
     } catch (err) {
       emitError(err);
     }

--- a/packages/bitbadgesjs-sdk/src/cli/utils/deploy-options.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/deploy-options.spec.ts
@@ -1,0 +1,46 @@
+import { Command } from 'commander';
+import { addDeployOptions, isDeployRequested, runEmitOrDeploy } from './deploy-options.js';
+
+const longFlags = (cmd: Command) => (cmd as any).options.map((o: any) => o.long);
+
+describe('addDeployOptions', () => {
+  test('attaches the standardized concise deploy flag set', () => {
+    const cmd = addDeployOptions(new Command('x'));
+    const flags = longFlags(cmd);
+    for (const f of ['--browser', '--burner', '--sign-only', '--frontend-url', '--no-open',
+      '--timeout', '--expected-address', '--fund', '--fee', '--fee-denom', '--gas',
+      '--new', '--reuse', '--non-interactive', '--poll-timeout']) {
+      expect(flags).toContain(f);
+    }
+    // Concise names only — the old verbose forms must be gone.
+    expect(flags).not.toContain('--deploy-with-browser');
+    expect(flags).not.toContain('--deploy-with-burner');
+  });
+
+  test('is idempotent / does not clobber a pre-declared flag', () => {
+    const cmd = new Command('y').option('--gas <n>', 'preexisting', '999');
+    addDeployOptions(cmd);
+    const gas = (cmd as any)._findOption('--gas');
+    expect(gas.description).toBe('preexisting'); // not overwritten
+    // and a second pass doesn't throw a commander duplicate-flag error
+    expect(() => addDeployOptions(cmd)).not.toThrow();
+  });
+});
+
+describe('isDeployRequested', () => {
+  test('true only when --browser or --burner is set', () => {
+    expect(isDeployRequested({})).toBe(false);
+    expect(isDeployRequested({ signOnly: true, timeout: '60' })).toBe(false);
+    expect(isDeployRequested({ browser: true })).toBe(true);
+    expect(isDeployRequested({ burner: true })).toBe(true);
+  });
+});
+
+describe('runEmitOrDeploy', () => {
+  test('no deploy flag → emits the msg verbatim (pipe-to-bb-deploy path)', async () => {
+    const msg = { typeUrl: '/tokenization.MsgTransferTokens', value: { a: 1 } };
+    const seen: any[] = [];
+    await runEmitOrDeploy(msg, {}, { emit: (m) => seen.push(m) });
+    expect(seen).toEqual([msg]);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/utils/deploy-options.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/deploy-options.ts
@@ -39,6 +39,7 @@ export interface DeployOpts {
   manager?: string;
   creator?: string;
   nodeUrl?: string;
+  port?: string; // --browser loopback port pin (standalone `bb deploy` only)
 }
 
 /** Add `--option` only if the command hasn't already declared it. */
@@ -101,6 +102,112 @@ export function isDeployRequested(opts: DeployOpts): boolean {
  * `--browser`, etc.). Process-exits on completion/failure like the
  * original (does not return on the deploy paths).
  */
+/**
+ * The single source of truth for the **browser** broadcast mechanic
+ * (bridgeSign handoff to the /sign page). Multi-msg capable. Does NOT
+ * process.exit or emit — returns `{ payload, result }` so callers can
+ * layer their own post-processing (the standalone `bb deploy` adds
+ * --wait-for-indexer; the inline `executeDeploy` just prints + exits).
+ *
+ * On a cancelled/rejected sign it writes the stderr notice and returns
+ * a `payload.success === false` (caller decides the exit code). A
+ * thrown bridge error propagates to the caller's catch.
+ */
+export async function browserBroadcast(
+  messages: { typeUrl: string; value: any }[],
+  opts: DeployOpts,
+  ctx: { expectedAddress?: string } = {}
+): Promise<{ payload: any; result: any }> {
+  const networkName = resolveNetwork(opts as any);
+  const apiUrl = getApiUrl(opts as any);
+  const apiKey = getApiKeyForNetwork(opts as any);
+  const { bridgeSign, resolveFrontendUrl } = await import('../auth/browser-bridge.js');
+  const frontendUrl = resolveFrontendUrl(networkName, opts.frontendUrl);
+  const expectedAddress = opts.expectedAddress ?? ctx.expectedAddress ?? opts.manager ?? opts.creator;
+  const requestedTimeoutSec = opts.timeout ? Math.min(1800, Math.max(60, Number(opts.timeout))) : 300;
+  process.stderr.write(`\nOpening browser to ${frontendUrl}/sign for wallet signature + broadcast...\n`);
+  const result = await bridgeSign({
+    mode: 'tx',
+    payload: {
+      chain: 'cosmos',
+      txsInfo: messages.map((m) => ({ type: m.typeUrl, msg: m.value })),
+      expectedAddress,
+      signOnly: !!opts.signOnly,
+    },
+    baseUrl: apiUrl,
+    frontendUrl,
+    apiKey,
+    timeoutMs: requestedTimeoutSec * 1000,
+    noOpen: opts.open === false,
+    port: opts.port ? Number(opts.port) : undefined,
+  });
+  if (result.error) {
+    process.stderr.write(`Browser broadcast cancelled or rejected: ${result.error}\n`);
+    return { payload: { success: false, path: 'browser', error: result.error }, result };
+  }
+  const payload: any = opts.signOnly
+    ? { success: !!result.signedTx, path: 'browser', mode: 'sign-only', signedTx: result.signedTx ?? null, chain: result.chain ?? 'cosmos' }
+    : { success: !!result.hash, path: 'browser', mode: 'sign-and-broadcast', txHash: result.hash ?? null, chain: result.chain ?? 'cosmos' };
+  return { payload, result };
+}
+
+/**
+ * The single source of truth for the **burner** broadcast mechanic
+ * (pickBurner + runBurnerCreate). CREATE-ONLY. Returns
+ * `{ payload, result }`; no process.exit/emit (caller layers the
+ * dust-recovery hint / --wait-for-indexer / exit). Caller is
+ * responsible for the `--manager` guard before calling.
+ */
+export async function burnerBroadcast(
+  builtMsg: { typeUrl: string; value: any },
+  opts: DeployOpts
+): Promise<{ payload: any; result: any }> {
+  const networkName = resolveNetwork(opts as any);
+  const network: BurnerNetwork = networkName as NetworkMode;
+  const apiUrl = getApiUrl(opts as any);
+  const nodeUrl = opts.nodeUrl || NETWORK_CONFIGS[network].nodeUrl;
+  const apiKey = getApiKeyForNetwork(opts as any);
+
+  if ((opts.fund ?? 'faucet') === 'faucet' && !apiKey && network !== 'local') {
+    process.stderr.write(
+      'Warning: --fund faucet requires an API key on non-local networks. Pass --api-key or run `bb settings set apiKey <key>`.\n'
+    );
+  }
+
+  const choice = await pickBurner({
+    network,
+    nodeUrl,
+    forceNew: Boolean(opts.new),
+    reuseSelector: opts.reuse
+  });
+
+  const result = await runBurnerCreate({
+    msg: builtMsg,
+    network,
+    apiUrl,
+    nodeUrl,
+    manager: opts.manager!,
+    fund: opts.fund === 'manual' ? 'manual' : 'faucet',
+    apiKey,
+    fee: { amount: String(opts.fee ?? '0'), denom: requireBbDenom(String(opts.feeDenom ?? DEFAULT_FEE_DENOM), '--fee-denom') },
+    gas: Number(opts.gas ?? 400000),
+    reuseRecord: choice.kind === 'reuse' ? choice.record : undefined,
+    nonInteractive: Boolean(opts.nonInteractive) || !process.stdout.isTTY,
+    pollTimeoutMs: Number(opts.pollTimeout ?? 60) * 1000
+  });
+
+  const payload = {
+    success: result.success,
+    ephemeralAddress: result.ephemeralAddress,
+    recoveryPath: result.recoveryPath,
+    txHash: result.txHash,
+    collectionId: result.collectionId ?? null,
+    paused: result.paused,
+    error: result.error
+  };
+  return { payload, result };
+}
+
 export async function executeDeploy(
   builtMsg: { typeUrl: string; value: any },
   opts: DeployOpts,
@@ -111,50 +218,10 @@ export async function executeDeploy(
     process.exit(2);
   }
 
-  // ── --browser ───────────────────────────────────────────────────────
   if (opts.browser) {
-    const networkName = resolveNetwork(opts as any);
-    const apiUrl = getApiUrl(opts as any);
-    const apiKey = getApiKeyForNetwork(opts as any);
-    const { bridgeSign, resolveFrontendUrl } = await import('../auth/browser-bridge.js');
-    const frontendUrl = resolveFrontendUrl(networkName, opts.frontendUrl);
-    const expectedAddress = opts.expectedAddress ?? ctx.expectedAddress ?? opts.manager ?? opts.creator;
-    const requestedTimeoutSec = opts.timeout ? Math.min(1800, Math.max(60, Number(opts.timeout))) : 300;
-    process.stderr.write(`\nOpening browser to ${frontendUrl}/sign for wallet signature + broadcast...\n`);
     try {
-      const result = await bridgeSign({
-        mode: 'tx',
-        payload: {
-          chain: 'cosmos',
-          txsInfo: [{ type: builtMsg.typeUrl, msg: builtMsg.value }],
-          expectedAddress,
-          signOnly: !!opts.signOnly,
-        },
-        baseUrl: apiUrl,
-        frontendUrl,
-        apiKey,
-        timeoutMs: requestedTimeoutSec * 1000,
-        noOpen: opts.open === false,
-      });
-      if (result.error) {
-        process.stderr.write(`Browser broadcast cancelled or rejected: ${result.error}\n`);
-        process.exit(1);
-      }
-      const payload: any = opts.signOnly
-        ? {
-            success: !!result.signedTx,
-            path: 'browser',
-            mode: 'sign-only',
-            signedTx: result.signedTx ?? null,
-            chain: result.chain ?? 'cosmos',
-          }
-        : {
-            success: !!result.hash,
-            path: 'browser',
-            mode: 'sign-and-broadcast',
-            txHash: result.hash ?? null,
-            chain: result.chain ?? 'cosmos',
-          };
+      const { payload } = await browserBroadcast([builtMsg], opts, ctx);
+      if (payload.error) process.exit(1); // browserBroadcast already wrote the stderr notice
       process.stdout.write('\n' + JSON.stringify(payload, null, 2) + '\n');
       process.exit(payload.success ? 0 : 1);
     } catch (err: any) {
@@ -163,7 +230,6 @@ export async function executeDeploy(
     }
   }
 
-  // ── --burner (CREATE-ONLY) ──────────────────────────────────────────
   if (opts.burner) {
     if (!opts.manager) {
       process.stderr.write(
@@ -171,50 +237,8 @@ export async function executeDeploy(
       );
       process.exit(2);
     }
-    const networkName = resolveNetwork(opts as any);
-    const network: BurnerNetwork = networkName as NetworkMode;
-    const apiUrl = getApiUrl(opts as any);
-    const nodeUrl = opts.nodeUrl || NETWORK_CONFIGS[network].nodeUrl;
-    const apiKey = getApiKeyForNetwork(opts as any);
-
-    if ((opts.fund ?? 'faucet') === 'faucet' && !apiKey && network !== 'local') {
-      process.stderr.write(
-        'Warning: --fund faucet requires an API key on non-local networks. Pass --api-key or run `bb settings set apiKey <key>`.\n'
-      );
-    }
-
-    const choice = await pickBurner({
-      network,
-      nodeUrl,
-      forceNew: Boolean(opts.new),
-      reuseSelector: opts.reuse
-    });
-
     try {
-      const result = await runBurnerCreate({
-        msg: builtMsg,
-        network,
-        apiUrl,
-        nodeUrl,
-        manager: opts.manager,
-        fund: opts.fund === 'manual' ? 'manual' : 'faucet',
-        apiKey,
-        fee: { amount: String(opts.fee ?? '0'), denom: requireBbDenom(String(opts.feeDenom ?? DEFAULT_FEE_DENOM), '--fee-denom') },
-        gas: Number(opts.gas ?? 400000),
-        reuseRecord: choice.kind === 'reuse' ? choice.record : undefined,
-        nonInteractive: Boolean(opts.nonInteractive) || !process.stdout.isTTY,
-        pollTimeoutMs: Number(opts.pollTimeout ?? 60) * 1000
-      });
-
-      const payload = {
-        success: result.success,
-        ephemeralAddress: result.ephemeralAddress,
-        recoveryPath: result.recoveryPath,
-        txHash: result.txHash,
-        collectionId: result.collectionId ?? null,
-        paused: result.paused,
-        error: result.error
-      };
+      const { payload, result } = await burnerBroadcast(builtMsg, opts);
       process.stdout.write('\n' + JSON.stringify(payload, null, 2) + '\n');
       if (!result.success && !result.paused) process.exit(1);
       process.exit(0);

--- a/packages/bitbadgesjs-sdk/src/cli/utils/deploy-options.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/deploy-options.ts
@@ -1,0 +1,245 @@
+/**
+ * Shared deploy flags + executor for every tx-emitting command.
+ *
+ * Mirrors the `addNetworkOptions` / output-flag helpers: any command
+ * that produces a `{ typeUrl, value }` msg attaches `addDeployOptions`
+ * and routes its output through `runEmitOrDeploy` (or, for commands that
+ * already emit their own envelope, `isDeployRequested` + `executeDeploy`).
+ *
+ * Default (no deploy flag) → the msg JSON is emitted to stdout, so
+ * `... | bb deploy` and scripting keep working unchanged. With
+ * `--browser` / `--burner` the same msg is broadcast inline via the
+ * canonical paths. Naming is the concise set used by standalone
+ * `bb deploy` (`--browser`, `--burner`, …) so the interface is identical
+ * everywhere.
+ */
+import type { Command } from 'commander';
+import { getApiUrl, getApiKeyForNetwork, resolveNetwork } from './io.js';
+import { tagHelpGroups } from './help-groups.js';
+import { NETWORK_CONFIGS, type NetworkMode } from '../../signing/types.js';
+import { runBurnerCreate, pickBurner, type BurnerNetwork } from './burner.js';
+import { requireBbDenom, DEFAULT_FEE_DENOM } from './denom.js';
+
+export interface DeployOpts {
+  browser?: boolean;
+  burner?: boolean;
+  signOnly?: boolean;
+  frontendUrl?: string;
+  open?: boolean; // commander sets `open: false` for --no-open
+  timeout?: string;
+  expectedAddress?: string;
+  fund?: string;
+  fee?: string;
+  feeDenom?: string;
+  gas?: string;
+  new?: boolean;
+  reuse?: string;
+  nonInteractive?: boolean;
+  pollTimeout?: string;
+  manager?: string;
+  creator?: string;
+  nodeUrl?: string;
+}
+
+/** Add `--option` only if the command hasn't already declared it. */
+function addOptionIfMissing(cmd: Command, flags: string, description: string, defaultValue?: string): Command {
+  const longFlag = flags.match(/--[a-z][a-z0-9-]*/)?.[0];
+  if (longFlag && (cmd as any)._findOption?.(longFlag)) return cmd;
+  return defaultValue !== undefined ? cmd.option(flags, description, defaultValue) : cmd.option(flags, description);
+}
+
+/**
+ * Attach the standardized deploy flag set + "Deploy" help-group tags.
+ * Idempotent per flag — safe on commands that predefine `--manager`,
+ * `--gas`, etc.
+ */
+export function addDeployOptions(cmd: Command): Command {
+  addOptionIfMissing(cmd, '--burner', 'Broadcast inline via the throwaway burner flow (CREATE-ONLY). Requires --manager.');
+  addOptionIfMissing(cmd, '--browser', 'Broadcast inline by handing off to the BitBadges /sign page; sign with your connected wallet (Keplr, MetaMask, …).');
+  addOptionIfMissing(cmd, '--sign-only', 'With --browser: have the wallet sign but not broadcast — returns the signed tx bytes.');
+  addOptionIfMissing(cmd, '--frontend-url <url>', 'With --browser: override the frontend base URL.');
+  addOptionIfMissing(cmd, '--no-open', 'With --browser: print the sign URL instead of auto-launching the browser.');
+  addOptionIfMissing(cmd, '--timeout <seconds>', 'With --browser: how long to wait for the wallet to confirm (default 300, max 1800).');
+  addOptionIfMissing(cmd, '--expected-address <addr>', 'With --browser: bb1.../0x... the connected wallet must match. Defaults to --manager / --creator.');
+  addOptionIfMissing(cmd, '--fund <mode>', 'With --burner: funding source for the burner (faucet | manual)', 'faucet');
+  addOptionIfMissing(cmd, '--fee <amount>', 'When deploying: fee amount in base units', '0');
+  addOptionIfMissing(cmd, '--fee-denom <symbol|denom>', 'When deploying: fee denom. BADGE, USDC, … or canonical denom', DEFAULT_FEE_DENOM);
+  addOptionIfMissing(cmd, '--gas <number>', 'When deploying: gas limit', '400000');
+  addOptionIfMissing(cmd, '--new', 'With --burner: skip the picker and always create a fresh wallet');
+  addOptionIfMissing(cmd, '--reuse <selector>', 'With --burner: reuse a specific saved burner by address or recovery file path');
+  addOptionIfMissing(cmd, '--non-interactive', 'With --burner: never prompt; on any prompt point save state and exit for later resume');
+  addOptionIfMissing(cmd, '--poll-timeout <seconds>', 'With --burner: seconds to wait for funding to land before prompting/exiting', '60');
+  tagHelpGroups(cmd, {
+    '--burner': 'Deploy',
+    '--browser': 'Deploy',
+    '--sign-only': 'Deploy',
+    '--frontend-url': 'Deploy',
+    '--no-open': 'Deploy',
+    '--timeout': 'Deploy',
+    '--expected-address': 'Deploy',
+    '--fund': 'Deploy',
+    '--fee': 'Deploy',
+    '--fee-denom': 'Deploy',
+    '--gas': 'Deploy',
+    '--new': 'Deploy',
+    '--reuse': 'Deploy',
+    '--non-interactive': 'Deploy',
+    '--poll-timeout': 'Deploy'
+  });
+  return cmd;
+}
+
+/** True if the user asked for an inline broadcast (vs. emit JSON). */
+export function isDeployRequested(opts: DeployOpts): boolean {
+  return Boolean(opts.browser || opts.burner);
+}
+
+/**
+ * Execute the inline broadcast for an already-built `{ typeUrl, value }`
+ * msg. Behavior is verbatim the build.ts `--deploy-with-*` blocks it
+ * replaces — only the flag NAMES changed (`--deploy-with-browser` →
+ * `--browser`, etc.). Process-exits on completion/failure like the
+ * original (does not return on the deploy paths).
+ */
+export async function executeDeploy(
+  builtMsg: { typeUrl: string; value: any },
+  opts: DeployOpts,
+  ctx: { expectedAddress?: string } = {}
+): Promise<void> {
+  if (opts.browser && opts.burner) {
+    process.stderr.write('\nError: --browser and --burner are mutually exclusive.\n');
+    process.exit(2);
+  }
+
+  // ── --browser ───────────────────────────────────────────────────────
+  if (opts.browser) {
+    const networkName = resolveNetwork(opts as any);
+    const apiUrl = getApiUrl(opts as any);
+    const apiKey = getApiKeyForNetwork(opts as any);
+    const { bridgeSign, resolveFrontendUrl } = await import('../auth/browser-bridge.js');
+    const frontendUrl = resolveFrontendUrl(networkName, opts.frontendUrl);
+    const expectedAddress = opts.expectedAddress ?? ctx.expectedAddress ?? opts.manager ?? opts.creator;
+    const requestedTimeoutSec = opts.timeout ? Math.min(1800, Math.max(60, Number(opts.timeout))) : 300;
+    process.stderr.write(`\nOpening browser to ${frontendUrl}/sign for wallet signature + broadcast...\n`);
+    try {
+      const result = await bridgeSign({
+        mode: 'tx',
+        payload: {
+          chain: 'cosmos',
+          txsInfo: [{ type: builtMsg.typeUrl, msg: builtMsg.value }],
+          expectedAddress,
+          signOnly: !!opts.signOnly,
+        },
+        baseUrl: apiUrl,
+        frontendUrl,
+        apiKey,
+        timeoutMs: requestedTimeoutSec * 1000,
+        noOpen: opts.open === false,
+      });
+      if (result.error) {
+        process.stderr.write(`Browser broadcast cancelled or rejected: ${result.error}\n`);
+        process.exit(1);
+      }
+      const payload: any = opts.signOnly
+        ? {
+            success: !!result.signedTx,
+            path: 'browser',
+            mode: 'sign-only',
+            signedTx: result.signedTx ?? null,
+            chain: result.chain ?? 'cosmos',
+          }
+        : {
+            success: !!result.hash,
+            path: 'browser',
+            mode: 'sign-and-broadcast',
+            txHash: result.hash ?? null,
+            chain: result.chain ?? 'cosmos',
+          };
+      process.stdout.write('\n' + JSON.stringify(payload, null, 2) + '\n');
+      process.exit(payload.success ? 0 : 1);
+    } catch (err: any) {
+      process.stderr.write(`Browser broadcast failed: ${err?.message || err}\n`);
+      process.exit(1);
+    }
+  }
+
+  // ── --burner (CREATE-ONLY) ──────────────────────────────────────────
+  if (opts.burner) {
+    if (!opts.manager) {
+      process.stderr.write(
+        '\nError: --burner requires --manager <bb1...>. The burner is a throwaway signer; the manager address captures lasting collection ownership.\n'
+      );
+      process.exit(2);
+    }
+    const networkName = resolveNetwork(opts as any);
+    const network: BurnerNetwork = networkName as NetworkMode;
+    const apiUrl = getApiUrl(opts as any);
+    const nodeUrl = opts.nodeUrl || NETWORK_CONFIGS[network].nodeUrl;
+    const apiKey = getApiKeyForNetwork(opts as any);
+
+    if ((opts.fund ?? 'faucet') === 'faucet' && !apiKey && network !== 'local') {
+      process.stderr.write(
+        'Warning: --fund faucet requires an API key on non-local networks. Pass --api-key or run `bb settings set apiKey <key>`.\n'
+      );
+    }
+
+    const choice = await pickBurner({
+      network,
+      nodeUrl,
+      forceNew: Boolean(opts.new),
+      reuseSelector: opts.reuse
+    });
+
+    try {
+      const result = await runBurnerCreate({
+        msg: builtMsg,
+        network,
+        apiUrl,
+        nodeUrl,
+        manager: opts.manager,
+        fund: opts.fund === 'manual' ? 'manual' : 'faucet',
+        apiKey,
+        fee: { amount: String(opts.fee ?? '0'), denom: requireBbDenom(String(opts.feeDenom ?? DEFAULT_FEE_DENOM), '--fee-denom') },
+        gas: Number(opts.gas ?? 400000),
+        reuseRecord: choice.kind === 'reuse' ? choice.record : undefined,
+        nonInteractive: Boolean(opts.nonInteractive) || !process.stdout.isTTY,
+        pollTimeoutMs: Number(opts.pollTimeout ?? 60) * 1000
+      });
+
+      const payload = {
+        success: result.success,
+        ephemeralAddress: result.ephemeralAddress,
+        recoveryPath: result.recoveryPath,
+        txHash: result.txHash,
+        collectionId: result.collectionId ?? null,
+        paused: result.paused,
+        error: result.error
+      };
+      process.stdout.write('\n' + JSON.stringify(payload, null, 2) + '\n');
+      if (!result.success && !result.paused) process.exit(1);
+      process.exit(0);
+    } catch (err: any) {
+      process.stderr.write(`Burner deploy failed: ${err?.message || err}\n`);
+      process.exit(1);
+    }
+  }
+}
+
+/**
+ * Emit the msg as JSON (default; keeps `| bb deploy` working) UNLESS a
+ * deploy flag was passed, in which case broadcast inline. For commands
+ * whose only output is the tx msg. Commands that emit a richer envelope
+ * (e.g. `bb build`) should call `isDeployRequested` + `executeDeploy`
+ * themselves so they keep emitting their envelope first.
+ */
+export async function runEmitOrDeploy(
+  builtMsg: { typeUrl: string; value: any },
+  opts: DeployOpts,
+  ctx: { emit: (msg: any) => void; expectedAddress?: string }
+): Promise<void> {
+  if (!isDeployRequested(opts)) {
+    ctx.emit(builtMsg);
+    return;
+  }
+  await executeDeploy(builtMsg, opts, { expectedAddress: ctx.expectedAddress });
+}


### PR DESCRIPTION
## Summary

DRY the deploy interface. One shared helper now gives **every tx-emitting command the identical deploy interface** (concise `--browser`/`--burner`/…, matching standalone `bb deploy`), and the broadcast executor lives in exactly one place. You never *have* to `| bb deploy`.

**Stacked on #236** (`feat/builder-standards-parity`).

## Design — `cli/utils/deploy-options.ts`

- **`addDeployOptions(cmd)`** — standardized concise flag set + `Deploy` help-group tag (idempotent).
- **`runEmitOrDeploy(msg, opts, {emit, expectedAddress})`** — no deploy flag → emit JSON (`| bb deploy` & scripting unchanged); else broadcast inline.
- **`browserBroadcast` / `burnerBroadcast`** — the single source of truth for the two broadcast mechanics (bridgeSign handoff; pickBurner+runBurnerCreate). Return `{payload,result}`; no exit/emit.
- **`executeDeploy`** — thin print+exit wrapper over the primitives, for commands whose only output is the tx.

## All phases complete & integration-validated (19/19 suites · 177/177)

- **Phase 1:** helper + spec; `build.ts` & `credit-tokens.ts` rewired (−~190 lines dup); `--deploy-with-*` → `--browser`/`--burner`.
- **Phase 3:** all 11 tx-emitting command files swept (~30 single-msg subcommands): products, bounties, nfts, smart-tokens, pay-requests, intents, prediction-markets, subscriptions, crowdfunds, auctions, dynamic-stores. Multi-msg subcommands (bounty accept/deny, crowdfund withdraw, intents fill, pm redeem/resolve, subscriptions subscribe, dynamic-stores bulk) intentionally stay emit-only (pipe to `bb deploy`, which handles arrays). Read-only list/show/status untouched.
- **Phase 2:** standalone `bb deploy` unified onto the **same** `browserBroadcast`/`burnerBroadcast` primitives — ~120 lines of duplicate broadcast code removed from deploy.ts while keeping its richer post-processing (wait-for-indexer, dust-hint, multi-msg browser, manager backfill). Behavior-preserving.

## Test plan

- [x] `deploy-options.spec.ts` (flag set, idempotency, emit-vs-deploy branching)
- [x] Full SDK unit suite: **134 suites / 3012 tests**
- [x] `npm run build` clean (tsc, no circular deps)
- [x] **Full integration green end-to-end after each phase: 19/19 suites / 177/177** (Phase 1, Phase 3, Phase 2 each validated on the live devnet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
