### PR TITLE
test(invoices): lock in open-ended payer-eligibility criteria

### DIFF
--- a/packages/bitbadgesjs-sdk/src/core/invoices.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/invoices.spec.ts
@@ -298,3 +298,54 @@ describe('isInvoiceApproval — misc', () => {
     expect(isInvoiceApproval(a)).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Eligibility criteria (mustOwnTokens / dynamicStoreChallenges)
+//
+// The mint forms let invoice creators gate WHO may pay (e.g. "only badge
+// holders" or "only addresses on a KYC allowlist"). These are layered onto
+// the pay approval's approvalCriteria. isInvoiceApproval MUST keep
+// recognizing the approval — it deliberately doesn't inspect these fields,
+// so the gate stays open-ended. These cases lock that contract in.
+// ---------------------------------------------------------------------------
+
+describe('isInvoiceApproval — open-ended eligibility criteria', () => {
+  it('still recognizes an invoice carrying mustOwnTokens (badge-ownership gate)', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.mustOwnTokens = [
+      {
+        collectionId: 1n,
+        amountRange: { start: 1n, end: 1n },
+        tokenIds: [{ start: 1n, end: 1n }],
+        ownershipTimes: [{ start: 1n, end: 18446744073709551615n }],
+        overrideWithCurrentTime: true,
+        mustSatisfyForAllAssets: true,
+        ownershipCheckParty: 'initiator'
+      }
+    ];
+    expect(isInvoiceApproval(a)).toBe(true);
+  });
+
+  it('still recognizes an invoice carrying dynamicStoreChallenges (allowlist gate)', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.dynamicStoreChallenges = [{ storeId: 7n, ownershipCheckParty: 'initiator' }];
+    expect(isInvoiceApproval(a)).toBe(true);
+  });
+
+  it('still recognizes an invoice carrying both gates at once', () => {
+    const a = makeValidInvoiceApproval();
+    a.approvalCriteria.mustOwnTokens = [
+      {
+        collectionId: 2n,
+        amountRange: { start: 1n, end: 1n },
+        tokenIds: [{ start: 1n, end: 1n }],
+        ownershipTimes: [{ start: 1n, end: 18446744073709551615n }],
+        overrideWithCurrentTime: true,
+        mustSatisfyForAllAssets: true,
+        ownershipCheckParty: 'initiator'
+      }
+    ];
+    a.approvalCriteria.dynamicStoreChallenges = [{ storeId: 3n, ownershipCheckParty: 'initiator' }];
+    expect(isInvoiceApproval(a)).toBe(true);
+  });
+});

--- a/packages/bitbadgesjs-sdk/src/core/payment-requests.spec.ts
+++ b/packages/bitbadgesjs-sdk/src/core/payment-requests.spec.ts
@@ -143,6 +143,35 @@ describe('validatePaymentRequestCollection — no-escrow inversion invariants', 
   });
 });
 
+describe('validatePaymentRequestCollection — open-ended payer-eligibility gates', () => {
+  // The mint form lets creators gate WHO may pay (badge ownership / KYC
+  // allowlist) by layering mustOwnTokens / dynamicStoreChallenges onto the
+  // PAY approval. The protocol check deliberately ignores those fields —
+  // adding them must NOT invalidate the collection (the Create button gates
+  // on this). votingChallenges stays the only forbidden gate.
+  it('still valid with mustOwnTokens on the pay approval', () => {
+    const c = fresh();
+    c.collectionApprovals[0].approvalCriteria.mustOwnTokens = [
+      {
+        collectionId: 1n,
+        amountRange: { start: 1n, end: 1n },
+        tokenIds: [{ start: 1n, end: 1n }],
+        ownershipTimes: [{ start: 1n, end: 18446744073709551615n }],
+        overrideWithCurrentTime: true,
+        mustSatisfyForAllAssets: true,
+        ownershipCheckParty: 'initiator'
+      }
+    ];
+    expect(validatePaymentRequestCollection(c).valid).toBe(true);
+  });
+
+  it('still valid with dynamicStoreChallenges on the pay approval', () => {
+    const c = fresh();
+    c.collectionApprovals[0].approvalCriteria.dynamicStoreChallenges = [{ storeId: 9n, ownershipCheckParty: 'initiator' }];
+    expect(validatePaymentRequestCollection(c).valid).toBe(true);
+  });
+});
+
 describe('validatePaymentRequestCollection — approval shape', () => {
   it('rejects when fewer than 2 approvals', () => {
     const c = fresh();


### PR DESCRIPTION
## What

Companion to **BitBadges/bitbadges-frontend** PR for payer-eligibility gates on invoices. That feature layers `mustOwnTokens` (badge ownership) / `dynamicStoreChallenges` (KYC allowlist) onto a payment-request's pay approval to gate **who may pay**.

Three SDK gates decide whether such a collection is recognized, and all are deliberately **open-ended** on these fields:

- `isInvoiceApproval` — what the invoices view keys off
- `validatePaymentRequestCollection` — what the mint Create button gates on
- `verifyPaymentRequest` — the standards lint (already audited; no spec exists yet)

## Why tests-only

No behavior change. The gates already accept these fields. These cases **pin** that — so the gates can't silently tighten later and quietly break the mint form / invoices view.

## Cases added

- `core/invoices.spec.ts` — `isInvoiceApproval` still returns `true` with `mustOwnTokens`, with `dynamicStoreChallenges`, and with both.
- `core/payment-requests.spec.ts` — `validatePaymentRequestCollection` stays `valid` with each gate on the pay approval.

`bunx jest core/invoices core/payment-requests` → **61 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)