### PR TITLE
fix(docs-ci): fail-fast doc-gen pipeline + pre-push Stoplight gate

### DIFF
--- a/.github/workflows/genapi.yml
+++ b/.github/workflows/genapi.yml
@@ -53,7 +53,22 @@ jobs:
           echo "Starting documentation generation..."
           echo "PYPI_TOKEN is set: $([[ ! -z "$PYPI_TOKEN" ]] && echo "true" || echo "false")"
           chmod +x ./scripts/gen_api_docs_ci.sh
-          source ./scripts/gen_api_docs_ci.sh
+          bash ./scripts/gen_api_docs_ci.sh
+
+      - name: Validate assembled spec before publish
+        run: |
+          bun -e '
+            const yaml = require("js-yaml");
+            const fs = require("fs");
+            const f = "./openapitypes/combined_processed.yaml";
+            if (!fs.existsSync(f)) { console.error(`FAIL: ${f} missing — assembly did not produce a spec.`); process.exit(1); }
+            const doc = yaml.load(fs.readFileSync(f, "utf8"));
+            const title = doc && doc.info && doc.info.title;
+            const n = doc && doc.paths ? Object.keys(doc.paths).length : 0;
+            if (title !== "BitBadges API") { console.error(`FAIL: info.title is ${JSON.stringify(title)} (expected "BitBadges API") — raw typeconv/partial spec, refusing to publish. See ticket 0408.`); process.exit(1); }
+            if (n < 90) { console.error(`FAIL: only ${n} paths (expected >= 90) — refusing to publish.`); process.exit(1); }
+            console.log(`Spec OK: title="${title}", paths=${n}`);
+          '
 
       - name: Push to Stoplight
         env:

--- a/packages/bitbadgesjs-sdk/scripts/gen_api_docs_ci.sh
+++ b/packages/bitbadgesjs-sdk/scripts/gen_api_docs_ci.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# fail-fast: any assembly step erroring must abort (never publish a
+# partial/raw spec). -u omitted on purpose — the sourced legacy
+# scripts use unset vars in find/while loops. #0408
+set -eo pipefail
 
 echo "No changes found. Proceeding..."
 

--- a/packages/bitbadgesjs-sdk/scripts/normalize_yml.ts
+++ b/packages/bitbadgesjs-sdk/scripts/normalize_yml.ts
@@ -3,14 +3,11 @@ import * as yaml from 'js-yaml';
 
 // Read the YAML file
 const filePath = process.argv[2];
-fs.readFile(filePath, 'utf8', (err, data) => {
-  if (err) {
-    console.error('Error reading the file:', err);
-    return;
-  }
 
-  // Parse YAML content
-  try {
+// Synchronous + fail-fast. A swallowed error here previously let CI
+// publish the raw typeconv spec (no paths, wrong title) — see #0408.
+try {
+    const data = fs.readFileSync(filePath, 'utf8');
     const yamlData = yaml.load(data);
 
     // Remove all 'title' properties from the YAML data
@@ -95,10 +92,10 @@ fs.readFile(filePath, 'utf8', (err, data) => {
 
     // Write the modified content back to the file
     fs.writeFileSync(filePath, modifiedYamlContent, 'utf8');
-  } catch (e) {
+} catch (e) {
     console.error('Error parsing or modifying YAML:', e);
-  }
-});
+    process.exit(1);
+}
 
 // Function to remove all 'title' properties recursively
 function removeTitleProperties(obj: any, parentKey: string) {
@@ -283,11 +280,15 @@ function addExamples(obj: any) {
     if (example.keys) {
       let temp = obj.components.schemas;
       for (const key of example.keys) {
-        temp = temp[key];
+        temp = temp?.[key];
       }
-      temp.examples = example.example ? [example.example] : example.examples;
+      if (temp) temp.examples = example.example ? [example.example] : example.examples;
     } else {
-      obj.components.schemas[`${example.key}`].examples = example.example ? [example.example] : example.examples;
+      // Schema may be absent if typeconv didn't emit it (env/dep
+      // dependent — node 18 vs 22). Skip the example rather than
+      // abort the whole merge. #0408
+      const target = obj.components.schemas[`${example.key}`];
+      if (target) target.examples = example.example ? [example.example] : example.examples;
     }
   }
 }
@@ -310,5 +311,7 @@ function orderDescriptionsAndRefs(obj: any) {
 }
 
 function removeTimestampLinks(obj: any) {
-  obj.components.schemas.UNIXMilliTimestamp.$ref = undefined;
+  if (obj.components.schemas.UNIXMilliTimestamp) {
+    obj.components.schemas.UNIXMilliTimestamp.$ref = undefined;
+  }
 }

--- a/packages/bitbadgesjs-sdk/scripts/spread_explodes.ts
+++ b/packages/bitbadgesjs-sdk/scripts/spread_explodes.ts
@@ -22,10 +22,11 @@ interface Parameter {
   required?: boolean;
 }
 
-function resolveReference(ref: string, document: any): Schema {
+function resolveReference(ref: string, document: any): Schema | undefined {
   const path = ref.replace('#/', '').split('/');
   let current = document;
   for (const segment of path) {
+    if (current == null) return undefined;
     current = current[segment];
   }
   return current;
@@ -37,6 +38,12 @@ function expandParameter(param: Parameter, document: any): Parameter[] {
   }
 
   const referencedSchema = resolveReference(param.schema.$ref, document);
+  if (!referencedSchema) {
+    // Dangling $ref — target schema was removed upstream (e.g. a
+    // deprecated payload typeconv no longer emits). Keep the param
+    // unexpanded instead of crashing the whole publish. #0408
+    return [param];
+  }
   if (!referencedSchema.properties || Object.keys(referencedSchema.properties).length === 0) {
     return [];
   }
@@ -59,6 +66,15 @@ function processYaml() {
     // Read and parse YAML
     const fileContent = readFileSync(inputPath, 'utf8');
     const document: any = yaml.load(fileContent);
+
+    // Guard: no paths means upstream assembly failed and combined.yaml
+    // is the raw typeconv output (typeconv emits an empty `paths: {}`,
+    // so the loop below would otherwise complete silently and overwrite
+    // the good file). Refuse to propagate it. #0408
+    if (!document || !document.paths || Object.keys(document.paths).length === 0) {
+      console.error('Error processing YAML: spec has no paths — upstream assembly failed, refusing to write.');
+      process.exit(1);
+    }
 
     // Process all paths
     for (const path of Object.values(document.paths)) {
@@ -91,6 +107,7 @@ function processYaml() {
     console.log(newYaml);
   } catch (error) {
     console.error('Error processing YAML:', error);
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary

The Stoplight API reference (`bitbadgesjs-sdk`) was silently wiped — schemas only, no routes, title literally `Converted from combined.yaml with typeconv`. The doc-gen pipeline **failed open** and CI reported **success** the whole time, so every SDK push to `main` kept re-publishing the broken spec.

Root cause (confirmed on the real CI env, node 18): `normalize_yml.ts` dereferenced hard-coded schema names with no existence check. typeconv's emitted schema set is environment-dependent (a name **absent on CI node 18** is **present on local node 22**), so the deref threw. The throw was swallowed (async `catch`, no exit), `spread_explodes` then propagated the raw typeconv output (empty `paths: {}`), and the Stoplight push ran unconditionally.

## Changes (4 files, ~55/16)

- **`normalize_yml.ts`**: sync read + `process.exit(1)` on error (was async + swallowed → exit 0); skip-if-absent guards on the hard-coded schema derefs in `addExamples()` / `removeTimestampLinks()` so a missing schema degrades one example, not the whole publish.
- **`spread_explodes.ts`**: `process.exit(1)` on error; refuse a spec with no `paths`; tolerate a dangling `$ref` (payload schema removed by the 2026-05-12 deprecations) instead of crashing.
- **`gen_api_docs_ci.sh`**: `set -eo pipefail`.
- **`genapi.yml`**: run the script via `bash` (not `source`) so a non-zero exit fails the job; add a **pre-push gate** asserting the assembled spec has `info.title == "BitBadges API"` and `paths >= 90` before the Stoplight push.

## Validation (real CI env, node 18, sandboxed — no Stoplight push)

- **Pre-fix** behaviour on node 18: the missing-schema throw → with the safety net, CI goes **red and refuses to publish** (this is exactly what would have prevented the incident).
- **With the schema guards**: pipeline runs **green end-to-end**, produces a correct spec (`title: BitBadges API`, **126 paths**), gate passes. → a post-merge `genapi` run on `main` will **restore** the live Stoplight docs.

## Notes

- Scope = safety net + the minimal unblock needed to restore (pre-agreed). Deferred follow-ups: pin `typeconv` (unpinned `npx`), full hard-coded-schema audit, and the `genapi.yml` `git restore .` ordering that has frozen the LLM-hosted `openapi-hosted/*` since 2026-04-24.
- **Restore is post-merge**: after this merges, trigger `genapi.yml` (`workflow_dispatch`) on `main`; the guarded run republishes the good spec.

Ref: autopilot backlog 0408

🤖 Generated with [Claude Code](https://claude.com/claude-code)