### PR TITLE
sdk: round-5 CLI follow-ups — close last two producer↔recognizer drift guards (#0434)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
@@ -30,9 +30,11 @@ import { buildBid } from './bid.js';
 import { buildPmSellIntent } from './pm-sell-intent.js';
 import { buildPmBuyIntent } from './pm-buy-intent.js';
 import { resolveCoin, parseDuration, toBaseUnits, sanitizeCosmosPathName, resolveExpiration } from './shared.js';
-import { buildPredictionMarketBuyIntent, buildPredictionMarketSellIntent } from '../prediction-markets.js';
+import { buildPredictionMarketBuyIntent, buildPredictionMarketSellIntent, isPredictionMarketValid, validatePredictionMarketCollection } from '../prediction-markets.js';
 import { buildIntentApproval } from '../intents.js';
 import { UintRangeArray } from '../uintRanges.js';
+import { isQuestApproval, doesCollectionFollowQuestProtocol } from '../quests.js';
+import { normalizeForReview } from '../review-normalize.js';
 import { buildOrderbookBidApproval, buildOrderbookListingApproval } from '../bids.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -589,6 +591,13 @@ describe('prediction-market builder', () => {
       buildPredictionMarket({ verifier: 'bb1verifier', ...META })
     );
   });
+  test('producer↔recognizer drift guard — built collection satisfies isPredictionMarketValid (#0434)', () => {
+    const built = normalizeForReview(buildPredictionMarket({ verifier: 'bb1verifier', ...META }));
+    const res = validatePredictionMarketCollection(built);
+    expect(res.valid).toBe(true);
+    expect(res.errors).toEqual([]);
+    expect(isPredictionMarketValid(built)).toBe(true);
+  });
   test('seven distinct pm-<role>-<hash> approval ids, stable across calls', () => {
     const ids = r.collectionApprovals.map((a: any) => a.approvalId);
     expect(ids.length).toBe(7);
@@ -711,6 +720,13 @@ describe('quests builder', () => {
   test('deterministic — identical params produce a byte-identical msg', () => {
     const p = { reward: 10, denom: 'BADGE', maxClaims: 100, ...META };
     expect(buildQuests(p)).toEqual(buildQuests(p));
+  });
+  test('producer↔recognizer drift guard — built quest is recognized by isQuestApproval (#0434)', () => {
+    const built = normalizeForReview(buildQuests({ reward: 10, denom: 'BADGE', maxClaims: 100, ...META }));
+    const questApproval = built.collectionApprovals.find((a: any) => a.approvalId === 'quests-approval');
+    expect(questApproval).toBeTruthy();
+    expect(isQuestApproval(questApproval)).toBe(true);
+    expect(doesCollectionFollowQuestProtocol(built as any)).toBe(true);
   });
   test('passes verification with zero violations', () => {
     expectCleanVerification(msg);


### PR DESCRIPTION
## Summary

**Stacked on #244** (base `feat/0431-cli-followups-r4`). Final round of the rolling CLI audit. Round-4's sweep **converged**: doc/code drift, numeric/units correctness, untested helpers, integration tautologies, zero-coverage commands, and CLI-DRY all came back CLEAN. The only genuine remaining finding is the last two instances of the #0425/#0407 producer↔recognizer-drift class:

- **#0434** `buildQuests` output is now round-tripped through `normalizeForReview` and asserted to satisfy `isQuestApproval` + `doesCollectionFollowQuestProtocol`; `buildPredictionMarket` output asserted against `validatePredictionMarketCollection` + `isPredictionMarketValid`. Both recognizers were previously tested only against hand-rolled all-bigint fixtures, never the builders' own wire output — a field rename or added recognizer constraint could make every CLI-built quest/PM unrecognizable on the frontend with a fully green suite. Mirrors the closed subscription #0425 guard. Both guards **pass** (no actual drift today — they lock it in).

Test-only; no source or docs change.

## Validation
- Build clean — `tsc` ×2, no circular dependencies.
- Unit: 143 suites / 3110 tests green (+2 drift-guard tests).
- Integration: 20 suites / 186 tests green.

## Test plan
- [ ] `bun run build` / `test:unit` / `test:integration` green
- [ ] Confirm the new `#0434` quests + prediction-market drift-guard tests fail if a builder field is renamed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stack: main ← #242 ← #243 ← #244 ← **this**. Audit converged — this is the final stacked round.