### PR TITLE
feat(ipfs): point default coin logo URLs at ipfs.bitbadges.io gateway

### DIFF
--- a/packages/bitbadgesjs-sdk/src/builder/sdk/coinRegistry.ts
+++ b/packages/bitbadgesjs-sdk/src/builder/sdk/coinRegistry.ts
@@ -55,7 +55,7 @@ export const MAINNET_COINS_REGISTRY: Record<string, CoinDetails> = {
     symbol: 'CHAOS',
     decimals: '9',
     baseDenom: 'badges:49:chaosnet',
-    image: 'https://bitbadges.io/_next/image?url=https%3A%2F%2Fbitbadges-ipfs.infura-ipfs.io%2Fipfs%2FQmdRQUvQBo6p24RQ7AS7RD6srqyUjoHJ5Cjs4p22zie9bQ&w=1920&q=75'
+    image: 'https://bitbadges.io/_next/image?url=https%3A%2F%2Fipfs.bitbadges.io%2Fipfs%2FQmdRQUvQBo6p24RQ7AS7RD6srqyUjoHJ5Cjs4p22zie9bQ&w=1920&q=75'
   },
   'ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349': {
     label: 'USDC',

--- a/packages/bitbadgesjs-sdk/src/common/constants.ts
+++ b/packages/bitbadgesjs-sdk/src/common/constants.ts
@@ -150,7 +150,7 @@ export const MAINNET_COINS_REGISTRY: Record<string, CoinDetails> = {
     decimals: '9',
     baseDenom: 'badges:49:chaosnet',
     image:
-      'https://bitbadges.io/_next/image?url=https%3A%2F%2Fbitbadges-ipfs.infura-ipfs.io%2Fipfs%2FQmdRQUvQBo6p24RQ7AS7RD6srqyUjoHJ5Cjs4p22zie9bQ&w=1920&q=75'
+      'https://bitbadges.io/_next/image?url=https%3A%2F%2Fipfs.bitbadges.io%2Fipfs%2FQmdRQUvQBo6p24RQ7AS7RD6srqyUjoHJ5Cjs4p22zie9bQ&w=1920&q=75'
   },
   'ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349': {
     skipGoSupported: true,


### PR DESCRIPTION
Part of removing our Infura IPFS dependency. Tracking: bitbadges-autopilot ticket 0461.

Swaps the two hardcoded Infura IPFS gateway URLs — the default CHAOS coin logo in `common/constants.ts` and `builder/sdk/coinRegistry.ts` — to the new gateway host `ipfs.bitbadges.io`. The referenced CID is unchanged (content-addressed), and it will be backfilled into DO Spaces by the indexer migration.

## Before merge

Deploy the gateway at `ipfs.bitbadges.io` (see the `bitbadges-ipfs-gateway` repo) so the referenced image resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
