### PR TITLE
feat(cli): bb swap execute — BitBadges-only auto-deploy, throw on Skip:Go-rerouted

### DIFF
--- a/packages/bitbadgesjs-sdk/src/cli/commands/swap.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/swap.spec.ts
@@ -7,7 +7,7 @@
  * so the documented agent contract stays stable.
  */
 
-import { swapCommand } from './swap.js';
+import { swapCommand, classifyBitBadgesOnlySwap } from './swap.js';
 
 describe('swapCommand shape', () => {
   it('exposes the documented top-level subcommands', () => {
@@ -19,10 +19,30 @@ describe('swapCommand shape', () => {
       'balances',
       'chains',
       'estimate',
+      'execute',
       'pools',
       'status',
       'track',
     ]);
+  });
+
+  it('execute takes [estimate] + reuses deploy signing flags', () => {
+    const c = swapCommand.commands.find((cmd) => cmd.name() === 'execute')!;
+    expect((c as any)._args.map((a: any) => a.name())).toEqual(['estimate']);
+    const longs = (c.options as any[]).map((o) => o.long);
+    // deploy signing flags come from the shared addDeployOptions helper —
+    // no second/EVM keyring is added here.
+    expect(longs).toEqual(
+      expect.arrayContaining(['--browser', '--burner', '--sign-only', '--force', '--track']),
+    );
+  });
+
+  it('estimate gains --execute / --force / --track + deploy flags', () => {
+    const c = swapCommand.commands.find((cmd) => cmd.name() === 'estimate')!;
+    const longs = (c.options as any[]).map((o) => o.long);
+    expect(longs).toEqual(
+      expect.arrayContaining(['--execute', '--force', '--track', '--browser', '--burner']),
+    );
   });
 
   it('assets exposes --include-svm + --include-cw20', () => {
@@ -82,5 +102,136 @@ describe('swapCommand shape', () => {
       const longs = (c.options as any[]).map((o) => o.long);
       expect(longs).toEqual(expect.arrayContaining(expected));
     }
+  });
+});
+
+describe('classifyBitBadgesOnlySwap — the three routing branches', () => {
+  const bbMsg = (overrides: Record<string, unknown> = {}) =>
+    JSON.stringify({
+      sender: 'bb1abc',
+      routes: [{ poolId: '1', tokenOutDenom: 'uusdc' }],
+      tokenIn: { denom: 'ubadge', amount: '1000000' },
+      tokenOutMinAmount: '980000',
+      affiliates: [],
+      ...overrides,
+    });
+
+  const bitbadgesOnly = {
+    success: true,
+    estimate: {
+      tokenOutAmount: '990000',
+      tokenInAmount: '1000000',
+      doesSwap: true,
+      autoRedirectedToWETH: false,
+      rerouted: false,
+      assetPath: [
+        { denom: 'ubadge', chainId: 'bitbadges-1', how: 'genesis' },
+        { denom: 'uusdc', chainId: 'bitbadges-1', how: 'swap' },
+      ],
+      skipGoMsgs: [
+        {
+          multi_chain_msg: {
+            chain_id: 'bitbadges-1',
+            path: ['bitbadges-1'],
+            msg_type_url: '/gamm.v1beta1.MsgSwapExactAmountIn',
+            msg: bbMsg(),
+          },
+        },
+      ],
+    },
+  };
+
+  // Branch 1 — BitBadges-only single native gamm swap → executable.
+  it('classifies a single BitBadges-native swap as executable with the TxModal alias typeUrl', () => {
+    const r = classifyBitBadgesOnlySwap(bitbadgesOnly);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      // Must be the /sign-page registry alias, NOT the proto type URL.
+      expect(r.built.typeUrl).toBe('gamm/SwapExactAmountIn');
+      expect(r.built.value.sender).toBe('bb1abc');
+      expect(r.chainId).toBe('bitbadges-1');
+      expect(r.tokenInSeed).toBe('1000000ubadge');
+    }
+  });
+
+  it('accepts a bare estimate object (no { success, estimate } wrapper)', () => {
+    const r = classifyBitBadgesOnlySwap(bitbadgesOnly.estimate);
+    expect(r.ok).toBe(true);
+  });
+
+  // Branch 2 — Skip:Go-rerouted / EVM / cross-chain → not executable.
+  it('refuses an EVM-tx route', () => {
+    const r = classifyBitBadgesOnlySwap({
+      estimate: { ...bitbadgesOnly.estimate, skipGoMsgs: [{ evm_tx: { chain_id: '1', to: '0x', data: '0x', value: '0' } }] },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/EVM/i);
+  });
+
+  it('refuses a Skip:Go-rerouted route even if it ends native', () => {
+    const r = classifyBitBadgesOnlySwap({ estimate: { ...bitbadgesOnly.estimate, rerouted: true } });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/rerouted/i);
+  });
+
+  it('refuses a WithIBCTransfer swap (IBC leg lands on another chain)', () => {
+    const r = classifyBitBadgesOnlySwap({
+      estimate: {
+        ...bitbadgesOnly.estimate,
+        skipGoMsgs: [
+          {
+            multi_chain_msg: {
+              chain_id: 'bitbadges-1',
+              path: ['bitbadges-1', 'osmosis-1'],
+              msg_type_url: '/gamm.v1beta1.MsgSwapExactAmountInWithIBCTransfer',
+              msg: bbMsg(),
+            },
+          },
+        ],
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/IBC/i);
+  });
+
+  it('refuses when the asset path leaves the BitBadges chain', () => {
+    const r = classifyBitBadgesOnlySwap({
+      estimate: {
+        ...bitbadgesOnly.estimate,
+        assetPath: [
+          { denom: 'ubadge', chainId: 'bitbadges-1', how: 'genesis' },
+          { denom: 'uusdc', chainId: 'noble-1', how: 'transfer' },
+        ],
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/asset path/i);
+  });
+
+  it('refuses an auto-WETH-redirected route', () => {
+    const r = classifyBitBadgesOnlySwap({ estimate: { ...bitbadgesOnly.estimate, autoRedirectedToWETH: true } });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/WETH/i);
+  });
+
+  // Branch 3 — multi-hop sequence → not executable.
+  it('refuses a multi-message (multi-hop) route', () => {
+    const r = classifyBitBadgesOnlySwap({
+      estimate: {
+        ...bitbadgesOnly.estimate,
+        skipGoMsgs: [
+          bitbadgesOnly.estimate.skipGoMsgs[0],
+          bitbadgesOnly.estimate.skipGoMsgs[0],
+        ],
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/message\(s\); BitBadges-only is exactly 1/);
+  });
+
+  it('refuses a failed estimate', () => {
+    const r = classifyBitBadgesOnlySwap({ success: false, estimate: bitbadgesOnly.estimate });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/did not succeed/i);
   });
 });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/swap.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/swap.ts
@@ -27,6 +27,204 @@ import {
 } from '../utils/indexer-options.js';
 import { requireSkipGoDenom } from '../utils/denom.js';
 import { appendQuery } from '../utils/list-options.js';
+import {
+  addDeployOptions,
+  isDeployRequested,
+  browserBroadcast,
+  type DeployOpts,
+} from '../utils/deploy-options.js';
+
+// ── swap execute: BitBadges-only detection + signing-flag handoff ───────
+//
+// `bb swap estimate` returns `estimate.skipGoMsgs` — either a single
+// BitBadges-native gamm swap (the only thing the existing deploy signing
+// flags can actually sign+broadcast: one Cosmos tx on the BitBadges
+// chain), or a Skip:Go-rerouted route (EVM / IBC multi-hop / another
+// Cosmos chain) which we deliberately do NOT auto-execute. Detection is
+// whole-route, not per-msg first-hop.
+
+interface MultiChainMsg {
+  chain_id: string;
+  path: string[];
+  msg: string;
+  msg_type_url: string;
+}
+interface SkipGoMsg {
+  multi_chain_msg?: MultiChainMsg;
+  evm_tx?: unknown;
+}
+
+function isBitBadgesChain(id?: string): boolean {
+  return !!id && id.startsWith('bitbadges');
+}
+
+/** Unwrap `{ success, estimate }` or a bare estimate object. */
+function extractEstimate(input: any): any {
+  if (input && typeof input === 'object' && input.estimate && typeof input.estimate === 'object') {
+    return input.estimate;
+  }
+  return input;
+}
+
+export type BitBadgesOnlyClassification =
+  | { ok: true; built: { typeUrl: string; value: any }; chainId: string; tokenInSeed?: string }
+  | { ok: false; reason: string };
+
+/**
+ * Returns the signable `{ typeUrl, value }` when the estimate is a single
+ * BitBadges-native gamm swap; otherwise `{ ok: false, reason }`. Pure +
+ * exported so the spec can assert the three routing branches directly.
+ *
+ * The typeUrl is the TxModal alias (`gamm/SwapExactAmountIn`) the `/sign`
+ * page's messageTypes registry is keyed by — mirrors the frontend's
+ * `parseSkipGoMsgsToTxInfo`. Passing the proto type URL would resolve to a
+ * registry miss and the wallet could not reconstruct the msg.
+ */
+export function classifyBitBadgesOnlySwap(estimateInput: any): BitBadgesOnlyClassification {
+  const estimate = extractEstimate(estimateInput);
+  if (!estimate || typeof estimate !== 'object') {
+    return { ok: false, reason: 'estimate payload missing or not an object' };
+  }
+  if (estimateInput && estimateInput.success === false) {
+    return { ok: false, reason: 'estimate did not succeed; nothing to execute' };
+  }
+  if (estimate.autoRedirectedToWETH) {
+    return { ok: false, reason: 'route auto-redirected to WETH (bridge unwrap requires a second tx)' };
+  }
+  if (estimate.rerouted) {
+    return { ok: false, reason: 'route was rerouted through Skip:Go (not a pure BitBadges-native swap)' };
+  }
+  const msgs: SkipGoMsg[] = Array.isArray(estimate.skipGoMsgs) ? estimate.skipGoMsgs : [];
+  if (msgs.length !== 1) {
+    return { ok: false, reason: `route has ${msgs.length} message(s); BitBadges-only is exactly 1` };
+  }
+  const m = msgs[0];
+  if (m.evm_tx) {
+    return { ok: false, reason: 'route contains an EVM tx' };
+  }
+  const mc = m.multi_chain_msg;
+  if (!mc) {
+    return { ok: false, reason: 'message has neither multi_chain_msg nor evm_tx' };
+  }
+  if (!isBitBadgesChain(mc.chain_id)) {
+    return { ok: false, reason: `message targets non-BitBadges chain "${mc.chain_id}"` };
+  }
+  if (Array.isArray(estimate.assetPath) && estimate.assetPath.some((p: any) => !isBitBadgesChain(p?.chainId))) {
+    return { ok: false, reason: 'asset path leaves the BitBadges chain' };
+  }
+  const tu = mc.msg_type_url || '';
+  if (tu.includes('WithIBCTransfer')) {
+    return { ok: false, reason: 'swap includes an IBC transfer leg (lands on another chain)' };
+  }
+  if (!tu.includes('SwapExactAmountIn')) {
+    return { ok: false, reason: `unsupported msg_type_url "${tu}" for BitBadges-only execute` };
+  }
+  let value: any;
+  try {
+    value = typeof mc.msg === 'string' ? JSON.parse(mc.msg) : mc.msg;
+  } catch (e: any) {
+    return { ok: false, reason: `failed to parse multi_chain_msg.msg JSON: ${e?.message || e}` };
+  }
+  const tokenInSeed =
+    value && value.tokenIn && value.tokenIn.amount != null && value.tokenIn.denom
+      ? `${value.tokenIn.amount}${value.tokenIn.denom}`
+      : undefined;
+  return { ok: true, built: { typeUrl: 'gamm/SwapExactAmountIn', value }, chainId: mc.chain_id, tokenInSeed };
+}
+
+class SwapExecuteError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+/**
+ * Shared by `bb swap execute` and `bb swap estimate --execute`.
+ *
+ * - BitBadges-only → emit the signable msg (default; pipeable into
+ *   `bb deploy`) or, with `--browser`, broadcast via the canonical
+ *   `/sign` handoff and optionally auto-`bb swap track`.
+ * - Anything else → emit the estimate (so it stays usable) then throw an
+ *   explicit NOT_IMPLEMENTED. No partial execution, no orchestrator.
+ */
+async function runSwapExecute(estimateInput: any, opts: any): Promise<void> {
+  const cls = classifyBitBadgesOnlySwap(estimateInput);
+
+  if (!cls.ok) {
+    process.stderr.write(
+      `\nNot a BitBadges-only swap (${cls.reason}). Cross-chain / EVM / multi-hop ` +
+        `auto-execute is NOT implemented. The estimate is returned below — sign it ` +
+        `in your wallet via the /sign page, broadcast the first tx, then run ` +
+        `\`bb swap track <tx-hash>\`.\n`
+    );
+    emit({ executable: false, reason: cls.reason, estimate: extractEstimate(estimateInput) }, opts);
+    throw new SwapExecuteError(
+      'NOT_IMPLEMENTED',
+      `Cross-chain / EVM / multi-hop swap auto-execute is not supported (${cls.reason}). ` +
+        `Use the /sign page to sign the returned estimate, then \`bb swap track\`.`
+    );
+  }
+
+  const estimate = extractEstimate(estimateInput);
+  const flagged = !!estimate.complianceNotPassedWarning || !!estimate.lowLiquidityWarning;
+  if (flagged) {
+    const parts = [
+      estimate.complianceNotPassedWarning ? 'compliance not passed' : null,
+      estimate.lowLiquidityWarning ? 'low liquidity' : null,
+    ].filter(Boolean);
+    process.stderr.write(
+      `\nWarning: route flagged — ${parts.join(' + ')}.` +
+        `${estimate.complianceErrorMessage ? ' ' + estimate.complianceErrorMessage : ''}\n`
+    );
+  }
+
+  if (!isDeployRequested(opts)) {
+    // Default: emit the signable msg so `bb swap execute … | bb deploy`
+    // and scripting keep working (same contract as every tx-emitting cmd).
+    emit(cls.built, opts);
+    return;
+  }
+
+  if (flagged && !opts.force) {
+    throw new SwapExecuteError(
+      'FLAGGED_ROUTE',
+      'Route is flagged (compliance / low-liquidity). Re-run with --force to broadcast anyway.'
+    );
+  }
+
+  if (opts.burner) {
+    throw new SwapExecuteError(
+      'INVALID_INPUT',
+      '--burner is CREATE-collection only and cannot sign a gamm swap. Use --browser, ' +
+        'or omit the flag to emit the msg and pipe into `bb deploy`.'
+    );
+  }
+
+  // --browser → reuse the canonical /sign handoff. Multi-msg capable; its
+  // messageTypes registry already maps gamm/SwapExactAmountIn.
+  const { payload } = await browserBroadcast([cls.built], opts as DeployOpts);
+  if (payload?.error) {
+    emit(payload, opts);
+    throw new SwapExecuteError('BROADCAST_FAILED', `Browser broadcast cancelled or rejected: ${payload.error}`);
+  }
+
+  let track: any;
+  if (opts.track && payload?.success && payload?.txHash) {
+    try {
+      const body: Record<string, string> = { txHash: payload.txHash, chainId: cls.chainId };
+      if (cls.tokenInSeed) body.tokenIn = cls.tokenInSeed;
+      track = await callApi('POST', '/swap/track', opts, body);
+    } catch (e: any) {
+      track = { tracked: false, error: e?.message || String(e) };
+    }
+  }
+  emit(track ? { ...payload, track } : payload, opts);
+  if (!payload?.success) {
+    throw new SwapExecuteError('BROADCAST_FAILED', 'Broadcast did not report success.');
+  }
+}
 
 // ── swap (parent) ──────────────────────────────────────────────────────
 
@@ -101,8 +299,9 @@ addOutputFlags(
 // ── swap estimate ───────────────────────────────────────────────────────
 
 addOutputFlags(
+  addDeployOptions(
   addNetworkFlags(swapCommand.command('estimate'))
-    .description('Estimate a swap from <from-denom> to <to-denom> for <amount>. Honors source/dest chain overrides.')
+    .description('Estimate a swap from <from-denom> to <to-denom> for <amount>. Honors source/dest chain overrides. With --execute, sign+broadcast a BitBadges-only result via the deploy signing flags.')
     .argument('<from>', 'Token in denom (e.g. "ubadge")')
     .argument('<to>', 'Token out denom (e.g. "uusdc")')
     .argument('<amount>', 'Integer amount of token in (e.g. "1000000" for 1 BADGE at 6 decimals)')
@@ -114,18 +313,26 @@ addOutputFlags(
     )
     .option('--slippage <pct>', 'Slippage tolerance percent (0-100)', '1')
     .option('--local-only', 'Restrict to BitBadges native pools (no Skip:Go rerouting). Both chains must be bitbadges-*.', false)
+    .option('--execute', 'Sign + broadcast the estimate when it is a BitBadges-only swap. Reuses the deploy signing flags (--browser); refuses cross-chain / EVM / multi-hop.', false)
+    .option('--force', 'With --execute --browser: broadcast even if the route is flagged (compliance / low-liquidity).', false)
+    .option('--track', 'With --execute --browser: after a successful broadcast, auto-call `bb swap track` to seed the activity row.', false)
+  )
 ).action(
   async (
     from: string,
     to: string,
     amount: string,
     opts: NetworkFlags &
-      OutputFlags & {
+      OutputFlags &
+      DeployOpts & {
         sourceChain?: string;
         destChain?: string;
         addresses?: string;
         slippage?: string;
         localOnly?: boolean;
+        execute?: boolean;
+        force?: boolean;
+        track?: boolean;
       }
   ) => {
     try {
@@ -145,7 +352,41 @@ addOutputFlags(
         isLocalOnly: !!opts.localOnly
       };
       const res = await callApi('POST', '/swap/estimate', opts, body);
-      emit(res, opts);
+      if (opts.execute) {
+        await runSwapExecute(res, opts);
+      } else {
+        emit(res, opts);
+      }
+    } catch (err) {
+      emitError(err);
+    }
+  }
+);
+
+// ── swap execute ────────────────────────────────────────────────────────
+
+addOutputFlags(
+  addDeployOptions(
+    addNetworkFlags(swapCommand.command('execute'))
+      .description(
+        'Sign + broadcast a BitBadges-only swap from a `bb swap estimate` result. ' +
+          'Cross-chain / EVM / multi-hop estimates are returned but NOT auto-executed (throws not-implemented).'
+      )
+      .argument('[estimate]', "Estimate JSON: omit or '-' for stdin, @file.json, or inline JSON")
+      .option('--force', 'Broadcast even if the route is flagged (compliance / low-liquidity).', false)
+      .option('--track', 'After a successful broadcast, auto-call `bb swap track` to seed the activity row.', false)
+  )
+).action(
+  async (
+    estimateArg: string | undefined,
+    opts: NetworkFlags & OutputFlags & DeployOpts & { force?: boolean; track?: boolean }
+  ) => {
+    try {
+      let raw = estimateArg;
+      if (!raw || raw === '-') raw = fs.readFileSync(0, 'utf-8');
+      else if (raw.startsWith('@')) raw = fs.readFileSync(raw.slice(1), 'utf-8');
+      const parsed = JSON.parse(raw);
+      await runSwapExecute(parsed, opts);
     } catch (err) {
       emitError(err);
     }


### PR DESCRIPTION
## Summary

Implements backlog ticket **0440**: closes the estimate→swap gap in `bb swap` without adding a second keyring or a cross-chain orchestrator.

- New `bb swap execute [estimate]` (stdin `-` / `@file` / inline JSON) **and** `bb swap estimate --execute`.
- **Whole-route** detection (not per-msg first-hop): a route is BitBadges-only iff it is a single native gamm `SwapExactAmountIn` on a `bitbadges-*` chain, every `assetPath` chainId is `bitbadges-*`, and there is no Skip:Go reroute / EVM tx / IBC-transfer leg / WETH redirect.
- **BitBadges-only** → reuse the shared `addDeployOptions` signing flags. Default (no deploy flag) emits the signable `{typeUrl,value}` so `bb swap execute … | bb deploy` and scripting keep working; `--browser` broadcasts via the canonical `/sign` handoff. `--track` auto-seeds the swap activity row; `--force` gates compliance/low-liquidity-flagged routes.
- **Routed through any other chain** → the estimate is still returned, but the execute path throws an explicit `NOT_IMPLEMENTED` pointing at `/sign` + `bb swap track`. No partial execution, no orchestrator.
- The signable typeUrl is the TxModal alias `gamm/SwapExactAmountIn` that the `/sign` page's `messageTypes` registry is keyed by (mirrors the frontend `parseSkipGoMsgsToTxInfo`); the proto type URL would be a registry miss and the wallet could not reconstruct the msg.
- `--burner` is explicitly refused for swaps (it is CREATE-collection only) rather than failing opaquely downstream.

## Test plan

- [x] `swap.spec.ts`: command-shape (new `execute` subcommand + `--execute/--force/--track` + reused `--browser/--burner/--sign-only` on `estimate`).
- [x] `swap.spec.ts`: exported pure `classifyBitBadgesOnlySwap` covering the three routing branches — BitBadges-only executable; rerouted/EVM/IBC/WETH/non-bitbadges refused; multi-hop refused; failed-estimate refused; bare-vs-wrapped estimate input.
- [x] Full `swap.spec.ts` green (19/19). (Pre-existing `src/cli/integration/` suites need a built `dist/` and are excluded by the repo's own `npm test`.)
- [ ] Docs: `for-developers/cli/` swap docs update tracked separately in the docs repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)