### PR TITLE
sdk: round-4 CLI follow-ups — PM intent tokenAmount guard + resolveExpiration/collection-options specs (#0431-#0433)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/cli/utils/collection-options.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/collection-options.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * collection-options.ts coverage (ticket 0433) — shipped in #0429
+ * without its spec (a round-2 implementation miss caught by the
+ * round-3 audit). Both helpers carry the branching logic whose absence
+ * was the latent boundary bug #0429 fixed; sibling csv-options.ts from
+ * the same DRY cycle is fully specced — this closes the gap.
+ */
+
+import { normalizeCollection, validateCollectionOrExit } from './collection-options.js';
+
+describe('normalizeCollection', () => {
+  // 0429's actual fix: the 4 raw command copies returned the indexer
+  // envelope unmodified; normalizeCollection must unwrap + run the
+  // class normalization (BigIntify of numeric fields is the
+  // BitBadgesCollection class's own, separately-tested concern — here
+  // we pin the boundary contract: unwrap, never-throw, raw fallback).
+  it('unwraps a {collection: X} envelope (returns the inner object, not the wrapper)', () => {
+    const out = normalizeCollection({ collection: { collectionId: '5', foo: 'bar' } });
+    expect(out).not.toHaveProperty('collection');
+    expect(out.collectionId).toBe('5');
+  });
+  it('processes a bare collection (no envelope) directly', () => {
+    const out = normalizeCollection({ collectionId: '7' });
+    expect(out).toBeTruthy();
+    expect(out.collectionId).toBe('7');
+  });
+  it('passes null / undefined through untouched', () => {
+    expect(normalizeCollection(null)).toBeNull();
+    expect(normalizeCollection(undefined)).toBeUndefined();
+  });
+  it('never throws — falls back to raw when class construction fails', () => {
+    const weird: any = 'not-a-collection';
+    expect(normalizeCollection(weird)).toBe('not-a-collection');
+    const broken: any = { collection: 12345 };
+    expect(() => normalizeCollection(broken)).not.toThrow();
+  });
+});
+
+describe('validateCollectionOrExit', () => {
+  let exitSpy: jest.SpyInstance;
+  let stderrSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(((_c?: number) => {
+      throw new Error('process.exit');
+    }) as never);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.BB_QUIET;
+  });
+
+  const ok = () => ({ valid: true, errors: [], warnings: [] });
+
+  it('exits 2 with a not-found message when collection is missing', () => {
+    expect(() => validateCollectionOrExit(null, 'ctx-x', ok, 'Bounty')).toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(2);
+    expect(stderrSpy.mock.calls.map((c) => c[0]).join('')).toContain('collection not found while running ctx-x');
+  });
+
+  it('prints errors + warnings and exits 2 when invalid', () => {
+    const bad = () => ({ valid: false, errors: ['e1', 'e2'], warnings: ['w1'] });
+    expect(() => validateCollectionOrExit({}, 'mint', bad, 'Crowdfund')).toThrow('process.exit');
+    const txt = stderrSpy.mock.calls.map((c) => c[0]).join('');
+    expect(txt).toContain('not a valid Crowdfund (failed in mint)');
+    expect(txt).toContain('- e1');
+    expect(txt).toContain('- e2');
+    expect(txt).toContain('- w1');
+    expect(exitSpy).toHaveBeenCalledWith(2);
+  });
+
+  it('valid + warnings → echoes warnings unless BB_QUIET, never exits', () => {
+    const warn = () => ({ valid: true, errors: [], warnings: ['heads-up'] });
+    validateCollectionOrExit({}, 'claim', warn, 'Auction');
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(stderrSpy.mock.calls.map((c) => c[0]).join('')).toContain('Warnings for claim');
+
+    stderrSpy.mockClear();
+    process.env.BB_QUIET = '1';
+    validateCollectionOrExit({}, 'claim', warn, 'Auction');
+    expect(stderrSpy.mock.calls.map((c) => c[0]).join('')).not.toContain('Warnings for claim');
+  });
+
+  it('valid + no warnings → silent, no exit', () => {
+    validateCollectionOrExit({}, 'ctx', ok, 'Smart Token');
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
@@ -29,9 +29,10 @@ import { buildListing } from './listing.js';
 import { buildBid } from './bid.js';
 import { buildPmSellIntent } from './pm-sell-intent.js';
 import { buildPmBuyIntent } from './pm-buy-intent.js';
-import { resolveCoin, parseDuration, toBaseUnits, sanitizeCosmosPathName } from './shared.js';
+import { resolveCoin, parseDuration, toBaseUnits, sanitizeCosmosPathName, resolveExpiration } from './shared.js';
 import { buildPredictionMarketBuyIntent, buildPredictionMarketSellIntent } from '../prediction-markets.js';
 import { buildIntentApproval } from '../intents.js';
+import { UintRangeArray } from '../uintRanges.js';
 import { buildOrderbookBidApproval, buildOrderbookListingApproval } from '../bids.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -128,6 +129,32 @@ describe('shared utilities', () => {
 
   test('parseDuration throws for invalid input', () => {
     expect(() => parseDuration('invalid')).toThrow('Invalid duration');
+  });
+
+  describe('resolveExpiration (#0432 — direct spec; the duration branch was only tested indirectly)', () => {
+    test('empty/undefined → now + defaultMs', () => {
+      const before = Date.now();
+      const got = Number(resolveExpiration(undefined, 30 * 24 * 60 * 60 * 1000));
+      expect(got).toBeGreaterThanOrEqual(before + 30 * 24 * 60 * 60 * 1000 - 50);
+      expect(got).toBeLessThanOrEqual(Date.now() + 30 * 24 * 60 * 60 * 1000 + 50);
+      expect(Number(resolveExpiration('', 1000))).toBeGreaterThan(Date.now());
+    });
+    test('pure-digit ≥10 chars → raw ms-since-epoch (no now offset)', () => {
+      expect(resolveExpiration('1798765432000', 1000)).toBe(1798765432000n);
+    });
+    test('duration shorthand → now + parseDuration', () => {
+      const got = Number(resolveExpiration('30d', 1000));
+      const exp = Date.now() + 2592000000;
+      expect(Math.abs(got - exp)).toBeLessThan(2000);
+      const h = Number(resolveExpiration('24h', 1000));
+      expect(Math.abs(h - (Date.now() + 86400000))).toBeLessThan(2000);
+    });
+    test('a <10-digit numeric string is treated as duration (→ throws), NOT raw ms', () => {
+      expect(() => resolveExpiration('123456789', 1000)).toThrow('Invalid duration');
+    });
+    test('unparseable input throws', () => {
+      expect(() => resolveExpiration('nope', 1000)).toThrow('Invalid duration');
+    });
   });
 
   test('sanitizeCosmosPathName passes clean input through', () => {
@@ -973,6 +1000,27 @@ describe('pm-buy-intent builder (delegates to canonical)', () => {
     const span = Number(def.transferTimes[0].end) - Date.now();
     expect(span).toBeGreaterThan(23 * 60 * 60 * 1000);
     expect(span).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 5000);
+  });
+});
+
+describe('canonical PM intent tokenAmount guard (#0431 — bb prediction-markets buy/sell parity)', () => {
+  const base = {
+    address: 'bb1t', collectionId: '9', tokenId: 1n,
+    paymentDenom: 'uusdc', paymentAmount: 1000n,
+    transferTimes: UintRangeArray.From([{ start: 1n, end: 9999999999999n }]),
+    approvalId: 'pm-guard'
+  };
+  test('buildPredictionMarketBuyIntent throws on 0n / negative tokenAmount', () => {
+    expect(() => buildPredictionMarketBuyIntent({ ...base, tokenAmount: 0n })).toThrow(/positive integer/i);
+    expect(() => buildPredictionMarketBuyIntent({ ...base, tokenAmount: -5n })).toThrow(/positive integer/i);
+  });
+  test('buildPredictionMarketSellIntent throws on 0n / negative tokenAmount', () => {
+    expect(() => buildPredictionMarketSellIntent({ ...base, tokenAmount: 0n })).toThrow(/positive integer/i);
+    expect(() => buildPredictionMarketSellIntent({ ...base, tokenAmount: -1n })).toThrow(/positive integer/i);
+  });
+  test('a positive tokenAmount still builds', () => {
+    expect(buildPredictionMarketBuyIntent({ ...base, tokenAmount: 200n }).approvalId).toBe('pm-guard');
+    expect(buildPredictionMarketSellIntent({ ...base, tokenAmount: 1n }).approvalId).toBe('pm-guard');
   });
 });
 

--- a/packages/bitbadgesjs-sdk/src/core/prediction-markets.ts
+++ b/packages/bitbadgesjs-sdk/src/core/prediction-markets.ts
@@ -844,6 +844,9 @@ export interface PredictionMarketSideArgs {
  * is misleading — it's an incoming approval, posted via MsgSetIncomingApproval).
  */
 export function buildPredictionMarketBuyIntent(args: PredictionMarketSideArgs): Record<string, unknown> {
+  if (args.tokenAmount <= 0n) {
+    throw new Error(`Prediction market intent tokenAmount must be a positive integer (got ${args.tokenAmount}).`);
+  }
   const tokenIds = [{ start: args.tokenId, end: args.tokenId }];
   return {
     fromListId: 'All',
@@ -923,6 +926,9 @@ export function buildPredictionMarketBuyIntent(args: PredictionMarketSideArgs): 
  * receive `paymentAmount` of `paymentDenom`. Proto-shape only.
  */
 export function buildPredictionMarketSellIntent(args: PredictionMarketSideArgs): Record<string, unknown> {
+  if (args.tokenAmount <= 0n) {
+    throw new Error(`Prediction market intent tokenAmount must be a positive integer (got ${args.tokenAmount}).`);
+  }
   const tokenIds = [{ start: args.tokenId, end: args.tokenId }];
   return {
     toListId: 'All',

--- a/packages/bitbadgesjs-sdk/src/core/subscriptions.ts
+++ b/packages/bitbadgesjs-sdk/src/core/subscriptions.ts
@@ -214,7 +214,10 @@ export const isUserRecurringApproval = (approval: iUserIncomingApproval<bigint>,
   }
 
   const intervalLength = BigInt(subscriptionApproval.approvalCriteria?.predeterminedBalances?.incrementedBalances.durationFromTimestamp ?? 0);
-  const chargePeriodLength = BigInt(Math.min(Number(intervalLength), 604800000));
+  // Bigint-exact cap (matches the producer at userRecurringApproval); the
+  // old `Number(intervalLength)` round-trip was lossy for absurd intervals.
+  const chargePeriodLength =
+    intervalLength < RECURRING_CHARGE_PERIOD_CAP_MS ? intervalLength : RECURRING_CHARGE_PERIOD_CAP_MS;
   const subscriptionAmount = subscriptionApproval.approvalCriteria?.coinTransfers?.[0]?.coins?.[0]?.amount ?? 0n;
   const approvalAmount = approval.approvalCriteria?.coinTransfers?.[0]?.coins?.[0]?.amount ?? 0n;
 


### PR DESCRIPTION
## Summary

**Stacked on #243** (base `feat/0428-cli-followups-r3`). Round-4 of the rolling audit — the codebase is converging; this is a tight batch (1 producer-correctness bug + 2 real coverage gaps, one a self-caught round-2 miss).

- **#0431** Canonical `buildPredictionMarketBuyIntent` / `buildPredictionMarketSellIntent` now throw on non-positive `tokenAmount`. Previously the slim `bb build pm-*-intent` builders guarded amount>0 but the end-user `bb prediction-markets buy/sell` called the canonical fn directly with `BigInt(opts.tokenAmount)` — `--token-amount 0`/`-5` flowed through. Guard now lives at the producer root (the #0422 pattern), so both surfaces enforce it. Also: `isUserRecurringApproval`'s charge-period cap is now bigint-exact (was `BigInt(Math.min(Number(intervalLength), …))` — lossy; now matches the producer `userRecurringApproval`'s pure-bigint cap — same producer↔recognizer-drift class as #0425).
- **#0432** Direct `resolveExpiration` unit spec. The duration branch (`now + parseDuration`) was only exercised indirectly via a determinism row that normalizes the time window out; now all three branches + the ≥10-digit ms-since-epoch heuristic boundary + invalid input are directly asserted.
- **#0433** `collection-options.spec.ts` — `normalizeCollection` (envelope unwrap / never-throws / raw-fallback) + `validateCollectionOrExit` (not-found→exit2 / errors+warnings→exit2 / `BB_QUIET` gate / silent-when-valid). The #0429 ticket scoped this spec but it wasn't written (round-2 miss; caught by the round-3 audit).

### Scope notes
- 0431: the slim builders' redundant pre-check left in place (no churn). `bb nfts bid/list --token-amount/--max-fills/--max-sales` left permissive — symmetric across build & end-user (≤0 → chain-accepted no-op), not an asymmetry; broad count-flag validation would be speculative.
- 0433: bigint-value assertions intentionally omitted — `BitBadgesCollection.convert(BigIntify)` is that class's own separately-tested concern and needs a full fixture; the boundary contract (unwrap/never-throw/fallback) is what #0429 actually fixed and is schema-independent.
- The round-3 CLI-DRY audit reported **converged** (the only residue — 2 `callApi` copies vs shared `callIndexer` — is below the ≥3 dedup bar; not filed, per no-churn).

## Validation
- Build clean — `tsc` ×2, no circular dependencies.
- Unit: 143 suites / 3108 tests green (+1 suite, +16 tests).
- Integration: 20 suites / 186 tests green.

## Test plan
- [ ] `bb prediction-markets buy-yes … --token-amount 0` now errors (parity with `bb build pm-buy-intent`)
- [ ] `bun run build` / `test:unit` / `test:integration` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stack: main ← #242 ← #243 ← **this**.