### PR TITLE
sdk: intent/listing/bid canonical consolidation + 0416-0421 follow-up batch

### DIFF
--- a/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/auctions.ts
@@ -4,7 +4,7 @@
  */
 
 import { Command } from 'commander';
-import * as crypto from 'node:crypto';
+import { resolveApprovalId } from '../utils/approval-id-options.js';
 import {
   addIndexerNetworkOptions as addNetworkFlags,
   addIndexerOutputOptions as addOutputFlags,
@@ -171,7 +171,7 @@ addOutputFlags(
       const transferTimes = details.acceptDeadline > 0n
         ? UintRangeArray.From([{ start: 1n, end: details.acceptDeadline }])
         : UintRangeArray.FullRanges();
-      const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
+      const approvalId = resolveApprovalId(opts);
       const approval = buildAuctionBidApproval({
         bidderAddress: creator,
         tokenId: 1n,

--- a/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/build.ts
@@ -745,7 +745,7 @@ sharedOpts(
     .requiredOption('--pay-amount <n>', 'Amount you send (display units)')
     .requiredOption('--receive-denom <symbol|denom>', 'What you receive. BADGE, USDC, … or canonical denom (ubadge, ibc/...)')
     .requiredOption('--receive-amount <n>', 'Amount you receive (display units)')
-    .option('--expiration <duration>', 'How long intent stays open', '7d')
+    .option('--expiration <duration>', 'How long intent stays open (default 30d, matches `bb intents create`)', '30d')
 ).action(async (opts) => {
   const { buildIntent } = await import('../../core/builders/intent.js');
   if (opts.json) { emit(buildIntent(readJsonInput(opts.json)), opts); return; }
@@ -890,14 +890,13 @@ sharedOpts(
           amount: [{ denom, amount }]
         }
       };
-      const text = opts.condensed ? JSON.stringify(msg) : JSON.stringify(msg, null, 2);
-      if (opts.outputFile) {
-        const fs = await import('node:fs');
-        fs.writeFileSync(opts.outputFile, text + '\n', 'utf-8');
-        if (!isQuiet({})) process.stderr.write(`Written to ${opts.outputFile}\n`);
-      } else {
-        process.stdout.write(text + '\n');
-      }
+      // Route through the shared emit() like every sibling build
+      // subcommand so --condensed/--output-file AND the deploy gate
+      // (--browser/--burner/--simulate) actually work. MsgSend is
+      // envelope-safe: not a collection / approval / transfer tx, so
+      // emit() skips all the collection-specific backfill and falls
+      // straight to output + the deploy gate.
+      emit(msg, opts);
     } catch (err: any) {
       process.stderr.write(`Error: ${err?.message || err}\n`);
       process.exit(1);

--- a/packages/bitbadgesjs-sdk/src/cli/commands/custom-2fa.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/custom-2fa.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * Command-tree shape tests for custom-2fa.ts (ticket 0420). Behavioural
+ * parse/guard coverage (comma-split recipients, expiry→duration, the
+ * future-window guard) lives in cli/integration/cli-build-pipeline.spec.ts
+ * (runCli emit-only, no devnet); the on-chain broadcast lives in
+ * cli/integration/custom-2fa.spec.ts. This guards flag/subcommand drift
+ * in the fast unit suite.
+ */
+
+import { custom2faCommand } from './custom-2fa.js';
+
+describe('custom2faCommand shape', () => {
+  it('exposes only the mint subcommand', () => {
+    expect(custom2faCommand.commands.map((c) => c.name()).sort()).toEqual(['mint']);
+  });
+
+  it('mint requires --creator + --to, takes a <collection-id> arg', () => {
+    const cmd = custom2faCommand.commands.find((c) => c.name() === 'mint')!;
+    const mandatory = (cmd as any).options.filter((o: any) => o.mandatory).map((o: any) => o.long);
+    expect(mandatory).toEqual(expect.arrayContaining(['--creator', '--to']));
+    expect((cmd as any)._args.map((a: any) => a.name())).toEqual(['collection-id']);
+  });
+
+  it('mint exposes canonical --expiration + hidden --expiry alias + the shared deploy flags', () => {
+    const cmd = custom2faCommand.commands.find((c) => c.name() === 'mint')!;
+    const all = (cmd as any).options.map((o: any) => o.long);
+    expect(all).toContain('--expiration');
+    expect(all).toContain('--expiry'); // deprecated hidden alias
+    expect(all).toEqual(expect.arrayContaining(['--browser', '--burner']));
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/intents.ts
@@ -18,8 +18,8 @@
  * SDK helpers.
  */
 
-import { Command } from 'commander';
-import * as crypto from 'node:crypto';
+import { Command, Option } from 'commander';
+import { resolveApprovalId } from '../utils/approval-id-options.js';
 import {
   addIndexerNetworkOptions as addNetworkFlags,
   addIndexerOutputOptions as addOutputFlags,
@@ -35,7 +35,8 @@ import { addDeployOptions, runEmitOrDeploy } from '../utils/deploy-options.js';
 import { appendQuery } from '../utils/list-options.js';
 import { requireBbDenom } from '../utils/denom.js';
 import { resolveAmount } from '../utils/amount.js';
-import { parseTimeFlag } from '../utils/time.js';
+import { resolveExpiry } from '../utils/expiry-options.js';
+import { emitDeprecation } from '../utils/deprecation.js';
 import {
   buildIntentApproval,
   buildIntentFillTx,
@@ -167,9 +168,11 @@ addOutputFlags(
         .requiredOption('--receive-amount <amount>', 'Amount of receive denom. Display units for symbol denoms, base units for chain denoms.')
         .option('--base-units', 'Treat --pay-amount and --receive-amount as already-in-base-units')
         .option(
-          '--valid-until <when>',
-          'Optional expiration: ms-since-epoch or duration (24h, 7d, 30d, monthly). Default 30d.'
+          '--expiration <when>',
+          'Expiration: ms-since-epoch (1748140800000) or duration (24h, 7d, 30d, monthly). Default 30d.'
         )
+        .addOption(new Option('--expiry <when>', 'Deprecated alias for --expiration').hideHelp())
+        .addOption(new Option('--valid-until <when>', 'Deprecated alias for --expiration').hideHelp())
         .option('--approval-id <id>', 'Override the auto-generated approval id (random hex by default)')
     )
   )
@@ -184,6 +187,8 @@ addOutputFlags(
         receiveDenom: string;
         receiveAmount: string;
         baseUnits?: boolean;
+        expiration?: string;
+        expiry?: string;
         validUntil?: string;
         approvalId?: string;
       }
@@ -207,11 +212,13 @@ addOutputFlags(
         process.stderr.write('Error: --pay-denom and --receive-denom must differ.\n');
         process.exit(2);
       }
-      const validUntil = opts.validUntil
-        ? parseTimeFlag(opts.validUntil, '--valid-until')
-        : BigInt(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      if (opts.validUntil && !opts.expiration) emitDeprecation('--valid-until', '--expiration');
+      const validUntil = resolveExpiry(
+        { expiration: opts.expiration ?? opts.validUntil, expiry: opts.expiry },
+        30 * 24 * 60 * 60 * 1000
+      );
       const collectionId = resolveCollectionId(opts);
-      const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
+      const approvalId = resolveApprovalId(opts);
 
       const approval = buildIntentApproval({
         address: creator,

--- a/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/nfts.ts
@@ -15,7 +15,7 @@
  */
 
 import { Command } from 'commander';
-import * as crypto from 'node:crypto';
+import { resolveApprovalId } from '../utils/approval-id-options.js';
 import {
   addIndexerNetworkOptions as addNetworkFlags,
   addIndexerOutputOptions as addOutputFlags,
@@ -81,7 +81,7 @@ addOutputFlags(
         { amountFlag: '--price', denomFlag: '--denom' }
       );
       const end = resolveExpiry(opts, 7 * 24 * 60 * 60 * 1000);
-      const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
+      const approvalId = resolveApprovalId(opts);
       const approval = buildOrderbookBidApproval({
         address: creator,
         tokenId: opts.tokenId ? BigInt(opts.tokenId) : undefined,
@@ -138,7 +138,7 @@ addOutputFlags(
         { amountFlag: '--price', denomFlag: '--denom' }
       );
       const end = resolveExpiry(opts, 30 * 24 * 60 * 60 * 1000);
-      const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
+      const approvalId = resolveApprovalId(opts);
       const approval = buildOrderbookListingApproval({
         address: creator,
         tokenId: BigInt(opts.tokenId),

--- a/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/prediction-markets.ts
@@ -13,7 +13,7 @@
  */
 
 import { Command } from 'commander';
-import * as crypto from 'node:crypto';
+import { resolveApprovalId } from '../utils/approval-id-options.js';
 import {
   addIndexerNetworkOptions as addNetworkFlags,
   addIndexerOutputOptions as addOutputFlags,
@@ -203,7 +203,7 @@ function buyAction(side: 'yes' | 'no') {
       );
       await fetchCollection(collectionId, opts).then((c) => validateOrExit(c, `prediction-markets buy-${side}`));
       const end = resolveExpiry(opts, 24 * 60 * 60 * 1000);
-      const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
+      const approvalId = resolveApprovalId(opts);
       const approval = buildPredictionMarketBuyIntent({
         address: creator,
         collectionId: String(collectionId),
@@ -234,7 +234,7 @@ function sellAction(side: 'yes' | 'no') {
       );
       await fetchCollection(collectionId, opts).then((c) => validateOrExit(c, `prediction-markets sell-${side}`));
       const end = resolveExpiry(opts, 24 * 60 * 60 * 1000);
-      const approvalId = opts.approvalId ?? crypto.randomBytes(16).toString('hex');
+      const approvalId = resolveApprovalId(opts);
       const approval = buildPredictionMarketSellIntent({
         address: creator,
         collectionId: String(collectionId),

--- a/packages/bitbadgesjs-sdk/src/cli/commands/subscriptions.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/subscriptions.ts
@@ -19,7 +19,7 @@
  */
 
 import { Command } from 'commander';
-import * as crypto from 'node:crypto';
+import { resolveApprovalId } from '../utils/approval-id-options.js';
 import {
   addIndexerNetworkOptions as addNetworkFlags,
   addIndexerOutputOptions as addOutputFlags,
@@ -350,11 +350,12 @@ addOutputFlags(
       .requiredOption('--creator <address>', 'Subscriber address (bb1.../0x — auto-normalized)')
       .option('--tier <approvalId>', 'Which faucet to renew (required for multi-tier collections)')
       .option('--tip <ubadge>', 'Optional tip per interval on top of the base subscription amount (in base denom units)', '0')
+      .option('--approval-id <id>', 'Override the auto-generated recurring-approval id (random hex by default)')
   )
 )).action(
   async (
     collectionId: string,
-    opts: NetworkFlags & OutputFlags & { creator: string; tier?: string; tip?: string }
+    opts: NetworkFlags & OutputFlags & { creator: string; tier?: string; tip?: string; approvalId?: string }
   ) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
@@ -369,7 +370,7 @@ addOutputFlags(
         firstIntervalStartTime: BigInt(Date.now()),
         ubadgeTipAmount: tip,
         transferTimes: UintRangeArray.FullRanges(),
-        approvalId: crypto.randomBytes(16).toString('hex'),
+        approvalId: resolveApprovalId(opts),
         tokenIds: faucet.tokenIds,
         denom
       });
@@ -454,11 +455,12 @@ addOutputFlags(
       .requiredOption('--creator <address>', 'Subscriber address (bb1.../0x — auto-normalized)')
       .option('--tier <approvalId>', 'Which faucet to subscribe to (required for multi-tier collections)')
       .option('--tip <ubadge>', 'Optional tip per interval on top of the base subscription amount', '0')
+      .option('--approval-id <id>', 'Override the auto-generated recurring-approval id (random hex by default)')
   )
 ).action(
   async (
     collectionId: string,
-    opts: NetworkFlags & OutputFlags & { creator: string; tier?: string; tip?: string }
+    opts: NetworkFlags & OutputFlags & { creator: string; tier?: string; tip?: string; approvalId?: string }
   ) => {
     try {
       const creator = requireBb1AddressStrict(opts.creator, '--creator');
@@ -475,7 +477,7 @@ addOutputFlags(
         firstIntervalStartTime: BigInt(Date.now()),
         ubadgeTipAmount: tip,
         transferTimes: UintRangeArray.FullRanges(),
-        approvalId: crypto.randomBytes(16).toString('hex'),
+        approvalId: resolveApprovalId(opts),
         tokenIds: faucet.tokenIds,
         denom
       });

--- a/packages/bitbadgesjs-sdk/src/cli/integration/cli-build-pipeline.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/cli-build-pipeline.spec.ts
@@ -83,6 +83,62 @@ describe('cli build pipeline integration', () => {
     });
   });
 
+  // `bb custom-2fa mint` parse/guard coverage (ticket 0420) — emit-only,
+  // no devnet. The on-chain broadcast is in integration/custom-2fa.spec.ts.
+  describe('bb custom-2fa mint (parse + guards)', () => {
+    const BURN = 'bb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs7gvmv';
+
+    it('emits MsgTransferTokens with a default 5-minute (300000ms) ownership window', () => {
+      const out = runCli(['custom-2fa', 'mint', '84', '--creator', CREATOR, '--to', BURN, '--local']);
+      expect(out.json.typeUrl).toBe('/tokenization.MsgTransferTokens');
+      const t = out.json.value.transfers[0];
+      expect(t.from).toBe('Mint');
+      expect(t.toAddresses).toEqual([BURN]);
+      const ot = t.balances[0].ownershipTimes[0];
+      expect(Number(ot.end) - Number(ot.start)).toBe(300000);
+    });
+
+    it('honors a custom --expiration duration (10m → 600000ms)', () => {
+      const out = runCli(['custom-2fa', 'mint', '84', '--creator', CREATOR, '--to', BURN, '--expiration', '10m', '--local']);
+      const ot = out.json.value.transfers[0].balances[0].ownershipTimes[0];
+      expect(Number(ot.end) - Number(ot.start)).toBe(600000);
+    });
+
+    it('comma-splits + de-dupes recipients', () => {
+      const out = runCli(['custom-2fa', 'mint', '84', '--creator', CREATOR, '--to', `${CREATOR},${CREATOR},${BURN}`, '--local']);
+      expect(out.json.value.transfers[0].toAddresses).toEqual([CREATOR, BURN]);
+    });
+
+    it('rejects a non-bb1 recipient (strict)', () => {
+      const out = runCli(
+        ['custom-2fa', 'mint', '84', '--creator', CREATOR, '--to', '0x0000000000000000000000000000000000000000', '--local'],
+        { throwOnError: false, parseJson: false }
+      );
+      expect(out.exitCode).not.toBe(0);
+    });
+
+    it('rejects a valid-but-past --expiration (future-window guard)', () => {
+      // 1577836800000 = 2020-01-01 UTC: a valid ms-since-epoch (parses
+      // fine) that is firmly in the past, so it reaches and trips the
+      // command's `expirationMs <= 0` guard.
+      const out = runCli(
+        ['custom-2fa', 'mint', '84', '--creator', CREATOR, '--to', BURN, '--expiration', '1577836800000', '--local'],
+        { throwOnError: false, parseJson: false }
+      );
+      expect(out.exitCode).not.toBe(0);
+      expect(out.stderr + out.stdout).toMatch(/future/i);
+    });
+
+    it('rejects an unparseable --expiration value', () => {
+      const out = runCli(
+        ['custom-2fa', 'mint', '84', '--creator', CREATOR, '--to', BURN, '--expiration', 'not-a-time', '--local'],
+        { throwOnError: false, parseJson: false }
+      );
+      expect(out.exitCode).not.toBe(0);
+      expect(out.stderr + out.stdout).toMatch(/invalid (time|duration)/i);
+    });
+  });
+
   describe('bb build quests', () => {
     it('emits MsgCreateCollection with the quest standard', () => {
       const out = runCli([
@@ -107,38 +163,43 @@ describe('cli build pipeline integration', () => {
   // ── Approval builders (user-level) ─────────────────────────────────────
 
   describe('bb build listing', () => {
-    it('emits MsgUpdateUserApprovals with one outgoing approval', () => {
+    it('emits MsgSetOutgoingApproval — identical shape to bb nfts list', () => {
       const out = runCli([
         'build', 'listing',
         '--address', CREATOR, '--collection-id', '1', '--token-ids', '1',
         '--price', '10', '--denom', 'USDC'
       ]);
-      expect(out.json.typeUrl).toBe('/tokenization.MsgUpdateUserApprovals');
-      expect(out.json.value.outgoingApprovals?.length ?? 0).toBeGreaterThan(0);
+      expect(out.json.typeUrl).toBe('/tokenization.MsgSetOutgoingApproval');
+      expect(out.json.value.creator).toBe(CREATOR);
+      expect(out.json.value.collectionId).toBe('1');
+      expect(out.json.value.approval.toListId).toBe('All');
     });
   });
 
   describe('bb build bid', () => {
-    it('emits MsgUpdateUserApprovals with one incoming approval', () => {
+    it('emits MsgSetIncomingApproval — identical shape to bb nfts bid', () => {
       const out = runCli([
         'build', 'bid',
         '--address', CREATOR, '--collection-id', '1', '--token-ids', '1',
         '--price', '5', '--denom', 'USDC'
       ]);
-      expect(out.json.typeUrl).toBe('/tokenization.MsgUpdateUserApprovals');
-      expect(out.json.value.incomingApprovals?.length ?? 0).toBeGreaterThan(0);
+      expect(out.json.typeUrl).toBe('/tokenization.MsgSetIncomingApproval');
+      expect(out.json.value.creator).toBe(CREATOR);
+      expect(out.json.value.approval.fromListId).toBe('All');
     });
   });
 
   describe('bb build intent', () => {
-    it('emits MsgUpdateUserApprovals (outgoing) for an OTC swap intent', () => {
+    it('emits MsgSetOutgoingApproval — identical shape to bb intents create', () => {
       const out = runCli([
         'build', 'intent',
         '--address', CREATOR, '--collection-id', '24',
         '--pay-denom', 'USDC', '--pay-amount', '10',
         '--receive-denom', 'BADGE', '--receive-amount', '100'
       ]);
-      expect(out.json.typeUrl).toBe('/tokenization.MsgUpdateUserApprovals');
+      expect(out.json.typeUrl).toBe('/tokenization.MsgSetOutgoingApproval');
+      expect(out.json.value.creator).toBe(CREATOR);
+      expect(out.json.value.approval.fromListId).toBe(CREATOR);
     });
   });
 

--- a/packages/bitbadgesjs-sdk/src/cli/integration/custom-2fa.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/custom-2fa.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Integration: `bb custom-2fa mint` end-to-end (ticket 0420).
+ *
+ * Personas:
+ *   - alice → collection manager + minter (genesis funds)
+ *   - charlie → 2FA token recipient
+ *
+ * Flow:
+ *   1. alice builds + deploys a Custom-2FA collection (--creator=alice)
+ *   2. alice mints a 2FA token to charlie via `bb custom-2fa mint`
+ *      → assert the emitted MsgTransferTokens encodes a bounded
+ *        (5-min) ownershipTimes window, NOT FullRanges (the #0407
+ *        forever-token regression this command exists to prevent)
+ *   3. broadcast the mint → chain accepts the bounded-window transfer
+ *      (code 0) — proves the helper works end-to-end on-chain.
+ *
+ * Skipped automatically when preflight fails.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import { preflightIntegration } from './harness/preflight.js';
+import { alice, charlie } from './harness/personas.js';
+import { runCli } from './harness/cli.js';
+import { deployMsgViaKeyring, waitForIndexerCollection, writeMsgToTmp } from './harness/chain.js';
+
+describe('custom-2fa mint integration', () => {
+  let ready = false;
+  let collectionId: string | undefined;
+
+  beforeAll(async () => {
+    ready = (await preflightIntegration()).ok;
+  }, 30000);
+
+  it('build + deploy creates a Custom-2FA collection', async () => {
+    if (!ready) return;
+    const manager = alice();
+    const tmp = path.join(os.tmpdir(), `c2fa-build-${crypto.randomBytes(4).toString('hex')}.json`);
+
+    runCli(
+      [
+        'build',
+        'custom-2fa',
+        '--name', 'Test 2FA',
+        '--image', 'https://example.com/2fa.png',
+        '--description', 'Short-lived 2FA token',
+        '--creator', manager.address,
+        '--output-file', tmp
+      ],
+      { parseJson: false } // build emits a review block, not JSON
+    );
+    expect(fs.existsSync(tmp)).toBe(true);
+
+    const tx = await deployMsgViaKeyring(tmp, manager.name);
+    expect(tx.code).toBe(0);
+    expect(tx.collectionId).toBeDefined();
+    collectionId = tx.collectionId!;
+    await waitForIndexerCollection(collectionId);
+  }, 90000);
+
+  it('mint encodes a bounded 5-min ownership window (not FullRanges) and the chain accepts it', async () => {
+    if (!ready || !collectionId) return;
+    const manager = alice();
+    const recipient = charlie();
+
+    const mintMsg = runCli([
+      'custom-2fa', 'mint', collectionId,
+      '--creator', manager.address,
+      '--to', recipient.address,
+      '--local'
+    ]);
+    expect(mintMsg.json.typeUrl).toBe('/tokenization.MsgTransferTokens');
+    const bal = mintMsg.json.value.transfers[0].balances[0];
+    expect(bal.tokenIds).toEqual([{ start: '1', end: '1' }]);
+    // The whole point of #0407: a 5-minute window, NOT a forever token.
+    const ot = bal.ownershipTimes[0];
+    expect(Number(ot.end) - Number(ot.start)).toBe(300000);
+    expect(bal.ownershipTimes.length).toBe(1);
+
+    const tmp = writeMsgToTmp(mintMsg.json, 'c2fa-mint');
+    const tx = await deployMsgViaKeyring(tmp, manager.name);
+    expect(tx.code).toBe(0);
+  }, 90000);
+});

--- a/packages/bitbadgesjs-sdk/src/cli/integration/prediction-markets.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/integration/prediction-markets.spec.ts
@@ -126,7 +126,7 @@ describe('prediction-markets integration', () => {
     expect(tx.code).toBe(0);
   }, 90000);
 
-  it('charlie places a SELL-NO intent → MsgSetOutgoingApproval (chain may reject)', async () => {
+  it('charlie places a SELL-NO intent → MsgSetOutgoingApproval accepted (code 0)', async () => {
     if (!ready || !collectionId) return;
     const trader = charlie();
 
@@ -142,9 +142,11 @@ describe('prediction-markets integration', () => {
 
     const tmp = writeMsgToTmp(sellMsg.json, 'pm-sell-no');
     const tx = await deployMsgViaKeyring(tmp, trader.name);
-    // Chain accepts the intent-set msg even if charlie has no NO tokens to
-    // sell — the actual fill only happens when a counterparty matches.
-    expect([0, tx.code]).toContain(tx.code);
+    // Setting an OUTGOING approval does not require holding the token —
+    // the chain accepts it (the actual fill only happens when a
+    // counterparty matches). `expect([0, tx.code]).toContain(tx.code)`
+    // was a tautology; assert the real accepted code.
+    expect(tx.code).toBe(0);
   }, 90000);
 
   it('cancel emits MsgDeleteIncomingApproval with the supplied approval id', async () => {

--- a/packages/bitbadgesjs-sdk/src/cli/utils/approval-id-options.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/approval-id-options.spec.ts
@@ -1,0 +1,28 @@
+import { Command } from 'commander';
+import { addApprovalIdOption, resolveApprovalId } from './approval-id-options.js';
+
+const longFlags = (cmd: Command) => (cmd as any).options.map((o: any) => o.long);
+
+describe('addApprovalIdOption', () => {
+  test('adds --approval-id', () => {
+    const cmd = addApprovalIdOption(new Command('a'));
+    expect(longFlags(cmd)).toContain('--approval-id');
+  });
+  test('idempotent — does not clobber a pre-declared flag', () => {
+    const cmd = new Command('b').option('--approval-id <id>', 'preexisting');
+    addApprovalIdOption(cmd);
+    expect((cmd as any)._findOption('--approval-id').description).toBe('preexisting');
+  });
+});
+
+describe('resolveApprovalId', () => {
+  test('returns the pinned id verbatim when provided', () => {
+    expect(resolveApprovalId({ approvalId: 'my-fixed-id' })).toBe('my-fixed-id');
+  });
+  test('generates a fresh 32-hex-char id when not pinned', () => {
+    const a = resolveApprovalId({});
+    const b = resolveApprovalId({});
+    expect(a).toMatch(/^[0-9a-f]{32}$/);
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/utils/approval-id-options.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/approval-id-options.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared `--approval-id` flag + resolution (ticket 0418).
+ *
+ * `opts.approvalId ?? crypto.randomBytes(16).toString('hex')` was
+ * re-implemented ≥6× (nfts bid/list, auctions, prediction-markets
+ * buy/sell, intents), and two subscriptions sites generated a bare
+ * random id with no override flag at all (couldn't be pinned for
+ * replay). This is the one shared RNG + resolver.
+ *
+ * Group label is a caller param — the flag keeps its per-command help
+ * slot (pass nothing to stay ungrouped, matching the existing sites).
+ */
+import { Command } from 'commander';
+import * as crypto from 'node:crypto';
+import { tagHelpGroups } from './help-groups.js';
+
+export function addApprovalIdOption(
+  cmd: Command,
+  cfg: { group?: string; description?: string } = {}
+): Command {
+  const desc = cfg.description ?? 'Override the auto-generated approval id (random 16-byte hex by default)';
+  if (!(cmd as any)._findOption?.('--approval-id')) {
+    cmd.option('--approval-id <id>', desc);
+  }
+  if (cfg.group) tagHelpGroups(cmd, { '--approval-id': cfg.group });
+  return cmd;
+}
+
+/** `--approval-id` if the user pinned one, else a fresh 16-byte hex id. */
+export function resolveApprovalId(opts: { approvalId?: string }): string {
+  return opts.approvalId ?? crypto.randomBytes(16).toString('hex');
+}

--- a/packages/bitbadgesjs-sdk/src/core/builders/bid.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/bid.ts
@@ -1,122 +1,64 @@
 /**
- * Bid builder — creates a user incoming approval for a marketplace bid.
- *
- * The bidder offers to buy tokens at a specified price. The seller
- * transfers tokens and the bidder pays via escrow coinTransfers.
+ * Bid builder — thin display-unit wrapper over the canonical
+ * `buildOrderbookBidApproval` (core/bids.ts), the same builder
+ * `bb nfts bid` uses. `bb build bid` and `bb nfts bid` now emit the
+ * identical `MsgSetIncomingApproval` shape.
  *
  * @module core/builders/bid
  */
-import {
-  FOREVER,
-  resolveCoin,
-  toBaseUnits,
-  durationToTimestamp,
-  stableHashId,
-  buildUserApprovalMsg,
-  approvalMetadata
-} from './shared.js';
+import { resolveCoin, toBaseUnits, durationToTimestamp, stableHashId } from './shared.js';
+import { buildOrderbookBidApproval, type OrderbookOrderArgs } from '../bids.js';
+import { UintRangeArray } from '../uintRanges.js';
 
 export interface BidParams {
   address: string; // bidder bb1... address
   collectionId: string; // collection to bid on
-  tokenIds: string; // "1-5" or "1"
+  tokenIds: string; // single token id (orderbook bids are single-token here)
   price: number; // bid price (display units)
   denom: string; // price coin (USDC, BADGE)
   expiration?: string; // bid duration, default "7d"
 }
 
-function parseTokenIdRange(input: string): any[] {
-  if (input.includes('-')) {
-    const [start, end] = input.split('-').map((s) => s.trim());
-    return [{ start, end }];
+/** Orderbook bids via the build verb are single-token. Accept "5" or "5-5"; reject a true range. */
+function singleTokenId(input: string, ctx: string): bigint {
+  const parts = String(input).split('-').map((s) => s.trim());
+  if (parts.length === 2 && parts[0] !== parts[1]) {
+    throw new Error(
+      `${ctx} supports a single token id (got range "${input}"). Bid per token id, or use \`bb nfts bid\` (omit --token-id) for a collection-wide bid.`
+    );
   }
-  return [{ start: input, end: input }];
+  return BigInt(parts[0]);
 }
 
-export function buildBid(params: BidParams): any {
+export function buildBid(params: BidParams): { typeUrl: string; value: any } {
   const coin = resolveCoin(params.denom);
-  const basePrice = toBaseUnits(params.price, coin.decimals);
-  const expirationTs = durationToTimestamp(params.expiration || '7d');
-  // Deterministic id so re-running the same bid is replayable/diff-able.
-  // Seeded on the shorthand params (not the resolved expiration
-  // timestamp, which is Date.now()-based); distinct bids on the same
-  // collection still get distinct ids because the seed differs.
-  const id = stableHashId('bid', {
+  const tokenId = singleTokenId(params.tokenIds, 'bid');
+  const end = BigInt(durationToTimestamp(params.expiration || '7d'));
+  const approvalId = stableHashId('bid', {
     address: params.address,
     collectionId: params.collectionId,
     tokenIds: params.tokenIds,
     price: params.price,
-    denom: params.denom,
+    denom: coin.denom,
     expiration: params.expiration || '7d'
   });
-  const tokenIds = parseTokenIdRange(params.tokenIds);
-
-  const approval = {
-    approvalId: id,
-    ...approvalMetadata(
-      'Bid',
-      'This approval is a proposal for this address to receive a token if certain conditions are met.'
-    ),
-    fromListId: 'All',
-    initiatedByListId: 'All',
-    transferTimes: [{ start: '1', end: expirationTs }],
-    tokenIds,
-    ownershipTimes: FOREVER,
-    version: '0',
-    approvalCriteria: {
-      predeterminedBalances: {
-        manualBalances: [],
-        incrementedBalances: {
-          startBalances: [{ amount: '1', tokenIds, ownershipTimes: FOREVER }],
-          incrementTokenIdsBy: '0',
-          incrementOwnershipTimesBy: '0',
-          durationFromTimestamp: '0',
-          allowOverrideTimestamp: false,
-          recurringOwnershipTimes: { startTime: '0', intervalLength: '0', chargePeriodLength: '0' },
-          allowOverrideWithAnyValidToken: false,
-          allowAmountScaling: false,
-          maxScalingMultiplier: '0'
-        },
-        orderCalculationMethod: {
-          useOverallNumTransfers: true,
-          usePerToAddressNumTransfers: false,
-          usePerFromAddressNumTransfers: false,
-          usePerInitiatedByAddressNumTransfers: false,
-          useMerkleChallengeLeafIndex: false,
-          challengeTrackerId: ''
-        }
-      },
-      maxNumTransfers: {
-        overallMaxNumTransfers: '1',
-        perToAddressMaxNumTransfers: '0',
-        perFromAddressMaxNumTransfers: '0',
-        perInitiatedByAddressMaxNumTransfers: '0',
-        amountTrackerId: id,
-        resetTimeIntervals: { startTime: '0', intervalLength: '0' }
-      },
-      coinTransfers: [
-        {
-          to: params.address,
-          coins: [{ amount: basePrice, denom: coin.denom }],
-          overrideFromWithApproverAddress: true,
-          overrideToWithInitiator: true
-        }
-      ],
-      autoDeletionOptions: {
-        afterOneUse: true,
-        afterOverallMaxNumTransfers: true,
-        allowCounterpartyPurge: false,
-        allowPurgeIfExpired: true
-      }
-    }
+  const args: OrderbookOrderArgs = {
+    address: params.address,
+    tokenId,
+    paymentAmount: BigInt(toBaseUnits(params.price, coin.decimals)),
+    paymentDenom: coin.denom,
+    tokenAmount: 1n,
+    transferTimes: UintRangeArray.From([{ start: 1n, end }]),
+    approvalId,
+    maxNumTransfers: 1n
   };
-
+  const approval = buildOrderbookBidApproval(args);
   return {
-    ...buildUserApprovalMsg({ collectionId: params.collectionId, incomingApprovals: [approval] }),
-    _meta: {
-      description: `Bid: ${params.price} ${coin.symbol} for token ${params.tokenIds} in collection ${params.collectionId}`,
-      collectionId: params.collectionId,
-      escrowCoins: [{ amount: basePrice, denom: coin.denom }]
+    typeUrl: '/tokenization.MsgSetIncomingApproval',
+    value: {
+      creator: params.address,
+      collectionId: String(params.collectionId),
+      approval
     }
   };
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/bounty.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/bounty.ts
@@ -9,7 +9,7 @@ import {
   resolveCoin,
   toBaseUnits,
   durationToTimestamp,
-  uniqueId,
+  stableHashId,
   buildMsg,
   frozenPermissions,
   defaultBalances,
@@ -57,6 +57,17 @@ export function buildBounty(params: BountyParams): any {
   const coin = resolveCoin(params.denom);
   const baseAmount = toBaseUnits(params.amount, coin.decimals);
   const expirationTs = durationToTimestamp(params.expiration || '30d');
+  // Deterministic votingChallenges proposalIds (was uniqueId — the last
+  // 0405/0406 straggler). Seed on the bounty params, NOT the Date.now()-
+  // based expirationTs, so identical params replay byte-identical.
+  const proposalSeed = {
+    amount: params.amount,
+    denom: coin.denom,
+    verifier: params.verifier,
+    recipient: params.recipient,
+    submitter: params.submitter,
+    expiration: params.expiration || '30d'
+  };
 
   const collectionApprovals = [
     // Accept — verifier approves, pays recipient
@@ -81,7 +92,7 @@ export function buildBounty(params: BountyParams): any {
         },
         votingChallenges: [
           {
-            proposalId: uniqueId('bounty-accept'),
+            proposalId: stableHashId('bounty-accept', proposalSeed),
             quorumThreshold: '100',
             voters: [{ address: params.verifier, weight: '1' }]
           }
@@ -120,7 +131,7 @@ export function buildBounty(params: BountyParams): any {
         },
         votingChallenges: [
           {
-            proposalId: uniqueId('bounty-deny'),
+            proposalId: stableHashId('bounty-deny', proposalSeed),
             quorumThreshold: '100',
             voters: [{ address: params.verifier, weight: '1' }]
           }

--- a/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
@@ -31,6 +31,8 @@ import { buildPmSellIntent } from './pm-sell-intent.js';
 import { buildPmBuyIntent } from './pm-buy-intent.js';
 import { resolveCoin, parseDuration, toBaseUnits, sanitizeCosmosPathName } from './shared.js';
 import { buildPredictionMarketBuyIntent, buildPredictionMarketSellIntent } from '../prediction-markets.js';
+import { buildIntentApproval } from '../intents.js';
+import { buildOrderbookBidApproval, buildOrderbookListingApproval } from '../bids.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -235,8 +237,11 @@ describe('smart-token builder', () => {
     const t = val(buildSmartToken({ backingCoin: 'USDC', aiAgentVault: true, ...META }));
     expect(t.standards).toContain('AI Agent Vault');
   });
-  test('passes verification', () => {
-    expect(verifyBuilder(msg).violations.filter((vi: any) => vi.standard === 'Smart Token')).toEqual([]);
+  test('deterministic — identical params produce byte-identical msg', () => {
+    expect(buildSmartToken({ backingCoin: 'USDC', ...META })).toEqual(buildSmartToken({ backingCoin: 'USDC', ...META }));
+  });
+  test('passes verification with zero violations (any standard)', () => {
+    expectCleanVerification(msg);
   });
 });
 
@@ -288,8 +293,12 @@ describe('subscription builder', () => {
       })
     ).toThrow(/single denom/);
   });
-  test('passes verification', () => {
-    expect(verifyBuilder(msg).violations.filter((vi: any) => vi.standard === 'Subscription')).toEqual([]);
+  test('deterministic — identical params produce byte-identical msg', () => {
+    expect(buildSubscription({ interval: 'monthly', price: 10, denom: 'USDC', recipient: 'bb1test', ...META }))
+      .toEqual(buildSubscription({ interval: 'monthly', price: 10, denom: 'USDC', recipient: 'bb1test', ...META }));
+  });
+  test('passes verification with zero violations (any standard)', () => {
+    expectCleanVerification(msg);
   });
 });
 
@@ -313,8 +322,22 @@ describe('bounty builder', () => {
   test('escrow coins', () => {
     expect(r.mintEscrowCoinsToTransfer[0].amount).toBe('100000000');
   });
-  test('passes verification', () => {
-    expect(verifyBuilder(msg).violations.filter((vi: any) => vi.standard === 'Bounty')).toEqual([]);
+  test('deterministic votingChallenges proposalIds (no uniqueId)', () => {
+    const p = { amount: 100, denom: 'USDC', verifier: 'bb1v', recipient: 'bb1r', submitter: 'bb1s', ...META };
+    const a = val(buildBounty(p)).collectionApprovals;
+    const b = val(buildBounty(p)).collectionApprovals;
+    const pid = (c: any[], id: string) =>
+      c.find((x: any) => x.approvalId === id).approvalCriteria.votingChallenges[0].proposalId;
+    expect(pid(a, 'bounty-accept')).toBe(pid(b, 'bounty-accept'));
+    expect(pid(a, 'bounty-deny')).toBe(pid(b, 'bounty-deny'));
+    expect(pid(a, 'bounty-accept')).not.toBe(pid(a, 'bounty-deny'));
+    expect(pid(a, 'bounty-accept').startsWith('bounty-accept-')).toBe(true);
+    // distinct params → distinct proposalId
+    expect(pid(val(buildBounty({ ...p, amount: 101 })).collectionApprovals, 'bounty-accept'))
+      .not.toBe(pid(a, 'bounty-accept'));
+  });
+  test('passes verification with zero violations (any standard)', () => {
+    expectCleanVerification(msg);
   });
 });
 
@@ -357,8 +380,13 @@ describe('payment-request builder', () => {
       expect(a.approvalCriteria.votingChallenges).toBeUndefined();
     }
   });
-  test('passes verification', () => {
-    expect(verifyBuilder(msg).violations.filter((vi: any) => vi.standard === 'PaymentRequest')).toEqual([]);
+  test('deterministic approval ids (no random ids; time window aside)', () => {
+    const prParams = { amount: 10, denom: 'USDC', payer: 'bb1payer', recipient: 'bb1recipient', context: 'ctx', name: 'Test', image: 'ipfs://test-image' };
+    const ids = (m: any) => m.value.collectionApprovals.map((a: any) => a.approvalId);
+    expect(ids(buildPaymentRequest(prParams))).toEqual(ids(buildPaymentRequest(prParams)));
+  });
+  test('passes verification with zero violations (any standard)', () => {
+    expectCleanVerification(msg);
   });
 });
 
@@ -504,8 +532,12 @@ describe('credit-token builder', () => {
   test('amount scaling', () => {
     expect(r.collectionApprovals[0].approvalCriteria.predeterminedBalances.incrementedBalances.allowAmountScaling).toBe(true);
   });
-  test('passes verification', () => {
-    expect(verifyBuilder(msg).violations.filter((vi: any) => vi.standard === 'Credit Token')).toEqual([]);
+  test('deterministic — identical params produce byte-identical msg', () => {
+    expect(buildCreditToken({ paymentDenom: 'USDC', recipient: 'bb1recipient', ...META }))
+      .toEqual(buildCreditToken({ paymentDenom: 'USDC', recipient: 'bb1recipient', ...META }));
+  });
+  test('passes verification with zero violations (any standard)', () => {
+    expectCleanVerification(msg);
   });
 });
 
@@ -611,48 +643,64 @@ describe('address-list builder', () => {
     expect(ids).toContain('manager-add');
     expect(ids).toContain('manager-remove');
   });
-  test('passes verification', () => {
-    expect(verifyBuilder(msg).violations.filter((vi: any) => vi.standard === 'Address List')).toEqual([]);
+  test('deterministic — identical params produce byte-identical msg', () => {
+    expect(buildAddressList({ name: 'My List', description: 'A test list.', image: 'ipfs://test-image' }))
+      .toEqual(buildAddressList({ name: 'My List', description: 'A test list.', image: 'ipfs://test-image' }));
+  });
+  test('passes verification with zero violations (any standard)', () => {
+    expectCleanVerification(msg);
   });
 });
 
 // ── Approval builder tests ───────────────────────────────────────────────────
 
-describe('intent builder', () => {
+describe('intent builder (delegates to canonical)', () => {
   const msg = buildIntent({ address: 'bb1creator', collectionId: '99', payDenom: 'USDC', payAmount: 100, receiveDenom: 'BADGE', receiveAmount: 50 });
 
-  test('has MsgUpdateUserApprovals typeUrl', () => {
-    expect(msg.typeUrl).toBe('/tokenization.MsgUpdateUserApprovals');
+  test('emits MsgSetOutgoingApproval — same envelope as bb intents create', () => {
+    expect(msg.typeUrl).toBe('/tokenization.MsgSetOutgoingApproval');
+    expect(msg.value.creator).toBe('bb1creator');
+    expect(msg.value.collectionId).toBe('99');
   });
-  test('outgoing approval', () => { expect(msg.value.updateOutgoingApprovals).toBe(true); });
-  test('dual coin transfers', () => {
-    expect(msg.value.outgoingApprovals[0].approvalCriteria.coinTransfers.length).toBe(2);
+  test('fromListId scoped to creator (FE-canonical — old slim builder omitted it)', () => {
+    expect(msg.value.approval.fromListId).toBe('bb1creator');
   });
-  test('first transfer pays creator', () => {
-    expect(msg.value.outgoingApprovals[0].approvalCriteria.coinTransfers[0].to).toBe('bb1creator');
+  test('dual coin transfers; first pays creator, second is escrow', () => {
+    const cts = msg.value.approval.approvalCriteria.coinTransfers;
+    expect(cts.length).toBe(2);
+    expect(cts[0].to).toBe('bb1creator');
+    expect(cts[1].overrideFromWithApproverAddress).toBe(true);
+    expect(cts[1].overrideToWithInitiator).toBe(true);
   });
-  test('second from escrow to filler', () => {
-    const ct = msg.value.outgoingApprovals[0].approvalCriteria.coinTransfers[1];
-    expect(ct.overrideFromWithApproverAddress).toBe(true);
-    expect(ct.overrideToWithInitiator).toBe(true);
-  });
-  test('auto-deletes', () => { expect(msg.value.outgoingApprovals[0].approvalCriteria.autoDeletionOptions.afterOneUse).toBe(true); });
-  test('collectionId in meta', () => { expect(msg._meta.collectionId).toBe('99'); });
-
   test('no requireToEqualsInitiatedBy — must stay fillable', () => {
-    // `true` here made the approval structurally unfillable; the
-    // canonical core/intents.ts path omits it.
-    expect(msg.value.outgoingApprovals[0].approvalCriteria.requireToEqualsInitiatedBy).toBeUndefined();
+    expect(msg.value.approval.approvalCriteria.requireToEqualsInitiatedBy).toBeUndefined();
+  });
+  test('no _meta — byte-identical to the intents-create path', () => {
+    expect((msg as any)._meta).toBeUndefined();
+  });
+  test('approval == buildIntentApproval for equivalent args (delegation parity)', () => {
+    const a = msg.value.approval;
+    const cts = a.approvalCriteria.coinTransfers;
+    const canonical = buildIntentApproval({
+      address: 'bb1creator',
+      payDenom: cts[1].coins[0].denom,
+      payAmount: BigInt(cts[1].coins[0].amount),
+      receiveDenom: cts[0].coins[0].denom,
+      receiveAmount: BigInt(cts[0].coins[0].amount),
+      transferTimes: a.transferTimes,
+      approvalId: a.approvalId
+    });
+    expect(a).toEqual(canonical);
+  });
+  test('deterministic approval id for identical params', () => {
+    const p = { address: 'bb1c', collectionId: '5', payDenom: 'USDC', payAmount: 7, receiveDenom: 'BADGE', receiveAmount: 3 };
+    expect(buildIntent(p).value.approval.approvalId).toBe(buildIntent(p).value.approval.approvalId);
   });
   test('throws on same pay/receive denom', () => {
     expect(() => buildIntent({ address: 'bb1a', collectionId: '1', payDenom: 'BADGE', payAmount: 10, receiveDenom: 'BADGE', receiveAmount: 5 }))
       .toThrow(/denoms must differ/);
-    // resolved-denom comparison also catches case variants
     expect(() => buildIntent({ address: 'bb1a', collectionId: '1', payDenom: 'USDC', payAmount: 10, receiveDenom: 'usdc', receiveAmount: 5 }))
       .toThrow(/denoms must differ/);
-  });
-  test('passes verification with zero violations', () => {
-    expectCleanVerification(msg);
   });
 });
 
@@ -661,40 +709,87 @@ describe('intent builder', () => {
 // canonical subscriber-side recurring approval is `userRecurringApproval`
 // in core/subscriptions.ts (covered by subscriptions tests).
 
-describe('listing builder', () => {
-  const msg = buildListing({ address: 'bb1seller', collectionId: '1', tokenIds: '1-5', price: 50, denom: 'USDC' });
+describe('listing builder (delegates to canonical)', () => {
+  const msg = buildListing({ address: 'bb1seller', collectionId: '1', tokenIds: '4', price: 50, denom: 'USDC' });
 
-  test('outgoing approval', () => { expect(msg.value.updateOutgoingApprovals).toBe(true); });
-  test('token range', () => { expect(msg.value.outgoingApprovals[0].tokenIds).toEqual([{ start: '1', end: '5' }]); });
-  test('pays seller', () => { expect(msg.value.outgoingApprovals[0].approvalCriteria.coinTransfers[0].to).toBe('bb1seller'); });
-  test('auto-deletes after max', () => { expect(msg.value.outgoingApprovals[0].approvalCriteria.autoDeletionOptions.afterOverallMaxNumTransfers).toBe(true); });
+  test('emits MsgSetOutgoingApproval — same envelope as bb nfts list', () => {
+    expect(msg.typeUrl).toBe('/tokenization.MsgSetOutgoingApproval');
+    expect(msg.value.creator).toBe('bb1seller');
+    expect(msg.value.collectionId).toBe('1');
+  });
+  test('single token id (canonical bigint shape)', () => {
+    expect(msg.value.approval.tokenIds).toEqual([{ start: 4n, end: 4n }]);
+  });
+  test('pays seller', () => {
+    expect(msg.value.approval.approvalCriteria.coinTransfers[0].to).toBe('bb1seller');
+  });
+  test('rejects a true token range (orderbook listings are single-token)', () => {
+    expect(() => buildListing({ address: 'bb1s', collectionId: '1', tokenIds: '1-5', price: 1, denom: 'USDC' }))
+      .toThrow(/single token id/);
+  });
+  test('approval == buildOrderbookListingApproval for equivalent args (delegation parity)', () => {
+    const a = msg.value.approval;
+    const canonical = buildOrderbookListingApproval({
+      address: 'bb1seller',
+      tokenId: 4n,
+      paymentAmount: BigInt(a.approvalCriteria.coinTransfers[0].coins[0].amount),
+      paymentDenom: a.approvalCriteria.coinTransfers[0].coins[0].denom,
+      tokenAmount: 1n,
+      transferTimes: a.transferTimes,
+      approvalId: a.approvalId,
+      maxNumTransfers: 1n
+    });
+    expect(a).toEqual(canonical);
+  });
+  test('deterministic approval id; no _meta', () => {
+    const p = { address: 'bb1seller', collectionId: '1', tokenIds: '4', price: 50, denom: 'USDC' };
+    expect(buildListing(p).value.approval.approvalId).toBe(buildListing(p).value.approval.approvalId);
+    expect((msg as any)._meta).toBeUndefined();
+  });
 });
 
-describe('bid builder', () => {
+describe('bid builder (delegates to canonical)', () => {
   const msg = buildBid({ address: 'bb1bidder', collectionId: '1', tokenIds: '3', price: 25, denom: 'BADGE' });
 
-  test('incoming approval', () => { expect(msg.value.updateIncomingApprovals).toBe(true); });
-  test('single token ID', () => { expect(msg.value.incomingApprovals[0].tokenIds).toEqual([{ start: '3', end: '3' }]); });
+  test('emits MsgSetIncomingApproval — same envelope as bb nfts bid', () => {
+    expect(msg.typeUrl).toBe('/tokenization.MsgSetIncomingApproval');
+    expect(msg.value.creator).toBe('bb1bidder');
+    expect(msg.value.collectionId).toBe('1');
+  });
+  test('single token id (canonical bigint shape)', () => {
+    expect(msg.value.approval.tokenIds).toEqual([{ start: 3n, end: 3n }]);
+  });
   test('escrow-funded', () => {
-    const ct = msg.value.incomingApprovals[0].approvalCriteria.coinTransfers[0];
+    const ct = msg.value.approval.approvalCriteria.coinTransfers[0];
     expect(ct.overrideFromWithApproverAddress).toBe(true);
     expect(ct.overrideToWithInitiator).toBe(true);
   });
-  test('auto-deletes', () => { expect(msg.value.incomingApprovals[0].approvalCriteria.autoDeletionOptions.afterOneUse).toBe(true); });
-
-  test('deterministic approval id — no Math.random/uniqueId', () => {
+  test('rejects a true token range', () => {
+    expect(() => buildBid({ address: 'bb1b', collectionId: '1', tokenIds: '1-5', price: 1, denom: 'BADGE' }))
+      .toThrow(/single token id/);
+  });
+  test('deterministic approval id for identical params', () => {
     const p = { address: 'bb1bidder', collectionId: '1', tokenIds: '3', price: 25, denom: 'BADGE' };
-    const a = buildBid({ ...p }).value.incomingApprovals[0];
-    const b = buildBid({ ...p }).value.incomingApprovals[0];
+    const a = buildBid({ ...p }).value.approval;
+    const b = buildBid({ ...p }).value.approval;
     expect(a.approvalId).toBe(b.approvalId);
     expect(a.approvalId.startsWith('bid-')).toBe(true);
-    // amountTrackerId stays in lockstep with approvalId
     expect(a.approvalCriteria.maxNumTransfers.amountTrackerId).toBe(a.approvalId);
-    // distinct bids on the same collection get distinct ids
-    expect(buildBid({ ...p, price: 26 }).value.incomingApprovals[0].approvalId).not.toBe(a.approvalId);
+    expect(buildBid({ ...p, price: 26 }).value.approval.approvalId).not.toBe(a.approvalId);
   });
-  test('passes verification with zero violations', () => {
-    expectCleanVerification(msg);
+  test('approval == buildOrderbookBidApproval for equivalent args (delegation parity)', () => {
+    const a = msg.value.approval;
+    const canonical = buildOrderbookBidApproval({
+      address: 'bb1bidder',
+      tokenId: 3n,
+      paymentAmount: BigInt(a.approvalCriteria.coinTransfers[0].coins[0].amount),
+      paymentDenom: a.approvalCriteria.coinTransfers[0].coins[0].denom,
+      tokenAmount: 1n,
+      transferTimes: a.transferTimes,
+      approvalId: a.approvalId,
+      maxNumTransfers: 1n
+    });
+    expect(a).toEqual(canonical);
   });
 });
 
@@ -826,26 +921,44 @@ describe('error handling', () => {
     expect(() => buildSubscription({ interval: 'monthly' } as any)).toThrow();
   });
 
-  test('buildBounty with zero amount still produces valid structure', () => {
+  test('buildBounty with zero amount: the zero propagates (not silently dropped) + verifier-clean', () => {
     const msg = buildBounty({ amount: 0, denom: 'BADGE', verifier: 'bb1v', recipient: 'bb1r', submitter: 'bb1s', ...META });
     expect(msg.typeUrl).toBe('/tokenization.MsgUniversalUpdateCollection');
     expect(msg.value.collectionApprovals.length).toBe(3);
+    // Proves amount:0 flowed through to the escrow coin rather than being
+    // silently coerced/dropped (the masking-bug class).
+    expect(val(msg).mintEscrowCoinsToTransfer[0].amount).toBe('0');
+    expectCleanVerification(msg);
   });
 
-  test('buildProductCatalog with empty products produces burn-only collection', () => {
+  test('buildProductCatalog with empty products: burn-only, well-formed, verifier-clean', () => {
     const msg = buildProductCatalog({ products: [], storeAddress: 'bb1s', ...META });
-    // Only burn approval, no purchase approvals
     expect(msg.value.collectionApprovals.length).toBe(1);
+    // The lone approval must be a real burn approval, not a mangled
+    // placeholder a silent-drop bug would also yield length 1.
+    const only = msg.value.collectionApprovals[0];
+    expect(typeof only.approvalId).toBe('string');
+    expect(only.approvalId.length).toBeGreaterThan(0);
+    expect(only.toListId).toBeTruthy();
+    expectCleanVerification(msg);
   });
 
-  test('buildCrowdfund goal of 1 base unit works', () => {
+  test('buildCrowdfund goal of 1 base unit: goal converts to 1 base unit + verifier-clean', () => {
     const msg = buildCrowdfund({ goal: 0.000001, denom: 'USDC', crowdfunder: 'bb1fund', ...META });
     expect(msg.value.collectionApprovals.length).toBeGreaterThanOrEqual(4);
+    // USDC has 6 decimals → 0.000001 must resolve to exactly "1" base
+    // unit somewhere in the emitted coin amounts (not 0 from a silent
+    // truncation, not display-units).
+    const coinAmounts = JSON.stringify(msg).match(/"amount":"\d+"/g) ?? [];
+    expect(coinAmounts).toContain('"amount":"1"');
+    expectCleanVerification(msg);
   });
 
-  test('buildAuction with very short windows works', () => {
+  test('buildAuction with very short windows: well-formed + verifier-clean', () => {
     const msg = buildAuction({ bidDeadline: '1m', acceptWindow: '1m', ...META });
     expect(msg.typeUrl).toBe('/tokenization.MsgUniversalUpdateCollection');
+    expect(msg.value.collectionApprovals.length).toBeGreaterThan(0);
+    expectCleanVerification(msg);
   });
 
   test('buildIntent rejects same pay/receive denom (no-op approval)', () => {
@@ -853,9 +966,9 @@ describe('error handling', () => {
       .toThrow(/denoms must differ/);
   });
 
-  test('buildListing parses single token ID', () => {
+  test('buildListing parses single token ID (canonical shape)', () => {
     const msg = buildListing({ address: 'bb1a', collectionId: '1', tokenIds: '42', price: 10, denom: 'BADGE' });
-    expect(msg.value.outgoingApprovals[0].tokenIds).toEqual([{ start: '42', end: '42' }]);
+    expect(msg.value.approval.tokenIds).toEqual([{ start: 42n, end: 42n }]);
   });
 
   test('buildPmSellIntent emits canonical token ids', () => {

--- a/packages/bitbadgesjs-sdk/src/core/builders/intent.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/intent.ts
@@ -1,22 +1,16 @@
 /**
- * Intent (OTC swap) builder — creates a user outgoing approval for an atomic swap.
- *
- * The creator offers to trade payDenom for receiveDenom via dual coinTransfers
- * on the Intent Exchange collection. Token ID 1 is used as the vehicle —
- * the real swap happens entirely in coinTransfers.
+ * Intent (OTC swap) builder — thin display-unit wrapper over the canonical
+ * `buildIntentApproval` (core/intents.ts), the same builder
+ * `bb intents create` uses. `bb build intent` and `bb intents create` now
+ * emit the identical `MsgSetOutgoingApproval` shape; this file only
+ * resolves display→base units + a deterministic approval id, enforces the
+ * same-denom guard, then delegates.
  *
  * @module core/builders/intent
  */
-import {
-  FOREVER,
-  resolveCoin,
-  toBaseUnits,
-  durationToTimestamp,
-  uniqueId,
-  mintToBurnBalances,
-  buildUserApprovalMsg,
-  approvalMetadata
-} from './shared.js';
+import { resolveCoin, toBaseUnits, durationToTimestamp, stableHashId } from './shared.js';
+import { buildIntentApproval, type IntentApprovalArgs } from '../intents.js';
+import { UintRangeArray } from '../uintRanges.js';
 
 export interface IntentParams {
   address: string; // creator bb1... address
@@ -25,82 +19,43 @@ export interface IntentParams {
   payAmount: number; // display units
   receiveDenom: string; // what creator receives
   receiveAmount: number; // display units
-  expiration?: string; // duration shorthand, default "7d"
+  expiration?: string; // duration shorthand, default "30d"
 }
 
-export function buildIntent(params: IntentParams): any {
+export function buildIntent(params: IntentParams): { typeUrl: string; value: any } {
   const payCoin = resolveCoin(params.payDenom);
   const receiveCoin = resolveCoin(params.receiveDenom);
-  // A same-denom intent is a no-op approval the chain accepts but with
-  // no economic effect. The canonical `bb intents create` path already
-  // rejects this (cli/commands/intents.ts); enforce it in the builder so
-  // `bb build intent` inherits the same guard. Compare resolved denoms
-  // so 'USDC' vs 'usdc' is also caught.
+  // A same-denom intent is a no-op approval the chain accepts but with no
+  // economic effect. Compare resolved denoms so 'USDC' vs 'usdc' is caught.
   if (payCoin.denom === receiveCoin.denom) {
     throw new Error('Intent pay and receive denoms must differ.');
   }
-  const payBase = toBaseUnits(params.payAmount, payCoin.decimals);
-  const receiveBase = toBaseUnits(params.receiveAmount, receiveCoin.decimals);
-  const expirationTs = durationToTimestamp(params.expiration || '7d');
-  const id = uniqueId('intent');
-
-  const approval = {
-    approvalId: id,
-    ...approvalMetadata(
-      'Intent',
-      'Atomic OTC swap — pay one denom and receive another in a single transfer.'
-    ),
-    toListId: 'All',
-    initiatedByListId: 'All',
-    transferTimes: [{ start: '1', end: expirationTs }],
-    tokenIds: [{ start: '1', end: '1' }],
-    ownershipTimes: FOREVER,
-    version: '0',
-    approvalCriteria: {
-      predeterminedBalances: mintToBurnBalances(),
-      maxNumTransfers: {
-        overallMaxNumTransfers: '1',
-        perToAddressMaxNumTransfers: '0',
-        perFromAddressMaxNumTransfers: '0',
-        perInitiatedByAddressMaxNumTransfers: '0',
-        amountTrackerId: id,
-        resetTimeIntervals: { startTime: '0', intervalLength: '0' }
-      },
-      coinTransfers: [
-        // 1. Filler pays creator the receive coin
-        {
-          to: params.address,
-          coins: [{ amount: receiveBase, denom: receiveCoin.denom }],
-          overrideFromWithApproverAddress: false,
-          overrideToWithInitiator: false
-        },
-        // 2. Creator's escrow pays filler the pay coin
-        {
-          to: '',
-          coins: [{ amount: payBase, denom: payCoin.denom }],
-          overrideFromWithApproverAddress: true,
-          overrideToWithInitiator: true
-        }
-      ],
-      autoDeletionOptions: {
-        afterOneUse: true,
-        afterOverallMaxNumTransfers: true,
-        allowCounterpartyPurge: false,
-        allowPurgeIfExpired: true
-      }
-      // No `requireToEqualsInitiatedBy` — the vehicle-token `to` is the
-      // creator while the fill initiator is the filler, so `true` made
-      // the approval structurally unfillable. The canonical
-      // core/intents.ts (the `bb intents create` path) omits it too.
-    }
+  const end = BigInt(durationToTimestamp(params.expiration || '30d'));
+  const approvalId = stableHashId('intent', {
+    address: params.address,
+    collectionId: params.collectionId,
+    payDenom: payCoin.denom,
+    payAmount: params.payAmount,
+    receiveDenom: receiveCoin.denom,
+    receiveAmount: params.receiveAmount,
+    expiration: params.expiration || '30d'
+  });
+  const args: IntentApprovalArgs = {
+    address: params.address,
+    payDenom: payCoin.denom,
+    payAmount: BigInt(toBaseUnits(params.payAmount, payCoin.decimals)),
+    receiveDenom: receiveCoin.denom,
+    receiveAmount: BigInt(toBaseUnits(params.receiveAmount, receiveCoin.decimals)),
+    transferTimes: UintRangeArray.From([{ start: 1n, end }]),
+    approvalId
   };
-
+  const approval = buildIntentApproval(args);
   return {
-    ...buildUserApprovalMsg({ collectionId: params.collectionId, outgoingApprovals: [approval] }),
-    _meta: {
-      description: `OTC Swap: ${params.payAmount} ${payCoin.symbol} → ${params.receiveAmount} ${receiveCoin.symbol}`,
-      collectionId: params.collectionId,
-      escrowCoins: [{ amount: payBase, denom: payCoin.denom }]
+    typeUrl: '/tokenization.MsgSetOutgoingApproval',
+    value: {
+      creator: params.address,
+      collectionId: String(params.collectionId),
+      approval
     }
   };
 }

--- a/packages/bitbadgesjs-sdk/src/core/builders/listing.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/listing.ts
@@ -1,112 +1,68 @@
 /**
- * Listing builder — creates a user outgoing approval for a marketplace listing.
- *
- * The seller lists tokens for sale at a fixed price. Buyers transfer tokens
- * and pay the seller via coinTransfers.
+ * Listing builder — thin display-unit wrapper over the canonical
+ * `buildOrderbookListingApproval` (core/bids.ts), the same builder
+ * `bb nfts list` uses. `bb build listing` and `bb nfts list` now emit the
+ * identical `MsgSetOutgoingApproval` shape (incl. the FE-canonical
+ * seller-scoped `fromListId` the old slim builder omitted).
  *
  * @module core/builders/listing
  */
-import {
-  FOREVER,
-  resolveCoin,
-  toBaseUnits,
-  durationToTimestamp,
-  uniqueId,
-  buildUserApprovalMsg,
-  approvalMetadata
-} from './shared.js';
+import { resolveCoin, toBaseUnits, durationToTimestamp, stableHashId } from './shared.js';
+import { buildOrderbookListingApproval, type OrderbookOrderArgs } from '../bids.js';
+import { UintRangeArray } from '../uintRanges.js';
 
 export interface ListingParams {
   address: string; // seller bb1... address
   collectionId: string; // collection to list from
-  tokenIds: string; // "1-5" or "1"
+  tokenIds: string; // single token id (orderbook listings are single-token)
   price: number; // asking price (display units)
   denom: string; // price coin (USDC, BADGE)
   maxSales?: number; // max number of sales, default 1
   expiration?: string; // listing duration, default "30d"
 }
 
-function parseTokenIdRange(input: string): any[] {
-  if (input.includes('-')) {
-    const [start, end] = input.split('-').map((s) => s.trim());
-    return [{ start, end }];
+/** Orderbook listings are single-token. Accept "5" or "5-5"; reject a true range. */
+function singleTokenId(input: string, ctx: string): bigint {
+  const parts = String(input).split('-').map((s) => s.trim());
+  if (parts.length === 2 && parts[0] !== parts[1]) {
+    throw new Error(
+      `${ctx} supports a single token id (got range "${input}"). List/bid per token id.`
+    );
   }
-  return [{ start: input, end: input }];
+  return BigInt(parts[0]);
 }
 
-export function buildListing(params: ListingParams): any {
+export function buildListing(params: ListingParams): { typeUrl: string; value: any } {
   const coin = resolveCoin(params.denom);
-  const basePrice = toBaseUnits(params.price, coin.decimals);
-  const expirationTs = durationToTimestamp(params.expiration || '30d');
-  const maxSales = params.maxSales || 1;
-  const id = uniqueId('listing');
-  const tokenIds = parseTokenIdRange(params.tokenIds);
-
-  const approval = {
-    approvalId: id,
-    ...approvalMetadata(
-      'Listing',
-      'This approval is a conditional offer to transfer a token from this address if certain conditions are met.'
-    ),
-    toListId: 'All',
-    initiatedByListId: 'All',
-    transferTimes: [{ start: '1', end: expirationTs }],
-    tokenIds,
-    ownershipTimes: FOREVER,
-    version: '0',
-    approvalCriteria: {
-      predeterminedBalances: {
-        manualBalances: [],
-        incrementedBalances: {
-          startBalances: [{ amount: '1', tokenIds, ownershipTimes: FOREVER }],
-          incrementTokenIdsBy: '0',
-          incrementOwnershipTimesBy: '0',
-          durationFromTimestamp: '0',
-          allowOverrideTimestamp: false,
-          recurringOwnershipTimes: { startTime: '0', intervalLength: '0', chargePeriodLength: '0' },
-          allowOverrideWithAnyValidToken: false,
-          allowAmountScaling: false,
-          maxScalingMultiplier: '0'
-        },
-        orderCalculationMethod: {
-          useOverallNumTransfers: true,
-          usePerToAddressNumTransfers: false,
-          usePerFromAddressNumTransfers: false,
-          usePerInitiatedByAddressNumTransfers: false,
-          useMerkleChallengeLeafIndex: false,
-          challengeTrackerId: ''
-        }
-      },
-      maxNumTransfers: {
-        overallMaxNumTransfers: String(maxSales),
-        perToAddressMaxNumTransfers: '0',
-        perFromAddressMaxNumTransfers: '0',
-        perInitiatedByAddressMaxNumTransfers: '0',
-        amountTrackerId: id,
-        resetTimeIntervals: { startTime: '0', intervalLength: '0' }
-      },
-      coinTransfers: [
-        {
-          to: params.address,
-          coins: [{ amount: basePrice, denom: coin.denom }],
-          overrideFromWithApproverAddress: false,
-          overrideToWithInitiator: false
-        }
-      ],
-      autoDeletionOptions: {
-        afterOneUse: false,
-        afterOverallMaxNumTransfers: true,
-        allowCounterpartyPurge: false,
-        allowPurgeIfExpired: true
-      }
-    }
+  const tokenId = singleTokenId(params.tokenIds, 'listing');
+  const end = BigInt(durationToTimestamp(params.expiration || '30d'));
+  const maxNumTransfers = BigInt(params.maxSales || 1);
+  const approvalId = stableHashId('listing', {
+    address: params.address,
+    collectionId: params.collectionId,
+    tokenIds: params.tokenIds,
+    price: params.price,
+    denom: coin.denom,
+    maxSales: params.maxSales || 1,
+    expiration: params.expiration || '30d'
+  });
+  const args: OrderbookOrderArgs = {
+    address: params.address,
+    tokenId,
+    paymentAmount: BigInt(toBaseUnits(params.price, coin.decimals)),
+    paymentDenom: coin.denom,
+    tokenAmount: 1n,
+    transferTimes: UintRangeArray.From([{ start: 1n, end }]),
+    approvalId,
+    maxNumTransfers
   };
-
+  const approval = buildOrderbookListingApproval(args);
   return {
-    ...buildUserApprovalMsg({ collectionId: params.collectionId, outgoingApprovals: [approval] }),
-    _meta: {
-      description: `Listing: ${params.tokenIds} from collection ${params.collectionId} for ${params.price} ${coin.symbol}`,
-      collectionId: params.collectionId
+    typeUrl: '/tokenization.MsgSetOutgoingApproval',
+    value: {
+      creator: params.address,
+      collectionId: String(params.collectionId),
+      approval
     }
   };
 }


### PR DESCRIPTION
Post-#240 CLI follow-up audit batch (tickets #0416–#0421). One PR, one commit (files interleave across tickets — see the per-area changelog).

## Bug fixes
- **`bb build listing` emitted an outgoing approval with no `fromListId`** — an under-constrained approval the chain could reject or interpret permissively. Now correctly seller-scoped (FE-canonical). *(#0416)*
- **`bb build send` silently ignored `--browser` / `--burner` / `--simulate` / `--output-file`** — advertised in `--help` but the command hand-rolled its own output and never hit the deploy path. Now honored. *(#0419)*

## Behavioral changes
- **`bb build intent` / `build listing` / `build bid` now emit canonical `MsgSet{Outgoing,Incoming}Approval`** (was a divergent slim `MsgUpdateUserApprovals`). The build verb and the end-user command (`bb intents create` / `bb nfts list` / `bb nfts bid`) now produce a byte-identical on-chain tx (delegation-parity tests assert this). *(#0416)*
- **`bb build listing` / `build bid` reject a multi-token range** with a clear error (orderbook approvals are single-token) instead of silently building a non-canonical range approval. *(#0416)*
- **Deterministic on-chain ids:** `intent`, `listing`, `bounty` builders derive approval/proposal ids from params (`stableHashId`) instead of random — identical inputs → byte-identical, replayable txs (last `uniqueId` stragglers from the 0405/0406 line). *(#0416, #0417)*
- **`bb build intent` default `--expiration` 7d → 30d** to match `bb intents create`. *(#0416)*

## Deprecations
- **`bb intents create --valid-until` → canonical `--expiration`.** `--valid-until` and `--expiry` still work as hidden aliases for one release, warn once on use. *(#0416)*

## New capability
- **`bb subscriptions enable-renewal` / `subscribe` gained `--approval-id`** — the recurring-approval id can now be pinned for replay (was always random/unpinnable). *(#0418)*

## Refactor + test hardening (summary)
- New shared `resolveApprovalId` helper; swept 5 commands off the duplicated RNG. *(#0418)*
- `bb custom-2fa mint` gained unit shape + emit/guard + full broadcast integration coverage (was zero coverage from #240). *(#0420)*
- 6 weak `.violations.filter(standard===X)` checks upgraded to `expectCleanVerification` (unmasks cross-standard violations); +5 builder determinism tests; 4 vacuous invalid-input tests now assert real behavior; the `expect([0,tx.code]).toContain(tx.code)` tautology replaced with `toBe(0)`. *(#0421)*

## Validation
- Build clean (no circular deps); unit **139 suites / 3052 tests**; integration **20/20 suites** green (incl. the new `bb custom-2fa mint` on-chain broadcast asserting a bounded 5-min ownership window).

## Downstream
- Paired bitbadges-docs PR: `build-commands.md` corrected for the new `build intent` default (30d) and the `build listing`/`build bid` single-token constraint (old docs showed a `"1-5"` range example that now errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)