### PR TITLE
fix(cli): agent-input hardening — base denoms, negative to-raw, entity-id hoisting (#0443)

### DIFF
--- a/packages/bitbadgesjs-sdk/src/cli/commands/amount.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/amount.spec.ts
@@ -67,3 +67,47 @@ describe('amountCommand shape', () => {
     expect((unwrap.options as any[]).filter((o) => o.required).map((o) => o.long)).toContain('--token-amount');
   });
 });
+
+describe('amount to-raw negative guard (#0443)', () => {
+  it('rejects a negative display amount with exit 2', async () => {
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`__exit_${code}`);
+      }) as any);
+    const errSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const outSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      await expect(
+        amountCommand.parseAsync(['to-raw', '-5', '--denom', 'BADGE'], { from: 'user' })
+      ).rejects.toThrow('__exit_2');
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('must be non-negative'));
+    } finally {
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+      outSpy.mockRestore();
+    }
+  });
+
+  it('still accepts a valid non-negative amount', async () => {
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`__exit_${code}`);
+      }) as any);
+    const writes: string[] = [];
+    const outSpy = jest.spyOn(process.stdout, 'write').mockImplementation((s: any) => {
+      writes.push(String(s));
+      return true;
+    });
+    const errSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      await amountCommand.parseAsync(['to-raw', '5', '--denom', 'BADGE'], { from: 'user' });
+      expect(writes.join('')).toContain('"raw"');
+    } finally {
+      exitSpy.mockRestore();
+      outSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/commands/amount.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/amount.ts
@@ -88,6 +88,14 @@ addOutputFlags(
 ).action((display: string, opts: any) => {
   const { denom, decimals, symbol } = resolveDecimals(opts.denom, opts.decimals);
   const mode = parseRoundingMode(opts.round);
+  // `fromDisplayAmount` is a general-purpose helper that intentionally
+  // supports signed amounts; the CLI is the trust boundary. A negative
+  // amount is never valid in a mint/deposit/transfer/trade context, so
+  // reject it here rather than silently emitting a negative raw value.
+  const displayNum = Number(display);
+  if (Number.isFinite(displayNum) && displayNum < 0) {
+    fail(2, `amount must be non-negative (got "${display}"). A negative amount is invalid for mint/deposit/transfer/trade.`);
+  }
   const c = CosmosCoinUtils.fromDisplayAmount(display, denom, decimals, undefined, mode);
   emit({ denom, decimals, ...(symbol ? { symbol } : {}), display, raw: c.getRawAmountString() }, opts);
 });

--- a/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/deploy.ts
@@ -38,6 +38,7 @@ import { browserBroadcast, burnerBroadcast } from '../utils/deploy-options.js';
 import { buildKeyringCommand, buildKeyringMultiCommand } from '../utils/keyring-command.js';
 import {
   extractEntityFromEvents,
+  extractEntityIds,
   waitForIndexer,
   type ExtractedEntity,
   type WaitForIndexerResult
@@ -748,6 +749,15 @@ deployCommand.action(async (input: string | undefined, opts: any) => {
       rawLog: primaryResult?.rawLog,
       ...(additionalTxs.length > 0 ? { additionalTxs } : {})
     };
+
+    // Hoist every recognizable id (collectionId, storeId, bidId, ...)
+    // out of the primary tx events so callers don't hand-parse events[].
+    // Surface-only — independent of the optional --wait-for-indexer poll
+    // below (which is intentionally limited to poll-able entities).
+    const execEntityIds = extractEntityIds(primaryResult?.events);
+    if (Object.keys(execEntityIds).length > 0) {
+      payload.entityIds = execEntityIds;
+    }
 
     // Optional indexer wait (matches burner/browser parity). Uses events
     // from the primary tx to extract the entity id.

--- a/packages/bitbadgesjs-sdk/src/cli/commands/tx.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/commands/tx.ts
@@ -18,6 +18,7 @@ import {
   successEnvelope,
   writeJsonEnvelope
 } from '../utils/envelope.js';
+import { extractEntityIds } from '../utils/wait-for-indexer.js';
 
 interface TxStatusData {
   /** Which RPC family found the tx. `cosmos` = LCD; `evm` = JSON-RPC. */
@@ -31,7 +32,13 @@ interface TxStatusData {
   gasUsed?: string;
   timestamp?: string;
   events?: Array<{ type: string; attributes: Array<{ key: string; value: string }> }>;
+  /** Kept for backward compat — equivalent to `entityIds.collectionId`. */
   collectionId?: string;
+  /**
+   * All recognizable id attributes hoisted out of `events` (collectionId,
+   * storeId, bidId, ...) so callers don't hand-parse the events array.
+   */
+  entityIds?: Record<string, string>;
 }
 
 interface NodeUrlOptions extends NetworkOptions {
@@ -181,23 +188,8 @@ async function fetchTxStatus(nodeUrl: string, evmRpcUrl: string, hash: string): 
   }
 }
 
-function extractCollectionId(events: any[] | undefined): string | undefined {
-  if (!Array.isArray(events)) return undefined;
-  for (const ev of events) {
-    const attrs: Array<{ key?: string; value?: string }> = ev?.attributes || [];
-    for (const a of attrs) {
-      if (!a?.key) continue;
-      const k = a.key.replace(/"/g, '');
-      if (k === 'collectionId' || k === 'collection_id') {
-        const v = a.value?.replace(/"/g, '');
-        if (v && v !== '0') return v;
-      }
-    }
-  }
-  return undefined;
-}
-
 function shapeTxData(hash: string, txResponse: any): TxStatusData {
+  const entityIds = extractEntityIds(txResponse.events);
   return {
     via: 'cosmos',
     hash,
@@ -209,7 +201,8 @@ function shapeTxData(hash: string, txResponse: any): TxStatusData {
     gasUsed: txResponse.gas_used ? String(txResponse.gas_used) : undefined,
     timestamp: txResponse.timestamp || undefined,
     events: txResponse.events || undefined,
-    collectionId: extractCollectionId(txResponse.events)
+    collectionId: entityIds.collectionId,
+    ...(Object.keys(entityIds).length > 0 ? { entityIds } : {})
   };
 }
 

--- a/packages/bitbadgesjs-sdk/src/cli/utils/wait-for-indexer.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/wait-for-indexer.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the surface-only `extractEntityIds` hoister (#0443).
+ * The narrow polling extractor `extractEntityFromEvents` is exercised
+ * indirectly by the deploy specs; this locks the broad id-map behavior.
+ */
+
+import { extractEntityIds, extractEntityFromEvents } from './wait-for-indexer.js';
+
+describe('extractEntityIds (#0443 — surface-only id hoister)', () => {
+  it('hoists collectionId, storeId and bidId from mixed events', () => {
+    const events = [
+      { type: 'create_collection', attributes: [{ key: 'collection_id', value: '42' }] },
+      { type: 'create_dynamic_store', attributes: [{ key: 'store_id', value: '7' }] },
+      { type: 'place_bid', attributes: [{ key: 'bid_id', value: '900' }] }
+    ];
+    expect(extractEntityIds(events)).toEqual({
+      collectionId: '42',
+      storeId: '7',
+      bidId: '900'
+    });
+  });
+
+  it('normalizes snake_case keys to camelCase and accepts camelCase as-is', () => {
+    const events = [
+      { type: 'x', attributes: [{ key: 'collection_id', value: '1' }] },
+      { type: 'y', attributes: [{ key: 'bidId', value: '2' }] }
+    ];
+    expect(extractEntityIds(events)).toEqual({ collectionId: '1', bidId: '2' });
+  });
+
+  it('skips zero / empty values and strips quote-wrapped keys/values', () => {
+    const events = [
+      { type: 'a', attributes: [{ key: '"collection_id"', value: '"0"' }] },
+      { type: 'b', attributes: [{ key: 'collection_id', value: '55' }] },
+      { type: 'c', attributes: [{ key: 'store_id', value: '' }] }
+    ];
+    // First collection_id is '0' (skipped); the second non-zero one wins.
+    expect(extractEntityIds(events)).toEqual({ collectionId: '55' });
+  });
+
+  it('first non-zero occurrence wins', () => {
+    const events = [
+      { type: 'a', attributes: [{ key: 'collection_id', value: '10' }] },
+      { type: 'b', attributes: [{ key: 'collection_id', value: '20' }] }
+    ];
+    expect(extractEntityIds(events)).toEqual({ collectionId: '10' });
+  });
+
+  it('ignores non-id attributes and returns {} for missing / non-array input', () => {
+    expect(
+      extractEntityIds([{ type: 'transfer', attributes: [{ key: 'amount', value: '5' }] }])
+    ).toEqual({});
+    expect(extractEntityIds(undefined)).toEqual({});
+    expect(extractEntityIds(null as any)).toEqual({});
+  });
+
+  it('does not broaden the narrow polling extractor', () => {
+    // bid_id has no poll endpoint — extractEntityFromEvents must still
+    // return null for it (only collection / dynamic-store are poll-able).
+    const events = [{ type: 'place_bid', attributes: [{ key: 'bid_id', value: '900' }] }];
+    expect(extractEntityFromEvents(events)).toBeNull();
+    expect(extractEntityIds(events)).toEqual({ bidId: '900' });
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/cli/utils/wait-for-indexer.ts
+++ b/packages/bitbadgesjs-sdk/src/cli/utils/wait-for-indexer.ts
@@ -64,6 +64,42 @@ export function extractEntityFromEvents(events: any[] | undefined): ExtractedEnt
   return null;
 }
 
+/**
+ * Surface-only entity-id extractor — DISTINCT from
+ * `extractEntityFromEvents` above.
+ *
+ * `extractEntityFromEvents` is deliberately narrow: it only returns ids
+ * the poller has a known indexer endpoint for (collection, dynamic
+ * store), because returning an id with no endpoint would cause a
+ * forever-404 poll. This function has the opposite goal: it does NOT
+ * poll anything, it just hoists *every* recognizable id attribute out
+ * of the raw tx events into a flat `{ collectionId, storeId, bidId,
+ * ... }` map so callers (`tx status`, `deploy --exec`) don't have to
+ * hand-parse `events[]`. Adding a key here is safe — there is no
+ * endpoint lookup, so no 404 risk.
+ *
+ * An attribute is treated as an entity id when its key ends in `_id`
+ * (snake) or `<lower>Id` (camel) with a non-empty, non-zero value.
+ * Keys are normalized to camelCase; first non-zero occurrence wins.
+ */
+export function extractEntityIds(events: any[] | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!Array.isArray(events)) return out;
+  for (const ev of events) {
+    const attrs: Array<{ key?: string; value?: string }> = ev?.attributes || [];
+    for (const a of attrs) {
+      if (!a?.key) continue;
+      const rawKey = a.key.replace(/"/g, '');
+      if (!/(_id$|[a-z]Id$)/.test(rawKey)) continue;
+      const v = a.value != null ? String(a.value).replace(/"/g, '') : '';
+      if (!v || v === '0') continue;
+      const camelKey = rawKey.replace(/_([a-z0-9])/g, (_m, c: string) => c.toUpperCase());
+      if (!(camelKey in out)) out[camelKey] = v;
+    }
+  }
+  return out;
+}
+
 /** Indexer path each waitable entity is fetched from. */
 export function indexerPathFor(entity: ExtractedEntity): string {
   switch (entity.entity) {

--- a/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/builders.spec.ts
@@ -101,6 +101,23 @@ describe('shared utilities', () => {
     expect(() => resolveCoin('DOGECOIN')).toThrow('Unknown coin');
   });
 
+  test('resolveCoin detects Cosmos u<symbol> denoms and throws toward the canonical form (#0443)', () => {
+    // Principle: do not silently coerce an ambiguous micro-denom to a
+    // registry entry — throw and point at the canonical symbol + denom.
+    expect(() => resolveCoin('uatom')).toThrow(
+      /On BitBadges, ATOM is the denom "ibc\/.*"/
+    );
+    expect(() => resolveCoin('uatom')).toThrow(/Pass "ATOM" or the full denom/);
+    expect(() => resolveCoin('uusdc')).toThrow(/USDC is the denom "ibc\/.*"/);
+    expect(() => resolveCoin('uosmo')).toThrow(/OSMO is the denom "ibc\/.*"/);
+
+    // ubadge still resolves via the direct registry-key match (its
+    // on-chain denom genuinely IS "ubadge").
+    expect(resolveCoin('ubadge').symbol).toBe('BADGE');
+    // A bogus u-prefixed string falls through to the generic message.
+    expect(() => resolveCoin('ufakecoin')).toThrow('Unknown coin');
+  });
+
   test('toBaseUnits converts correctly', () => {
     expect(toBaseUnits(10, 6)).toBe('10000000');
     expect(toBaseUnits(1, 9)).toBe('1000000000');

--- a/packages/bitbadgesjs-sdk/src/core/builders/shared.ts
+++ b/packages/bitbadgesjs-sdk/src/core/builders/shared.ts
@@ -51,6 +51,25 @@ export function resolveCoin(symbolOrDenom: string): ResolvedCoin {
     }
   }
 
+  // Cosmos micro-denom convention ("uatom"/"uusdc"/"uosmo"): on BitBadges
+  // the on-chain denom is the IBC hash, not the u<symbol> spelling, and
+  // "uatom" could mean a different chain's coin entirely. We deliberately
+  // do NOT silently coerce it to a registry entry — guessing is a
+  // band-aid. Detect the pattern and throw with the canonical denom +
+  // symbol so the caller fixes the input at the source.
+  // (ubadge is already caught by the direct-match above.)
+  if (/^u[a-z0-9]+$/.test(symbolOrDenom)) {
+    const aliasSymbol = symbolOrDenom.slice(1).toUpperCase();
+    const match = Object.values(registry).find((d) => d.symbol.toUpperCase() === aliasSymbol);
+    if (match) {
+      throw new Error(
+        `Unknown coin "${symbolOrDenom}". On BitBadges, ${match.symbol} is the denom ` +
+          `"${match.baseDenom}", not the Cosmos micro-denom spelling. ` +
+          `Pass "${match.symbol}" or the full denom "${match.baseDenom}".`
+      );
+    }
+  }
+
   const supported = Object.values(registry)
     .map((c) => c.symbol)
     .filter((s, i, a) => a.indexOf(s) === i)


### PR DESCRIPTION
Backlog #0443. Three confirmed agent-flow papercuts in the `bb` CLI, one PR, three commits. Build clean (tsc x2 + tsc-alias + fixup + madge), full suite green: **169 suites / 3079 tests passing**.

## Changes

**(a) Detect Cosmos `u<symbol>` denoms and throw toward the canonical form** — `uatom`/`uusdc`/`uosmo` are a natural agent input, but on BitBadges the on-chain denom is the IBC hash, and `uatom` could mean a *different* chain's coin entirely. Per throw-don't-band-aid, `resolveCoin` does **not** silently coerce it to a registry entry (that would be a guess). It detects the micro-denom pattern and throws an actionable error naming the canonical symbol **and** the `ibc/<hash>` denom, so the caller fixes the input at the source. `ubadge` still resolves (its on-chain denom genuinely *is* `ubadge`); bogus `u`-strings fall through to the generic message. `bb amount ... --denom uatom` surfaces this as a clean exit-2 with the suggestion.

**(b) Reject negative `amount to-raw` at the CLI boundary** — `CosmosCoinUtils.fromDisplayAmount` intentionally supports signed amounts (general-purpose helper); the CLI is the trust boundary. `bb amount to-raw -1 --denom BADGE` now exits 2 with a clear message instead of silently emitting `raw: -1000000000`. The helper itself is unchanged.

**(c) Hoist all entity ids into `tx status` + `deploy --exec`** — new surface-only `extractEntityIds()` flattens every `<x>_id` / `<x>Id` event attribute into a camelCase map (`collectionId`, `storeId`, `bidId`, ...). Wired into `tx status` data and the keyring `deploy --exec` envelope so agents stop hand-parsing `events[]` for store/bid ids. Deliberately distinct from the narrow `extractEntityFromEvents` poller, which is left untouched — broadening *that* would cause forever-404 polls for entities with no indexer endpoint.

## Tests
- `builders.spec.ts` — `resolveCoin` throws the canonical-form suggestion for `uatom`/`uusdc`/`uosmo`; `ubadge` still resolves; bogus `u`-string still generic-throws
- `amount.spec.ts` — `to-raw` rejects negative (exit 2), still accepts valid
- `wait-for-indexer.spec.ts` (new) — `extractEntityIds` snake→camel, zero/empty skip, first-wins, narrow poller not broadened

🤖 Generated with [Claude Code](https://claude.com/claude-code)
