### PR TITLE
sdk: custom-2fa mint helper (#0407) + pm-intent consolidation (#0415) + --expiration rename (#0414)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/cli/commands/custom-2fa.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/custom-2fa.ts
@@ -1,0 +1,78 @@
+/**
+ * `bitbadges-cli custom-2fa` — end-user surface for the Custom-2FA standard.
+ * Mirrors the FE's `custom-2fa/Custom2FALayout` mint flow.
+ *
+ *   mint  — MsgTransferTokens that issues short-lived 2FA tokens
+ *
+ * Collection creation stays `bb build custom-2fa`. `mint` is the post-
+ * creation action: it encodes the 5-minute token lifetime at mint time
+ * (ownershipTimes), which the collection approval cannot do on its own.
+ */
+
+import { Command } from 'commander';
+import {
+  addIndexerNetworkOptions as addNetworkFlags,
+  addIndexerOutputOptions as addOutputFlags,
+  emitIndexerResult as emit,
+  emitIndexerError as emitError,
+  type IndexerNetworkFlags as NetworkFlags,
+  type IndexerOutputFlags as OutputFlags,
+} from '../utils/indexer-options.js';
+import { requireBb1AddressStrict } from '../utils/address.js';
+import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
+import { addExpiryOption, resolveExpiry } from '../utils/expiry-options.js';
+import { mintCustom2FA, CUSTOM_2FA_TOKEN_EXPIRATION_MS } from '../../core/builders/custom-2fa.js';
+
+export const custom2faCommand = new Command('custom-2fa').description(
+  'Custom-2FA standard — issue short-lived two-factor tokens. Create the collection with `bb build custom-2fa`, then `mint`.'
+);
+
+addDeployOptions(
+  addExpiryOption(
+    addOutputFlags(
+      addNetworkFlags(
+        custom2faCommand
+          .command('mint')
+          .description(
+            'Emit MsgTransferTokens that mints short-lived 2FA tokens. The lifetime is encoded at mint time (default 5m) — without it the tokens never expire.'
+          )
+          .argument('<collection-id>', 'Custom-2FA collection ID')
+          .requiredOption('--creator <address>', 'Manager address (bb1...) — only the manager may mint. Strict; run `bb account convert` for 0x')
+          .requiredOption('--to <addresses>', 'Recipient bb1... address(es), comma-separated')
+      )
+    ),
+    { description: '2FA token lifetime: duration (5m, 10m) or ms-since-epoch. Default 5m.' }
+  )
+).action(
+  async (
+    collectionId: string,
+    opts: NetworkFlags & OutputFlags & { creator: string; to: string; expiration?: string; expiry?: string }
+  ) => {
+    try {
+      const creator = requireBb1AddressStrict(opts.creator, '--creator');
+      const recipients = String(opts.to)
+        .split(',')
+        .map((a) => a.trim())
+        .filter(Boolean)
+        .map((a) => requireBb1AddressStrict(a, '--to'));
+      const endMs = resolveExpiry(opts, CUSTOM_2FA_TOKEN_EXPIRATION_MS);
+      const expirationMs = Number(endMs - BigInt(Date.now()));
+      if (expirationMs <= 0) {
+        throw new Error('--expiration must be in the future (a duration like 5m, or a future ms-since-epoch).');
+      }
+      const msg = mintCustom2FA({
+        creator,
+        collectionId: String(collectionId),
+        recipients,
+        expirationMs
+      });
+      await runEmitOrDeploy(msg, opts, { emit: (m) => emit(m, opts), expectedAddress: creator });
+    } catch (err) {
+      emitError(err);
+    }
+  }
+).addHelpText('after', `
+Examples:
+  $ bb custom-2fa mint 84 --creator bb1mgr...xyz --to bb1user...abc | bb deploy
+  $ bb custom-2fa mint 84 --creator bb1mgr...xyz --to bb1a...,bb1b... --expiration 10m --browser
+`);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
@@ -29,7 +29,7 @@ import { requireBb1Address, requireBb1AddressStrict } from '../utils/address.js'
 import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import { requireBbDenom } from '../utils/denom.js';
 import { resolveAmount } from '../utils/amount.js';
-import { resolveExpiry } from '../utils/expiry-options.js';
+import { addExpiryOption, resolveExpiry } from '../utils/expiry-options.js';
 import {
   buildOrderbookBidApproval,
   buildOrderbookListingApproval,
@@ -47,6 +47,7 @@ export const nftsCommand = new Command('nfts').description(
 addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
+    addExpiryOption(
     nftsCommand
       .command('bid')
       .description(
@@ -59,16 +60,16 @@ addOutputFlags(
       .option('--base-units', 'Treat --price as already-in-base-units')
       .option('--token-id <n>', 'Specific token ID to bid on (omit for collection-wide bid)')
       .option('--token-amount <n>', 'Number of tokens (default 1)', '1')
-      .option('--expiry <when>', 'Bid expiry: ms-since-epoch (1748140800000) or duration (7d, 24h, monthly). Default 7d.')
       .option('--approval-id <id>', 'Override the random approval id')
       .option('--max-fills <n>', 'Cap on partial fills (default 1)', '1')
+    , { description: 'Bid expiry: ms-since-epoch (1748140800000) or duration (7d, 24h, monthly). Default 7d.' })
   )
 )).action(
   async (
     collectionId: string,
     opts: NetworkFlags & OutputFlags & {
       creator: string; price: string; denom: string; baseUnits?: boolean;
-      tokenId?: string; tokenAmount?: string; expiry?: string; approvalId?: string; maxFills?: string;
+      tokenId?: string; tokenAmount?: string; expiration?: string; expiry?: string; approvalId?: string; maxFills?: string;
     }
   ) => {
     try {
@@ -97,7 +98,7 @@ addOutputFlags(
 ).addHelpText('after', `
 Examples:
   $ bb nfts bid 42 --creator bb1bidder...xyz --price 1.5 --denom USDC --token-id 7 | bb deploy
-  $ bb nfts bid 42 --creator bb1bidder...xyz --price 1.5 --denom USDC --expiry 24h | bb deploy
+  $ bb nfts bid 42 --creator bb1bidder...xyz --price 1.5 --denom USDC --expiration 24h | bb deploy
 `);
 
 // ── list (sell-side outgoing approval) ───────────────────────────────────
@@ -105,6 +106,7 @@ Examples:
 addDeployOptions(
 addOutputFlags(
   addNetworkFlags(
+    addExpiryOption(
     nftsCommand
       .command('list')
       .description('Emit MsgSetOutgoingApproval that lists a token for sale.')
@@ -116,15 +118,15 @@ addOutputFlags(
       .option('--base-units', 'Treat --price as already-in-base-units')
       .option('--token-amount <n>', 'Number of tokens (default 1)', '1')
       .option('--max-sales <n>', 'Allow multiple fills of this listing (default 1)', '1')
-      .option('--expiry <when>', 'Listing expiry: ms-since-epoch or duration (7d, 30d, monthly). Default 30d.')
       .option('--approval-id <id>', 'Override the random approval id')
+    , { description: 'Listing expiry: ms-since-epoch or duration (7d, 30d, monthly). Default 30d.' })
   )
 )).action(
   async (
     collectionId: string,
     opts: NetworkFlags & OutputFlags & {
       creator: string; tokenId: string; price: string; denom: string; baseUnits?: boolean;
-      tokenAmount?: string; maxSales?: string; expiry?: string; approvalId?: string;
+      tokenAmount?: string; maxSales?: string; expiration?: string; expiry?: string; approvalId?: string;
     }
   ) => {
     try {

--- a/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.spec.ts
@@ -39,11 +39,12 @@ describe('predictionMarketsCommand shape', () => {
     }
   });
 
-  it('buy/sell verbs accept --expiry + --approval-id', () => {
+  it('buy/sell verbs expose --expiration (canonical) + hidden --expiry alias + --approval-id', () => {
     for (const verb of ['buy-yes', 'buy-no', 'sell-yes', 'sell-no']) {
       const cmd = predictionMarketsCommand.commands.find((c) => c.name() === verb);
       const flagNames = (cmd! as any).options.map((o: any) => o.long);
-      expect(flagNames).toContain('--expiry');
+      expect(flagNames).toContain('--expiration');
+      expect(flagNames).toContain('--expiry'); // deprecated hidden alias, still functional
       expect(flagNames).toContain('--approval-id');
     }
   });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
@@ -27,7 +27,7 @@ import { requireBb1AddressStrict } from '../utils/address.js';
 import { bbError, BBErrorCode } from '../utils/envelope.js';
 import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import { resolveAmount } from '../utils/amount.js';
-import { resolveExpiry } from '../utils/expiry-options.js';
+import { addExpiryOption, resolveExpiry } from '../utils/expiry-options.js';
 import {
   validatePredictionMarketCollection,
   classifySettlementApproval,
@@ -191,7 +191,7 @@ addOutputFlags(
 function buyAction(side: 'yes' | 'no') {
   return async (
     collectionId: string,
-    opts: NetworkFlags & OutputFlags & { creator: string; tokenAmount: string; paymentAmount: string; denom: string; baseUnits?: boolean; expiry?: string; approvalId?: string }
+    opts: NetworkFlags & OutputFlags & { creator: string; tokenAmount: string; paymentAmount: string; denom: string; baseUnits?: boolean; expiration?: string; expiry?: string; approvalId?: string }
   ) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
@@ -222,7 +222,7 @@ function buyAction(side: 'yes' | 'no') {
 function sellAction(side: 'yes' | 'no') {
   return async (
     collectionId: string,
-    opts: NetworkFlags & OutputFlags & { creator: string; tokenAmount: string; paymentAmount: string; denom: string; baseUnits?: boolean; expiry?: string; approvalId?: string }
+    opts: NetworkFlags & OutputFlags & { creator: string; tokenAmount: string; paymentAmount: string; denom: string; baseUnits?: boolean; expiration?: string; expiry?: string; approvalId?: string }
   ) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
@@ -251,6 +251,7 @@ function sellAction(side: 'yes' | 'no') {
 }
 
 const tradeOpts = (cmd: Command, side: 'yes' | 'no', dir: 'buy' | 'sell') =>
+  addExpiryOption(
   cmd
     .description(
       `Emit Msg${dir === 'buy' ? 'SetIncomingApproval' : 'SetOutgoingApproval'} that ${dir === 'buy' ? 'buys' : 'sells'} ${side.toUpperCase()} tokens (token-id ${side === 'yes' ? '1' : '2'}). Pipe to \`bb deploy\`.`
@@ -261,13 +262,13 @@ const tradeOpts = (cmd: Command, side: 'yes' | 'no', dir: 'buy' | 'sell') =>
     .requiredOption('--payment-amount <n>', 'Payment side amount. Display units for symbol denoms, base units for chain denoms. Use --base-units to force base-units.')
     .requiredOption('--denom <symbol|denom>', 'Payment denom. BADGE, USDC, … or canonical denom (ubadge, ibc/...) or badgeslp:* alias.')
     .option('--base-units', 'Treat --payment-amount as already-in-base-units')
-    .option('--expiry <when>', 'Approval expiry: ms-since-epoch or duration (24h, 7d). Default 24h.')
-    .option('--approval-id <id>', 'Override the random approval id');
+    .option('--approval-id <id>', 'Override the random approval id'),
+  { description: 'Approval expiry: ms-since-epoch or duration (24h, 7d). Default 24h.' });
 
 addDeployOptions(addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('buy-yes'), 'yes', 'buy')))).action(buyAction('yes')).addHelpText('after', `
 Examples:
   $ bb prediction-markets buy-yes 55 --creator bb1trader...xyz --token-amount 100 --payment-amount 40 --denom USDC | bb deploy
-  $ bb prediction-markets buy-yes 55 --creator bb1trader...xyz --token-amount 100 --payment-amount 40 --denom USDC --expiry 7d | bb deploy
+  $ bb prediction-markets buy-yes 55 --creator bb1trader...xyz --token-amount 100 --payment-amount 40 --denom USDC --expiration 7d | bb deploy
 `);
 addDeployOptions(addOutputFlags(addNetworkFlags(tradeOpts(predictionMarketsCommand.command('buy-no'), 'no', 'buy')))).action(buyAction('no')).addHelpText('after', `
 Examples:

--- a/packages/bitbadgesjs-sdk/src/cli/index.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/index.ts
@@ -195,6 +195,7 @@ import { auctionsCommand } from './commands/auctions.js';
 import { predictionMarketsCommand } from './commands/prediction-markets.js';
 import { smartTokensCommand } from './commands/smart-tokens.js';
 import { nftsCommand } from './commands/nfts.js';
+import { custom2faCommand } from './commands/custom-2fa.js';
 
 // Misc
 import { makeCompletionCommand } from './commands/completion.js';
@@ -302,6 +303,7 @@ const HELP_GROUPS: { title: string; commands: Command[] }[] = [
       predictionMarketsCommand,
       smartTokensCommand,
       nftsCommand,
+      custom2faCommand,
       dynamicStoresCommand
     ]
   }

--- a/packages/bitbadgesjs-sdk/src/cli/integration/cli-build-pipeline.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/cli-build-pipeline.spec.ts
@@ -143,14 +143,17 @@ describe('cli build pipeline integration', () => {
   });
 
   describe('bb build pm-buy-intent', () => {
-    it('emits MsgUpdateUserApprovals (incoming)', () => {
+    it('emits MsgSetIncomingApproval — identical shape to bb prediction-markets buy-yes', () => {
       const out = runCli([
         'build', 'pm-buy-intent',
         '--address', CREATOR, '--collection-id', '1',
         '--token', 'yes', '--amount', '10',
         '--price', '5', '--denom', 'USDC'
       ]);
-      expect(out.json.typeUrl).toBe('/tokenization.MsgUpdateUserApprovals');
+      expect(out.json.typeUrl).toBe('/tokenization.MsgSetIncomingApproval');
+      expect(out.json.value.creator).toBe(CREATOR);
+      expect(out.json.value.collectionId).toBe('1');
+      expect(out.json.value.approval.fromListId).toBe('All');
     });
   });
 
@@ -241,14 +244,17 @@ describe('cli build pipeline integration', () => {
   });
 
   describe('bb build pm-sell-intent', () => {
-    it('emits MsgUpdateUserApprovals (outgoing)', () => {
+    it('emits MsgSetOutgoingApproval — identical shape to bb prediction-markets sell-no', () => {
       const out = runCli([
         'build', 'pm-sell-intent',
         '--address', CREATOR, '--collection-id', '1',
         '--token', 'no', '--amount', '10',
         '--price', '5', '--denom', 'USDC'
       ]);
-      expect(out.json.typeUrl).toBe('/tokenization.MsgUpdateUserApprovals');
+      expect(out.json.typeUrl).toBe('/tokenization.MsgSetOutgoingApproval');
+      expect(out.json.value.creator).toBe(CREATOR);
+      expect(out.json.value.collectionId).toBe('1');
+      expect(out.json.value.approval.toListId).toBe('All');
     });
   });
 

--- a/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
@@ -16,7 +16,12 @@ import { buildProductCatalog } from './product-catalog.js';
 import { buildPredictionMarket } from './prediction-market.js';
 import { buildSmartToken } from './smart-token.js';
 import { buildCreditToken } from './credit-token.js';
-import { buildCustom2FA } from './custom-2fa.js';
+import {
+  buildCustom2FA,
+  mintCustom2FA,
+  getCustom2FAOwnershipTimes,
+  CUSTOM_2FA_TOKEN_EXPIRATION_MS
+} from './custom-2fa.js';
 import { buildQuests } from './quests.js';
 import { buildAddressList } from './address-list.js';
 import { buildIntent } from './intent.js';
@@ -25,6 +30,7 @@ import { buildBid } from './bid.js';
 import { buildPmSellIntent } from './pm-sell-intent.js';
 import { buildPmBuyIntent } from './pm-buy-intent.js';
 import { resolveCoin, parseDuration, toBaseUnits, sanitizeCosmosPathName } from './shared.js';
+import { buildPredictionMarketBuyIntent, buildPredictionMarketSellIntent } from '../prediction-markets.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -528,6 +534,45 @@ describe('custom-2fa builder', () => {
   });
 });
 
+describe('mintCustom2FA (mint-side expiry helper, ticket 0407)', () => {
+  test('default lifetime window is exactly 5 minutes (300000ms)', () => {
+    const msg = mintCustom2FA({ creator: 'bb1mgr', collectionId: '84', recipients: ['bb1user'] });
+    expect(msg.typeUrl).toBe('/tokenization.MsgTransferTokens');
+    const ot = msg.value.transfers[0].balances[0].ownershipTimes[0];
+    expect(Number(ot.end) - Number(ot.start)).toBe(CUSTOM_2FA_TOKEN_EXPIRATION_MS);
+    expect(CUSTOM_2FA_TOKEN_EXPIRATION_MS).toBe(300000);
+  });
+  test('custom lifetime is honored', () => {
+    const msg = mintCustom2FA({ creator: 'bb1mgr', collectionId: '84', recipients: ['bb1user'], expirationMs: 600000 });
+    const ot = msg.value.transfers[0].balances[0].ownershipTimes[0];
+    expect(Number(ot.end) - Number(ot.start)).toBe(600000);
+  });
+  test('getCustom2FAOwnershipTimes round-trips the FE window', () => {
+    const [t] = getCustom2FAOwnershipTimes();
+    expect(Number(t.end) - Number(t.start)).toBe(300000);
+  });
+  test('mints token id 1, amount 1, from Mint', () => {
+    const t = mintCustom2FA({ creator: 'bb1mgr', collectionId: '84', recipients: ['bb1a', 'bb1b'] }).value.transfers[0];
+    expect(t.from).toBe('Mint');
+    expect(t.toAddresses).toEqual(['bb1a', 'bb1b']);
+    expect(t.balances[0].amount).toBe('1');
+    expect(t.balances[0].tokenIds).toEqual([{ start: '1', end: '1' }]);
+  });
+  test('de-dupes recipients', () => {
+    const t = mintCustom2FA({ creator: 'bb1mgr', collectionId: '84', recipients: ['bb1a', 'bb1a', 'bb1b'] }).value.transfers[0];
+    expect(t.toAddresses).toEqual(['bb1a', 'bb1b']);
+  });
+  test('throws without a manager (creator)', () => {
+    expect(() => mintCustom2FA({ creator: '', collectionId: '84', recipients: ['bb1a'] })).toThrow(/manager/i);
+  });
+  test('throws without recipients', () => {
+    expect(() => mintCustom2FA({ creator: 'bb1mgr', collectionId: '84', recipients: [] })).toThrow(/recipient/i);
+  });
+  test('throws on non-positive lifetime', () => {
+    expect(() => mintCustom2FA({ creator: 'bb1mgr', collectionId: '84', recipients: ['bb1a'], expirationMs: 0 })).toThrow(/positive/i);
+  });
+});
+
 describe('quests builder', () => {
   const msg = buildQuests({ reward: 10, denom: 'BADGE', maxClaims: 100, ...META });
   const r = val(msg);
@@ -653,30 +698,70 @@ describe('bid builder', () => {
   });
 });
 
-describe('pm-sell-intent builder', () => {
+describe('pm-sell-intent builder (delegates to canonical)', () => {
   const msg = buildPmSellIntent({ address: 'bb1seller', collectionId: '42', token: 'yes', amount: 100, price: 50, denom: 'USDC' });
 
-  test('outgoing approval', () => { expect(msg.value.updateOutgoingApprovals).toBe(true); });
-  test('YES = token ID 1', () => { expect(msg.value.outgoingApprovals[0].tokenIds).toEqual([{ start: '1', end: '1' }]); });
+  test('emits MsgSetOutgoingApproval — same envelope as bb prediction-markets sell-yes', () => {
+    expect(msg.typeUrl).toBe('/tokenization.MsgSetOutgoingApproval');
+    expect(msg.value.creator).toBe('bb1seller');
+    expect(msg.value.collectionId).toBe('42');
+  });
+  test('YES = token ID 1 (canonical bigint shape)', () => {
+    expect(msg.value.approval.tokenIds).toEqual([{ start: 1n, end: 1n }]);
+    expect(msg.value.approval.toListId).toBe('All');
+  });
   test('NO = token ID 2', () => {
     const no = buildPmSellIntent({ address: 'bb1', collectionId: '42', token: 'no', amount: 1, price: 1, denom: 'USDC' });
-    expect(no.value.outgoingApprovals[0].tokenIds).toEqual([{ start: '2', end: '2' }]);
+    expect(no.value.approval.tokenIds).toEqual([{ start: 2n, end: 2n }]);
   });
-  test('pays seller', () => { expect(msg.value.outgoingApprovals[0].approvalCriteria.coinTransfers[0].to).toBe('bb1seller'); });
-  test('meta', () => { expect(msg._meta.collectionId).toBe('42'); expect(msg._meta.token).toBe('yes'); });
+  test('pays seller', () => { expect(msg.value.approval.approvalCriteria.coinTransfers[0].to).toBe('bb1seller'); });
+  test('no _meta — byte-identical to the prediction-markets path', () => {
+    expect((msg as any)._meta).toBeUndefined();
+  });
+  test('approval == buildPredictionMarketSellIntent for equivalent args (delegation parity)', () => {
+    const a = msg.value.approval;
+    const canonical = buildPredictionMarketSellIntent({
+      address: 'bb1seller', collectionId: '42', tokenId: 1n, tokenAmount: 100n,
+      paymentDenom: a.approvalCriteria.coinTransfers[0].coins[0].denom,
+      paymentAmount: BigInt(a.approvalCriteria.coinTransfers[0].coins[0].amount),
+      transferTimes: a.transferTimes, approvalId: a.approvalId
+    });
+    expect(a).toEqual(canonical);
+  });
+  test('deterministic approval id for identical params', () => {
+    const a = buildPmSellIntent({ address: 'bb1s', collectionId: '7', token: 'yes', amount: 3, price: 9, denom: 'USDC' });
+    const b = buildPmSellIntent({ address: 'bb1s', collectionId: '7', token: 'yes', amount: 3, price: 9, denom: 'USDC' });
+    expect(a.value.approval.approvalId).toBe(b.value.approval.approvalId);
+  });
 });
 
-describe('pm-buy-intent builder', () => {
+describe('pm-buy-intent builder (delegates to canonical)', () => {
   const msg = buildPmBuyIntent({ address: 'bb1buyer', collectionId: '42', token: 'no', amount: 200, price: 30, denom: 'USDC' });
 
-  test('incoming approval', () => { expect(msg.value.updateIncomingApprovals).toBe(true); });
-  test('NO = token ID 2', () => { expect(msg.value.incomingApprovals[0].tokenIds).toEqual([{ start: '2', end: '2' }]); });
+  test('emits MsgSetIncomingApproval — same envelope as bb prediction-markets buy-no', () => {
+    expect(msg.typeUrl).toBe('/tokenization.MsgSetIncomingApproval');
+    expect(msg.value.creator).toBe('bb1buyer');
+    expect(msg.value.collectionId).toBe('42');
+  });
+  test('NO = token ID 2 (canonical bigint shape)', () => {
+    expect(msg.value.approval.tokenIds).toEqual([{ start: 2n, end: 2n }]);
+    expect(msg.value.approval.fromListId).toBe('All');
+  });
   test('escrow-funded', () => {
-    const ct = msg.value.incomingApprovals[0].approvalCriteria.coinTransfers[0];
+    const ct = msg.value.approval.approvalCriteria.coinTransfers[0];
     expect(ct.overrideFromWithApproverAddress).toBe(true);
     expect(ct.overrideToWithInitiator).toBe(true);
   });
-  test('meta', () => { expect(msg._meta.collectionId).toBe('42'); expect(msg._meta.escrowCoins.length).toBe(1); });
+  test('approval == buildPredictionMarketBuyIntent for equivalent args (delegation parity)', () => {
+    const a = msg.value.approval;
+    const canonical = buildPredictionMarketBuyIntent({
+      address: 'bb1buyer', collectionId: '42', tokenId: 2n, tokenAmount: 200n,
+      paymentDenom: a.approvalCriteria.coinTransfers[0].coins[0].denom,
+      paymentAmount: BigInt(a.approvalCriteria.coinTransfers[0].coins[0].amount),
+      transferTimes: a.transferTimes, approvalId: a.approvalId
+    });
+    expect(a).toEqual(canonical);
+  });
 });
 
 // ── Zero-violations suite: every builder must pass ALL standard checks ───────
@@ -773,9 +858,8 @@ describe('error handling', () => {
     expect(msg.value.outgoingApprovals[0].tokenIds).toEqual([{ start: '42', end: '42' }]);
   });
 
-  test('buildPmSellIntent invalid token value still works', () => {
-    // TypeScript would catch this, but runtime should not crash
+  test('buildPmSellIntent emits canonical token ids', () => {
     const msg = buildPmSellIntent({ address: 'bb1a', collectionId: '1', token: 'yes', amount: 1, price: 1, denom: 'BADGE' });
-    expect(msg.value.outgoingApprovals[0].tokenIds).toEqual([{ start: '1', end: '1' }]);
+    expect(msg.value.approval.tokenIds).toEqual([{ start: 1n, end: 1n }]);
   });
 });

--- a/packages/bitbadgesjs-sdk/src/core/builders/custom-2fa.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/custom-2fa.ts
@@ -174,3 +174,79 @@ export function buildCustom2FA(params: Custom2FAParams): any {
     tokenMetadata: [tokenMetadataEntry([{ start: '1', end: '1' }], collectionSource, '2FA token')]
   });
 }
+
+/**
+ * 5-minute default 2FA token lifetime. Mirrors the FE constant
+ * `CUSTOM_2FA_TOKEN_EXPIRATION_MS` in
+ * `bitbadges-frontend/src/bitbadges-api/utils/custom-2fa-protocol.ts`.
+ */
+export const CUSTOM_2FA_TOKEN_EXPIRATION_MS = 300000;
+
+/**
+ * The mint-time ownership window `[now, now + expirationMs]` — string ms.
+ * The collection approval uses FOREVER + `allowPurgeIfExpired`, so the
+ * short lifetime MUST be encoded here at mint time (exactly what the FE
+ * `getCustom2FAOwnershipTimes()` does). Without it the minted token gets
+ * full ownership and never expires, silently breaking the 2FA guarantee.
+ */
+export function getCustom2FAOwnershipTimes(
+  expirationMs: number = CUSTOM_2FA_TOKEN_EXPIRATION_MS
+): { start: string; end: string }[] {
+  const now = Date.now();
+  return [{ start: String(now), end: String(now + expirationMs) }];
+}
+
+export interface MintCustom2FAParams {
+  /** Manager address — the only address allowed to mint (matches the
+   *  collection's `custom-2fa-mint` approval `initiatedByListId`). */
+  creator: string;
+  collectionId: string;
+  /** bb1... recipients to issue a 2FA token to (token id 1, amount 1). */
+  recipients: string[];
+  /** Token lifetime in ms. Default 5 min (`CUSTOM_2FA_TOKEN_EXPIRATION_MS`). */
+  expirationMs?: number;
+}
+
+/**
+ * Build the mint `MsgTransferTokens` for custom-2fa tokens, encoding the
+ * short lifetime at mint time via `ownershipTimes` — the SDK/CLI mirror of
+ * the FE `Custom2FALayout` mint. A CLI user who broadcasts their own mint
+ * without this gets forever-tokens.
+ */
+export function mintCustom2FA(params: MintCustom2FAParams): { typeUrl: string; value: any } {
+  if (!params.creator) {
+    throw new Error(
+      'mintCustom2FA requires --creator <bb1...> (the manager; only the manager may mint 2FA tokens).'
+    );
+  }
+  const recipients = (params.recipients ?? []).filter(Boolean);
+  const toAddresses = recipients.filter((a, i) => recipients.indexOf(a) === i);
+  if (toAddresses.length === 0) {
+    throw new Error('mintCustom2FA requires at least one recipient (--to <bb1...>).');
+  }
+  const expirationMs = params.expirationMs ?? CUSTOM_2FA_TOKEN_EXPIRATION_MS;
+  if (!Number.isFinite(expirationMs) || expirationMs <= 0) {
+    throw new Error('mintCustom2FA: token lifetime must be a positive duration.');
+  }
+  return {
+    typeUrl: '/tokenization.MsgTransferTokens',
+    value: {
+      creator: params.creator,
+      collectionId: String(params.collectionId),
+      transfers: [
+        {
+          from: 'Mint',
+          toAddresses,
+          balances: [
+            {
+              amount: '1',
+              tokenIds: [{ start: '1', end: '1' }],
+              ownershipTimes: getCustom2FAOwnershipTimes(expirationMs)
+            }
+          ],
+          memo: ''
+        }
+      ]
+    }
+  };
+}

--- a/packages/bitbadgesjs-sdk/src/core/builders/index.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/index.ts
@@ -25,7 +25,14 @@ export {
   SMART_TOKEN_TRANSFERABLE_APPROVAL_ID
 } from './smart-token.js';
 export { buildCreditToken, type CreditTokenParams } from './credit-token.js';
-export { buildCustom2FA, type Custom2FAParams } from './custom-2fa.js';
+export {
+  buildCustom2FA,
+  type Custom2FAParams,
+  mintCustom2FA,
+  getCustom2FAOwnershipTimes,
+  CUSTOM_2FA_TOKEN_EXPIRATION_MS,
+  type MintCustom2FAParams
+} from './custom-2fa.js';
 export { buildQuests, type QuestsParams } from './quests.js';
 export { buildAddressList, type AddressListParams } from './address-list.js';
 

--- a/packages/bitbadgesjs-sdk/src/core/builders/pm-buy-intent.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/pm-buy-intent.ts
@@ -1,111 +1,63 @@
 /**
  * Prediction Market Buy Intent — user incoming approval to buy YES/NO tokens.
  *
- * The creator wants to buy YES or NO tokens from a prediction market collection
- * and pays via escrow. The seller transfers tokens and receives payment.
+ * Thin display-unit wrapper over the canonical
+ * `buildPredictionMarketBuyIntent` (core/prediction-markets.ts) — the same
+ * builder `bb prediction-markets buy-yes` uses. `bb build pm-buy-intent`
+ * and `bb prediction-markets buy-*` now emit the identical
+ * `MsgSetIncomingApproval` shape; this file only resolves display→base
+ * units + a deterministic approval id, then delegates.
  *
  * @module core/builders/pm-buy-intent
  */
-import {
-  FOREVER,
-  resolveCoin,
-  toBaseUnits,
-  durationToTimestamp,
-  uniqueId,
-  buildUserApprovalMsg,
-  approvalMetadata
-} from './shared.js';
+import { resolveCoin, toBaseUnits, durationToTimestamp, stableHashId } from './shared.js';
+import { buildPredictionMarketBuyIntent, type PredictionMarketSideArgs } from '../prediction-markets.js';
+import { UintRangeArray } from '../uintRanges.js';
 
 export interface PmBuyIntentParams {
   address: string; // buyer bb1... address
   collectionId: string; // prediction market collection ID
   token: 'yes' | 'no'; // which outcome token to buy
-  amount: number; // number of tokens to buy (display units)
+  amount: number; // number of tokens to buy (unitless count)
   price: number; // total payment amount (display units)
   denom: string; // payment coin (USDC, BADGE)
   expiration?: string; // duration shorthand, default "7d"
 }
 
-export function buildPmBuyIntent(params: PmBuyIntentParams): any {
+export function buildPmBuyIntent(params: PmBuyIntentParams): { typeUrl: string; value: any } {
   if (!Number.isInteger(params.amount) || params.amount <= 0) {
     throw new Error(
       `buildPmBuyIntent: amount must be a positive integer (got ${params.amount}). Prediction market tokens are unitless counts, not fractional.`
     );
   }
   const coin = resolveCoin(params.denom);
-  const basePrice = toBaseUnits(params.price, coin.decimals);
-  const expirationTs = durationToTimestamp(params.expiration || '7d');
-  const id = uniqueId('pm-buy');
-  const tokenId = params.token === 'yes' ? '1' : '2';
-
-  const approval = {
-    approvalId: id,
-    ...approvalMetadata(
-      'Buy prediction tokens',
-      'Receive prediction market outcome tokens in exchange for an escrowed payment.'
-    ),
-    fromListId: 'All',
-    initiatedByListId: 'All',
-    transferTimes: [{ start: '1', end: expirationTs }],
-    tokenIds: [{ start: tokenId, end: tokenId }],
-    ownershipTimes: FOREVER,
-    version: '0',
-    approvalCriteria: {
-      predeterminedBalances: {
-        manualBalances: [],
-        incrementedBalances: {
-          startBalances: [{ amount: String(params.amount), tokenIds: [{ start: tokenId, end: tokenId }], ownershipTimes: FOREVER }],
-          incrementTokenIdsBy: '0',
-          incrementOwnershipTimesBy: '0',
-          durationFromTimestamp: '0',
-          allowOverrideTimestamp: false,
-          recurringOwnershipTimes: { startTime: '0', intervalLength: '0', chargePeriodLength: '0' },
-          allowOverrideWithAnyValidToken: false,
-          allowAmountScaling: false,
-          maxScalingMultiplier: '0'
-        },
-        orderCalculationMethod: {
-          useOverallNumTransfers: true,
-          usePerToAddressNumTransfers: false,
-          usePerFromAddressNumTransfers: false,
-          usePerInitiatedByAddressNumTransfers: false,
-          useMerkleChallengeLeafIndex: false,
-          challengeTrackerId: ''
-        }
-      },
-      maxNumTransfers: {
-        overallMaxNumTransfers: '1',
-        perToAddressMaxNumTransfers: '0',
-        perFromAddressMaxNumTransfers: '0',
-        perInitiatedByAddressMaxNumTransfers: '0',
-        amountTrackerId: id,
-        resetTimeIntervals: { startTime: '0', intervalLength: '0' }
-      },
-      coinTransfers: [
-        // Buyer's escrow pays seller
-        {
-          to: '',
-          coins: [{ amount: basePrice, denom: coin.denom }],
-          overrideFromWithApproverAddress: true,
-          overrideToWithInitiator: true
-        }
-      ],
-      autoDeletionOptions: {
-        afterOneUse: true,
-        afterOverallMaxNumTransfers: true,
-        allowCounterpartyPurge: false,
-        allowPurgeIfExpired: true
-      }
-    }
+  const tokenId = params.token === 'yes' ? 1n : 2n;
+  const end = BigInt(durationToTimestamp(params.expiration || '7d'));
+  const approvalId = stableHashId('pm-buy', {
+    address: params.address,
+    collectionId: params.collectionId,
+    token: params.token,
+    amount: params.amount,
+    price: params.price,
+    denom: coin.denom
+  });
+  const args: PredictionMarketSideArgs = {
+    address: params.address,
+    collectionId: String(params.collectionId),
+    tokenId,
+    tokenAmount: BigInt(params.amount),
+    paymentDenom: coin.denom,
+    paymentAmount: BigInt(toBaseUnits(params.price, coin.decimals)),
+    transferTimes: UintRangeArray.From([{ start: 1n, end }]),
+    approvalId
   };
-
+  const approval = buildPredictionMarketBuyIntent(args);
   return {
-    ...buildUserApprovalMsg({ collectionId: params.collectionId, incomingApprovals: [approval] }),
-    _meta: {
-      description: `PM Buy: ${params.amount} ${params.token.toUpperCase()} for ${params.price} ${coin.symbol}`,
-      collectionId: params.collectionId,
-      token: params.token,
-      escrowCoins: [{ amount: basePrice, denom: coin.denom }]
+    typeUrl: '/tokenization.MsgSetIncomingApproval',
+    value: {
+      creator: params.address,
+      collectionId: String(params.collectionId),
+      approval
     }
   };
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/pm-sell-intent.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/pm-sell-intent.ts
@@ -1,110 +1,63 @@
 /**
  * Prediction Market Sell Intent — user outgoing approval to sell YES/NO tokens.
  *
- * The creator sells a specified amount of YES or NO tokens from a prediction
- * market collection and receives payment in return.
+ * Thin display-unit wrapper over the canonical
+ * `buildPredictionMarketSellIntent` (core/prediction-markets.ts) — the same
+ * builder `bb prediction-markets sell-yes` uses. `bb build pm-sell-intent`
+ * and `bb prediction-markets sell-*` now emit the identical
+ * `MsgSetOutgoingApproval` shape; this file only resolves display→base
+ * units + a deterministic approval id, then delegates.
  *
  * @module core/builders/pm-sell-intent
  */
-import {
-  FOREVER,
-  resolveCoin,
-  toBaseUnits,
-  durationToTimestamp,
-  uniqueId,
-  buildUserApprovalMsg,
-  approvalMetadata
-} from './shared.js';
+import { resolveCoin, toBaseUnits, durationToTimestamp, stableHashId } from './shared.js';
+import { buildPredictionMarketSellIntent, type PredictionMarketSideArgs } from '../prediction-markets.js';
+import { UintRangeArray } from '../uintRanges.js';
 
 export interface PmSellIntentParams {
   address: string; // seller bb1... address
   collectionId: string; // prediction market collection ID
   token: 'yes' | 'no'; // which outcome token to sell
-  amount: number; // number of tokens to sell (display units)
+  amount: number; // number of tokens to sell (unitless count)
   price: number; // total payment amount (display units)
   denom: string; // payment coin (USDC, BADGE)
   expiration?: string; // duration shorthand, default "7d"
 }
 
-export function buildPmSellIntent(params: PmSellIntentParams): any {
+export function buildPmSellIntent(params: PmSellIntentParams): { typeUrl: string; value: any } {
   if (!Number.isInteger(params.amount) || params.amount <= 0) {
     throw new Error(
       `buildPmSellIntent: amount must be a positive integer (got ${params.amount}). Prediction market tokens are unitless counts, not fractional.`
     );
   }
   const coin = resolveCoin(params.denom);
-  const basePrice = toBaseUnits(params.price, coin.decimals);
-  const expirationTs = durationToTimestamp(params.expiration || '7d');
-  const id = uniqueId('pm-sell');
-  const tokenId = params.token === 'yes' ? '1' : '2';
-
-  const approval = {
-    approvalId: id,
-    ...approvalMetadata(
-      'Sell prediction tokens',
-      'Offer prediction market outcome tokens for sale at a fixed price.'
-    ),
-    toListId: 'All',
-    initiatedByListId: 'All',
-    transferTimes: [{ start: '1', end: expirationTs }],
-    tokenIds: [{ start: tokenId, end: tokenId }],
-    ownershipTimes: FOREVER,
-    version: '0',
-    approvalCriteria: {
-      predeterminedBalances: {
-        manualBalances: [],
-        incrementedBalances: {
-          startBalances: [{ amount: String(params.amount), tokenIds: [{ start: tokenId, end: tokenId }], ownershipTimes: FOREVER }],
-          incrementTokenIdsBy: '0',
-          incrementOwnershipTimesBy: '0',
-          durationFromTimestamp: '0',
-          allowOverrideTimestamp: false,
-          recurringOwnershipTimes: { startTime: '0', intervalLength: '0', chargePeriodLength: '0' },
-          allowOverrideWithAnyValidToken: false,
-          allowAmountScaling: false,
-          maxScalingMultiplier: '0'
-        },
-        orderCalculationMethod: {
-          useOverallNumTransfers: true,
-          usePerToAddressNumTransfers: false,
-          usePerFromAddressNumTransfers: false,
-          usePerInitiatedByAddressNumTransfers: false,
-          useMerkleChallengeLeafIndex: false,
-          challengeTrackerId: ''
-        }
-      },
-      maxNumTransfers: {
-        overallMaxNumTransfers: '1',
-        perToAddressMaxNumTransfers: '0',
-        perFromAddressMaxNumTransfers: '0',
-        perInitiatedByAddressMaxNumTransfers: '0',
-        amountTrackerId: id,
-        resetTimeIntervals: { startTime: '0', intervalLength: '0' }
-      },
-      coinTransfers: [
-        // Buyer pays seller directly
-        {
-          to: params.address,
-          coins: [{ amount: basePrice, denom: coin.denom }],
-          overrideFromWithApproverAddress: false,
-          overrideToWithInitiator: false
-        }
-      ],
-      autoDeletionOptions: {
-        afterOneUse: true,
-        afterOverallMaxNumTransfers: true,
-        allowCounterpartyPurge: false,
-        allowPurgeIfExpired: true
-      }
-    }
+  const tokenId = params.token === 'yes' ? 1n : 2n;
+  const end = BigInt(durationToTimestamp(params.expiration || '7d'));
+  const approvalId = stableHashId('pm-sell', {
+    address: params.address,
+    collectionId: params.collectionId,
+    token: params.token,
+    amount: params.amount,
+    price: params.price,
+    denom: coin.denom
+  });
+  const args: PredictionMarketSideArgs = {
+    address: params.address,
+    collectionId: String(params.collectionId),
+    tokenId,
+    tokenAmount: BigInt(params.amount),
+    paymentDenom: coin.denom,
+    paymentAmount: BigInt(toBaseUnits(params.price, coin.decimals)),
+    transferTimes: UintRangeArray.From([{ start: 1n, end }]),
+    approvalId
   };
-
+  const approval = buildPredictionMarketSellIntent(args);
   return {
-    ...buildUserApprovalMsg({ collectionId: params.collectionId, outgoingApprovals: [approval] }),
-    _meta: {
-      description: `PM Sell: ${params.amount} ${params.token.toUpperCase()} for ${params.price} ${coin.symbol}`,
-      collectionId: params.collectionId,
-      token: params.token
+    typeUrl: '/tokenization.MsgSetOutgoingApproval',
+    value: {
+      creator: params.address,
+      collectionId: String(params.collectionId),
+      approval
     }
   };
 }


### PR DESCRIPTION
Three related SDK/CLI tickets, one PR, three commits.

## #0407 — custom-2fa mint-side expiry helper (bug fix)
The custom-2fa collection approval uses `FOREVER` + `allowPurgeIfExpired`, so the 5-minute token lifetime **must** be encoded at mint time (the FE does this in `Custom2FALayout` via `getCustom2FAOwnershipTimes()`). The SDK/CLI had no mint helper — a CLI user broadcasting their own mint got **forever-tokens**, silently breaking the standard.
- `mintCustom2FA()` + `getCustom2FAOwnershipTimes()` + `CUSTOM_2FA_TOKEN_EXPIRATION_MS` (300000), mirroring the FE protocol util.
- New `bb custom-2fa mint` command (shared deploy flags + `--expiration`; `runEmitOrDeploy` so default emits JSON, `--browser`/`--burner` broadcast inline).

## #0415 — pm-buy/sell-intent consolidation (refactor)
`bb build pm-*-intent` used a slim string-shaped `MsgUpdateUserApprovals` builder; `bb prediction-markets buy/sell` used the canonical proto-shape `buildPredictionMarket{Buy,Sell}Intent` + `MsgSet{Incoming,Outgoing}Approval`. Both valid, but divergent. The slim builders now delegate to the canonical path and emit the **identical** shape (`_meta` dropped for true parity). Deterministic `stableHashId` replaces the last `uniqueId`. Low broadcast risk: `bb prediction-markets buy/sell | bb deploy` already exercises this exact msg type.

## #0414 — `--expiry` → `--expiration` (rename only)
The shared `addExpiryOption` helper (canonical `--expiration` + hidden deprecated `--expiry` that warns once) already existed. The 3 remaining inline `--expiry` sites (nfts bid/list, prediction-markets buy/sell) now adopt it. Scoped to the rename per agreement — the list/amount flag-sweep + network-shim-deletion churn from the parent tickets is dropped (no logic-dedup payoff).

## Validation
- Build clean (no circular deps).
- Unit: **137 suites / 3039 tests green**.
- Integration: **19/19 suites / 177 tests green** (one transient indexer-propagation flake in the unrelated `dynamic-stores` suite; passes 6/6 on re-run).

## Downstream
- bitbadges-docs PR: documents `bb custom-2fa mint` + standards-table row.
- Plugin / chain / frontend / indexer: confirmed no change needed (FE is the reference for 0407/0415; docs never referenced `--expiry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)