### PR TITLE
feat(api): tier filter + per-tier counts on GetCollectionOwners types

### DIFF
--- a/packages/bitbadgesjs-sdk/src/api-indexer/requests/wrappers.ts
+++ b/packages/bitbadgesjs-sdk/src/api-indexer/requests/wrappers.ts
@@ -33,6 +33,18 @@ import { iMetadata, Metadata } from '../metadata/metadata.js';
 export interface iGetCollectionOwnersPayload {
   bookmark?: string;
   oldestFirst?: boolean;
+  /**
+   * If set, filter owners to holders of this token ID (tier) server-side and
+   * include per-tier `counts` in the response. Enables tier-scoped views
+   * (e.g. subscriber management) to scale without paging every holder.
+   */
+  tokenId?: NumberType;
+  /**
+   * Only meaningful alongside `tokenId`. When true, the returned page is
+   * restricted to holders whose ownership currently covers now (active),
+   * excluding expired holders.
+   */
+  onlyActive?: boolean;
 }
 
 /**
@@ -41,6 +53,12 @@ export interface iGetCollectionOwnersPayload {
 export interface iGetCollectionOwnersSuccessResponse<T extends NumberType> {
   owners: Array<iBalanceDoc<T>>;
   pagination: PaginationInfo;
+  /**
+   * Present only when `tokenId` was provided. Holder counts for that tier.
+   * Plain integers (holder counts, well within safe-integer range) — not
+   * NumberType, so they aren't affected by number-type conversion.
+   */
+  counts?: { total: number; active: number; expired: number };
 }
 
 /**
@@ -52,11 +70,13 @@ export class GetCollectionOwnersSuccessResponse<T extends NumberType>
 {
   owners: BalanceDoc<T>[];
   pagination: PaginationInfo;
+  counts?: { total: number; active: number; expired: number };
 
   constructor(data: iGetCollectionOwnersSuccessResponse<T>) {
     super();
     this.owners = data.owners.map((owner) => new BalanceDoc(owner));
     this.pagination = data.pagination;
+    this.counts = data.counts;
   }
 
   getNumberFieldNames(): string[] {


### PR DESCRIPTION
## What

Forward type contract for the indexer's tier-filtered owners query (companion to **bitbadges-indexer #200**), which powers subscriber-management views that scale to 10k+ holders.

- `iGetCollectionOwnersPayload`: add optional **`tokenId`** (filter owners to a tier server-side) and **`onlyActive`** (restrict the returned page to currently-active holders).
- `iGetCollectionOwnersSuccessResponse`: add optional **`counts: { total, active, expired }`** — present only when `tokenId` is provided. Plain integers (holder counts, safe-integer range), so deliberately not `NumberType` and unaffected by number-type conversion. The response class copies `counts` through.

## Notes

- The existing `BitBadgesApi.getCollectionOwners(collectionId, payload)` method already forwards the payload, so **no method change** is needed — consumers pick up `tokenId`/`onlyActive`/`counts` on their next SDK bump.
- No behavior change; purely additive optional fields. SDK build (`tsc --build`) is clean, no circular deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)